### PR TITLE
Web: Add connection failure banner

### DIFF
--- a/client/web/src/app/core/i18n/localizations/ar.json
+++ b/client/web/src/app/core/i18n/localizations/ar.json
@@ -108,6 +108,12 @@
   "TERMS_GOVERNING_LAW": "تُفسَّر هذه الشروط وتُطبَّق وفقاً لقوانين الولاية القضائية التي توجد فيها جهة تشغيل الخدمة، دون اعتبار لتنازع القوانين.",
   "LEGAL_NOTICE": "هذه الوثيقة لأغراض المعلومات فقط ولا تُعد استشارة قانونية. يُرجى استشارة محامٍ مختص لملابساتك الخاصة.",
 
+  "_CONNECTION_WARNING_SECTION": "==== CONNECTION WARNING ====",
+  "CONNECTION_WARNING_TITLE": "تعذّر الاتصال ببعض الأعضاء",
+  "CONNECTION_WARNING_DESC": "قد تمنع شبكتك الاتصال المباشر بين الأجهزة. جرّب تحديث الصفحة، أو التبديل إلى شبكة أخرى، أو تعطيل VPN أو جدار الحماية.",
+  "CONNECTION_WARNING_REFRESH": "تحديث",
+  "CONNECTION_WARNING_DISMISS": "تجاهل",
+
   "_STATUS_ERRORS_SECTION": "==== STATUS & ERRORS ====",
   "CONNECTION_LOST": "تم فقد الاتصال",
   "ERROR": "حدث خطأ",

--- a/client/web/src/app/core/i18n/localizations/en.json
+++ b/client/web/src/app/core/i18n/localizations/en.json
@@ -108,6 +108,12 @@
   "TERMS_GOVERNING_LAW": "These Terms shall be governed by and construed in accordance with the laws of the jurisdiction where the Service operator is established, without regard to its conflict of law provisions.",
   "LEGAL_NOTICE": "This document is provided for informational purposes only and does not constitute legal advice. Consult a qualified attorney for advice specific to your situation.",
 
+  "_CONNECTION_WARNING_SECTION": "==== CONNECTION WARNING ====",
+  "CONNECTION_WARNING_TITLE": "Unable to connect to some members",
+  "CONNECTION_WARNING_DESC": "Your network may be blocking peer-to-peer connections. Try refreshing the page, switching to a different network, or disabling your VPN/firewall.",
+  "CONNECTION_WARNING_REFRESH": "Refresh",
+  "CONNECTION_WARNING_DISMISS": "Dismiss",
+
   "_STATUS_ERRORS_SECTION": "==== STATUS & ERRORS ====",
   "CONNECTION_LOST": "Connection lost",
   "ERROR": "Something went wrong",

--- a/client/web/src/app/core/services/communication/webrtc-communication.service.ts
+++ b/client/web/src/app/core/services/communication/webrtc-communication.service.ts
@@ -133,6 +133,9 @@ export class WebRTCCommunicationService {
     };
 
     channel.onerror = (ev: Event) => {
+      // Ignore events from stale data channels that have been replaced
+      if (this.dataChannels.get(targetUser) !== channel) return;
+
       if ('error' in ev) {
         const rtcErrorEvent = ev as RTCErrorEvent;
         const error = rtcErrorEvent.error;
@@ -151,6 +154,9 @@ export class WebRTCCommunicationService {
     };
 
     channel.onclose = () => {
+      // Ignore events from stale data channels that have been replaced
+      if (this.dataChannels.get(targetUser) !== channel) return;
+
       this.logger.info('setupDataChannel', `Data channel with ${targetUser} is closed`);
       this.dataChannelOpen$.next(false);
       this.dataChannels.delete(targetUser);

--- a/client/web/src/app/core/services/communication/webrtc-signaling.service.ts
+++ b/client/web/src/app/core/services/communication/webrtc-signaling.service.ts
@@ -17,6 +17,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { NGXLogger } from 'ngx-logger';
 import { WebRTCCommunicationService } from './webrtc-communication.service';
 import { HotToastService } from '@ngxpert/hot-toast';
+import { Subject } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -30,6 +31,9 @@ export class WebRTCSignalingService {
   private communicationService = inject(WebRTCCommunicationService);
 
   // =============== Properties ===============
+  public peerDisconnected$ = new Subject<string>();
+  public peerConnected$ = new Subject<string>();
+
   private peerConnections = new Map<string, RTCPeerConnection>();
   private reconnectAttempts = new Map<string, number>();
   private connectionLocks = new Set<string>();
@@ -435,6 +439,7 @@ export class WebRTCSignalingService {
           iceGatheringTimeout = null;
         }
         this.logger.info('createPeerConnection', `Successfully connected to ${targetUser}`);
+        this.peerConnected$.next(targetUser);
       } else if (state === 'failed' || state === 'disconnected') {
         // Clear timeout on failure
         if (iceGatheringTimeout) {
@@ -475,6 +480,7 @@ export class WebRTCSignalingService {
    * @param targetUser The user to handle disconnection for
    */
   private handleDisconnection(targetUser: string) {
+    this.peerDisconnected$.next(targetUser);
     const attempts = this.reconnectAttempts.get(targetUser) ?? 0;
 
     // Log diagnostic info on first failure

--- a/client/web/src/app/core/services/communication/webrtc-signaling.service.ts
+++ b/client/web/src/app/core/services/communication/webrtc-signaling.service.ts
@@ -48,7 +48,12 @@ export class WebRTCSignalingService {
   constructor() {
     this.initializeSignalMessageHandler();
     this.communicationService.dataChannelClosed$.subscribe((targetUser) => {
-      if (this.wsService.isConnected() && this.peerConnections.has(targetUser)) {
+      if (
+        this.wsService.isConnected() &&
+        this.peerConnections.has(targetUser) &&
+        !this.connectionLocks.has(targetUser) &&
+        !this.reconnectionTimeouts.has(targetUser)
+      ) {
         this.logger.info(
           'handleDataChannelClose',
           `Data channel closed with ${targetUser}, attempting reconnection`
@@ -155,12 +160,14 @@ export class WebRTCSignalingService {
       };
       dataChannel.onerror = () => {
         this.connectionLocks.delete(targetUser);
-        this.closePeerConnection(targetUser, true);
-        this.handleDisconnection(targetUser);
+        if (this.peerConnections.get(targetUser) === peerConnection) {
+          this.closePeerConnection(targetUser, true);
+          this.handleDisconnection(targetUser);
+        }
       };
       dataChannel.onclose = () => {
         this.connectionLocks.delete(targetUser);
-        if (this.wsService.isConnected()) {
+        if (this.wsService.isConnected() && this.peerConnections.get(targetUser) === peerConnection) {
           this.closePeerConnection(targetUser, true);
           this.handleDisconnection(targetUser);
         }
@@ -430,6 +437,9 @@ export class WebRTCSignalingService {
     };
 
     peerConnection.onconnectionstatechange = () => {
+      // Ignore events from stale connections that have been replaced
+      if (this.peerConnections.get(targetUser) !== peerConnection) return;
+
       const state = peerConnection.connectionState;
 
       if (state === 'connected') {
@@ -438,6 +448,7 @@ export class WebRTCSignalingService {
           clearTimeout(iceGatheringTimeout);
           iceGatheringTimeout = null;
         }
+        this.reconnectAttempts.delete(targetUser);
         this.logger.info('createPeerConnection', `Successfully connected to ${targetUser}`);
         this.peerConnected$.next(targetUser);
       } else if (state === 'failed' || state === 'disconnected') {
@@ -451,6 +462,9 @@ export class WebRTCSignalingService {
     };
 
     peerConnection.oniceconnectionstatechange = () => {
+      // Ignore events from stale connections that have been replaced
+      if (this.peerConnections.get(targetUser) !== peerConnection) return;
+
       const iceState = peerConnection.iceConnectionState;
 
       if (iceState === 'connected' || iceState === 'completed') {
@@ -480,7 +494,11 @@ export class WebRTCSignalingService {
    * @param targetUser The user to handle disconnection for
    */
   private handleDisconnection(targetUser: string) {
-    this.peerDisconnected$.next(targetUser);
+    // Skip if a reconnection is already scheduled for this user
+    if (this.reconnectionTimeouts.has(targetUser)) {
+      return;
+    }
+
     const attempts = this.reconnectAttempts.get(targetUser) ?? 0;
 
     // Log diagnostic info on first failure
@@ -543,6 +561,7 @@ export class WebRTCSignalingService {
         );
       }
       this.closePeerConnection(targetUser, true);
+      this.peerDisconnected$.next(targetUser);
     }
   }
 
@@ -894,14 +913,9 @@ export class WebRTCSignalingService {
   private reconnect(targetUser: string) {
     this.logger.info('reconnect', `Reconnecting WebRTC with ${targetUser}...`);
 
-    const peerConnection = this.peerConnections.get(targetUser);
-    if (peerConnection) {
-      peerConnection.close();
-      this.peerConnections.delete(targetUser);
-    }
-
-    this.initiateConnection(targetUser);
+    this.closePeerConnection(targetUser, true);
     this.reconnectAttempts.set(targetUser, 0);
+    this.initiateConnection(targetUser);
   }
 
   /**
@@ -1019,12 +1033,14 @@ export class WebRTCSignalingService {
       };
       dataChannel.onerror = () => {
         this.connectionLocks.delete(targetUser);
-        this.closePeerConnection(targetUser, true);
-        this.handleDisconnection(targetUser);
+        if (this.peerConnections.get(targetUser) === peerConnection) {
+          this.closePeerConnection(targetUser, true);
+          this.handleDisconnection(targetUser);
+        }
       };
       dataChannel.onclose = () => {
         this.connectionLocks.delete(targetUser);
-        if (this.wsService.isConnected()) {
+        if (this.wsService.isConnected() && this.peerConnections.get(targetUser) === peerConnection) {
           this.closePeerConnection(targetUser, true);
           this.handleDisconnection(targetUser);
         }

--- a/client/web/src/app/core/services/communication/webrtc-signaling.service.ts
+++ b/client/web/src/app/core/services/communication/webrtc-signaling.service.ts
@@ -167,7 +167,10 @@ export class WebRTCSignalingService {
       };
       dataChannel.onclose = () => {
         this.connectionLocks.delete(targetUser);
-        if (this.wsService.isConnected() && this.peerConnections.get(targetUser) === peerConnection) {
+        if (
+          this.wsService.isConnected() &&
+          this.peerConnections.get(targetUser) === peerConnection
+        ) {
           this.closePeerConnection(targetUser, true);
           this.handleDisconnection(targetUser);
         }
@@ -1040,7 +1043,10 @@ export class WebRTCSignalingService {
       };
       dataChannel.onclose = () => {
         this.connectionLocks.delete(targetUser);
-        if (this.wsService.isConnected() && this.peerConnections.get(targetUser) === peerConnection) {
+        if (
+          this.wsService.isConnected() &&
+          this.peerConnections.get(targetUser) === peerConnection
+        ) {
           this.closePeerConnection(targetUser, true);
           this.handleDisconnection(targetUser);
         }

--- a/client/web/src/app/core/services/communication/webrtc-signaling.service.ts
+++ b/client/web/src/app/core/services/communication/webrtc-signaling.service.ts
@@ -140,9 +140,9 @@ export class WebRTCSignalingService {
       'initiateConnection',
       `Initiating connection with ${targetUser} (role: caller)`
     );
-    const peerConnection = this.createPeerConnection(targetUser);
 
     try {
+      const peerConnection = this.createPeerConnection(targetUser);
       if (!peerConnection) {
         this.logger.error(
           'initiateConnection',
@@ -157,6 +157,10 @@ export class WebRTCSignalingService {
       dataChannel.onopen = () => {
         this.connectionLocks.delete(targetUser);
         this.communicationService.sendQueuedMessages(targetUser);
+        if (peerConnection.connectionState === 'connected') {
+          this.reconnectAttempts.delete(targetUser);
+          this.peerConnected$.next(targetUser);
+        }
       };
       dataChannel.onerror = () => {
         this.connectionLocks.delete(targetUser);
@@ -258,13 +262,6 @@ export class WebRTCSignalingService {
     if (requestDelayTimeout) {
       clearTimeout(requestDelayTimeout);
       this.connectionRequestDelays.delete(targetUser);
-    }
-
-    // Clear reconnection timeout
-    const reconnectionTimeout = this.reconnectionTimeouts.get(targetUser);
-    if (reconnectionTimeout) {
-      clearTimeout(reconnectionTimeout);
-      this.reconnectionTimeouts.delete(targetUser);
     }
 
     // Clear state mismatch timeout
@@ -451,9 +448,17 @@ export class WebRTCSignalingService {
           clearTimeout(iceGatheringTimeout);
           iceGatheringTimeout = null;
         }
-        this.reconnectAttempts.delete(targetUser);
-        this.logger.info('createPeerConnection', `Successfully connected to ${targetUser}`);
-        this.peerConnected$.next(targetUser);
+        // Only clear retry counter and emit connected when data channel is also open
+        if (this.communicationService.isConnected(targetUser)) {
+          this.reconnectAttempts.delete(targetUser);
+          this.logger.info('createPeerConnection', `Successfully connected to ${targetUser}`);
+          this.peerConnected$.next(targetUser);
+        } else {
+          this.logger.info(
+            'createPeerConnection',
+            `Peer connection connected to ${targetUser}, waiting for data channel`
+          );
+        }
       } else if (state === 'failed' || state === 'disconnected') {
         // Clear timeout on failure
         if (iceGatheringTimeout) {
@@ -534,7 +539,7 @@ export class WebRTCSignalingService {
 
       const timeoutId = setTimeout(() => {
         this.reconnectionTimeouts.delete(targetUser);
-        if (!this.peerConnections.has(targetUser)) {
+        if (!this.communicationService.isConnected(targetUser)) {
           this.logger.debug(
             'handleDisconnection',
             `Attempting reconnection ${attempts + 1} to ${targetUser}`
@@ -543,8 +548,9 @@ export class WebRTCSignalingService {
         } else {
           this.logger.debug(
             'handleDisconnection',
-            `Connection already exists for ${targetUser}, skipping reconnect`
+            `Connection healthy for ${targetUser}, skipping reconnect`
           );
+          this.reconnectAttempts.delete(targetUser);
         }
       }, delay);
 
@@ -1019,20 +1025,24 @@ export class WebRTCSignalingService {
 
     // Temporarily bypass role checking and initiate connection
     this.connectionLocks.add(targetUser);
-    const peerConnection = this.createPeerConnection(targetUser);
-
-    if (!peerConnection) {
-      this.logger.error('forceInitiateConnection', `PeerConnection missing for ${targetUser}`);
-      return;
-    }
 
     try {
+      const peerConnection = this.createPeerConnection(targetUser);
+      if (!peerConnection) {
+        this.logger.error('forceInitiateConnection', `PeerConnection missing for ${targetUser}`);
+        throw new Error(`Failed to create peer connection for ${targetUser}`);
+      }
+
       const dataChannel = peerConnection.createDataChannel('data', DATA_CHANNEL_OPTIONS);
       this.communicationService.setupDataChannel(dataChannel, targetUser);
 
       dataChannel.onopen = () => {
         this.connectionLocks.delete(targetUser);
         this.communicationService.sendQueuedMessages(targetUser);
+        if (peerConnection.connectionState === 'connected') {
+          this.reconnectAttempts.delete(targetUser);
+          this.peerConnected$.next(targetUser);
+        }
       };
       dataChannel.onerror = () => {
         this.connectionLocks.delete(targetUser);

--- a/client/web/src/app/core/services/communication/webrtc.service.ts
+++ b/client/web/src/app/core/services/communication/webrtc.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, inject } from '@angular/core';
-import { BehaviorSubject, Subject } from 'rxjs';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { ChatMessage, DataChannelMessage } from '../../../utils/constants';
 import { IWebRTCService } from '../../interfaces/webrtc.interface';
 import { WebRTCSignalingService } from './webrtc-signaling.service';
@@ -15,12 +15,12 @@ export class WebRTCService implements IWebRTCService {
   private logger = inject(NGXLogger);
 
   // =============== Public Properties ===============
-  public get peerDisconnected$(): Subject<string> {
-    return this.signalingService.peerDisconnected$;
+  public get peerDisconnected$(): Observable<string> {
+    return this.signalingService.peerDisconnected$.asObservable();
   }
 
-  public get peerConnected$(): Subject<string> {
-    return this.signalingService.peerConnected$;
+  public get peerConnected$(): Observable<string> {
+    return this.signalingService.peerConnected$.asObservable();
   }
 
   /**

--- a/client/web/src/app/core/services/communication/webrtc.service.ts
+++ b/client/web/src/app/core/services/communication/webrtc.service.ts
@@ -15,6 +15,14 @@ export class WebRTCService implements IWebRTCService {
   private logger = inject(NGXLogger);
 
   // =============== Public Properties ===============
+  public get peerDisconnected$(): Subject<string> {
+    return this.signalingService.peerDisconnected$;
+  }
+
+  public get peerConnected$(): Subject<string> {
+    return this.signalingService.peerConnected$;
+  }
+
   /**
    * Gets the data channel open subject
    */

--- a/client/web/src/app/features/chat/chat.component.html
+++ b/client/web/src/app/features/chat/chat.component.html
@@ -1994,33 +1994,41 @@
                   class="flex items-center gap-6 px-2"
                   [ngClass]="isRTL ? 'flex-row-reverse' : 'flex-row'"
                 >
-                  <img
-                    [src]="'/icons/link.svg'"
-                    alt="Attach Files"
+                  <button
+                    type="button"
+                    [disabled]="hasNoConnectedPeers"
+                    (click)="fileInput.click()"
+                    class="p-0 border-0 bg-transparent disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+                    [attr.aria-label]="'Attach Files'"
                     title="Attach Files"
-                    (click)="hasNoConnectedPeers ? null : fileInput.click()"
-                    class="h-5 w-5"
-                    [ngClass]="
-                      hasNoConnectedPeers ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
-                    "
-                    loading="lazy"
-                    width="20"
-                    height="20"
-                  />
-                  <img
-                    [src]="'/icons/emoji.svg'"
-                    alt="Emoji"
-                    title="Open emoji picker"
-                    class="h-5 w-5"
-                    [ngClass]="
-                      hasNoConnectedPeers ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
-                    "
-                    (mouseenter)="hasNoConnectedPeers ? null : openEmojiPicker()"
+                  >
+                    <img
+                      [src]="'/icons/link.svg'"
+                      alt=""
+                      class="h-5 w-5"
+                      loading="lazy"
+                      width="20"
+                      height="20"
+                    />
+                  </button>
+                  <button
+                    type="button"
+                    [disabled]="hasNoConnectedPeers"
+                    (mouseenter)="openEmojiPicker()"
                     (mouseleave)="handleEmojiIconMouseLeave()"
-                    loading="lazy"
-                    width="20"
-                    height="20"
-                  />
+                    class="p-0 border-0 bg-transparent disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+                    [attr.aria-label]="'Open emoji picker'"
+                    title="Open emoji picker"
+                  >
+                    <img
+                      [src]="'/icons/emoji.svg'"
+                      alt=""
+                      class="h-5 w-5"
+                      loading="lazy"
+                      width="20"
+                      height="20"
+                    />
+                  </button>
                 </div>
                 <button
                   [disabled]="isSendDisabled"

--- a/client/web/src/app/features/chat/chat.component.html
+++ b/client/web/src/app/features/chat/chat.component.html
@@ -1243,7 +1243,7 @@
         }
 
         <!-- MARK: - Connection Warning Banner -->
-        @if (messages.length > 0) {
+        @if (showConnectionWarning) {
           <div
             class="w-full mb-3 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 dark:border-amber-600/50 dark:bg-amber-900/20"
           >

--- a/client/web/src/app/features/chat/chat.component.html
+++ b/client/web/src/app/features/chat/chat.component.html
@@ -228,7 +228,8 @@
                 <div class="ml-auto">
                   <button
                     type="button"
-                    class="rounded-md p-1 text-textMuted hover:text-brand dark:text-textVeryMuted dark:hover:text-brandDark"
+                    [disabled]="!isConnectedToMember(member)"
+                    class="rounded-md p-1 text-textMuted hover:text-brand dark:text-textVeryMuted dark:hover:text-brandDark disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:text-textMuted dark:disabled:hover:text-textVeryMuted"
                     aria-label="Send file to user"
                     title="Send file to user"
                     (click)="openFilePickerForMember(member)"
@@ -736,7 +737,8 @@
                   <div class="ml-auto">
                     <button
                       type="button"
-                      class="rounded-md p-1 text-textMuted hover:text-brand dark:text-textVeryMuted dark:hover:text-brandDark"
+                      [disabled]="!isConnectedToMember(member)"
+                      class="rounded-md p-1 text-textMuted hover:text-brand dark:text-textVeryMuted dark:hover:text-brandDark disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:text-textMuted dark:disabled:hover:text-textVeryMuted"
                       aria-label="Send file to user"
                       title="Send file to user"
                       (click)="openFilePickerForMember(member)"
@@ -1213,7 +1215,7 @@
     </div>
 
     <!-- MARK: - Main Content -->
-    <div class="flex-1 overflow-auto px-4 py-6 bg-contentArea dark:bg-baseDark md:p-8">
+    <div class="flex-1 overflow-hidden px-4 py-6 bg-contentArea dark:bg-baseDark md:p-8">
       <div class="flex h-full w-full flex-col items-start justify-between">
         <!-- MARK: - Room Name -->
         @if (messages.length > 0) {
@@ -1240,8 +1242,75 @@
           </div>
         }
 
+        <!-- MARK: - Connection Warning Banner -->
+        @if (messages.length > 0) {
+          <div
+            class="w-full mb-3 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 dark:border-amber-600/50 dark:bg-amber-900/20"
+          >
+            <div class="flex items-start gap-3">
+              <svg
+                class="mt-0.5 h-5 w-5 shrink-0 text-amber-600 dark:text-amber-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                />
+              </svg>
+              <div class="flex-1 min-w-0">
+                <p class="text-sm font-expoArabicMedium text-amber-800 dark:text-amber-200">
+                  {{ 'CONNECTION_WARNING_TITLE' | translate }}
+                </p>
+                <p class="mt-1 text-xs text-amber-700 dark:text-amber-300/80">
+                  {{ 'CONNECTION_WARNING_DESC' | translate }}
+                </p>
+                <div class="mt-2 flex flex-wrap items-center gap-2">
+                  <button
+                    (click)="refreshPage()"
+                    class="inline-flex items-center gap-1 rounded-md bg-amber-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-amber-700 dark:bg-amber-500 dark:hover:bg-amber-600"
+                  >
+                    <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                      />
+                    </svg>
+                    {{ 'CONNECTION_WARNING_REFRESH' | translate }}
+                  </button>
+                  <button
+                    (click)="dismissConnectionWarning()"
+                    class="inline-flex items-center rounded-md px-2.5 py-1 text-xs font-medium text-amber-700 hover:bg-amber-100 dark:text-amber-300 dark:hover:bg-amber-800/30"
+                  >
+                    {{ 'CONNECTION_WARNING_DISMISS' | translate }}
+                  </button>
+                </div>
+              </div>
+              <button
+                (click)="dismissConnectionWarning()"
+                class="shrink-0 text-amber-500 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-200"
+                aria-label="Dismiss"
+              >
+                <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        }
+
         <!-- MARK: - Messages Container -->
-        <div class="w-full flex-1 overflow-auto pt-5 max-h-[90%] no-scrollbar" #messageContainer>
+        <div class="w-full flex-1 overflow-auto pt-5 min-h-0 no-scrollbar" #messageContainer>
           <div class="flex w-full flex-col items-start justify-start gap-4">
             <!-- MARK: - Welcome State (Empty Messages) -->
             @if (messages.length === 0) {
@@ -1929,8 +1998,11 @@
                     [src]="'/icons/link.svg'"
                     alt="Attach Files"
                     title="Attach Files"
-                    (click)="fileInput.click()"
-                    class="h-5 w-5 cursor-pointer"
+                    (click)="hasNoConnectedPeers ? null : fileInput.click()"
+                    class="h-5 w-5"
+                    [ngClass]="
+                      hasNoConnectedPeers ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
+                    "
                     loading="lazy"
                     width="20"
                     height="20"
@@ -1939,8 +2011,11 @@
                     [src]="'/icons/emoji.svg'"
                     alt="Emoji"
                     title="Open emoji picker"
-                    class="h-5 w-5 cursor-pointer"
-                    (mouseenter)="openEmojiPicker()"
+                    class="h-5 w-5"
+                    [ngClass]="
+                      hasNoConnectedPeers ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
+                    "
+                    (mouseenter)="hasNoConnectedPeers ? null : openEmojiPicker()"
                     (mouseleave)="handleEmojiIconMouseLeave()"
                     loading="lazy"
                     width="20"
@@ -1948,7 +2023,8 @@
                   />
                 </div>
                 <button
-                  class="flex items-center justify-center gap-2 rounded-lg p-2 text-white bg-brand min-w-[100px] h-[40px] dark:bg-brandDark md:min-w-[124px] md:h-[44px]"
+                  [disabled]="isSendDisabled"
+                  class="flex items-center justify-center gap-2 rounded-lg p-2 text-white bg-brand min-w-[100px] h-[40px] dark:bg-brandDark md:min-w-[124px] md:h-[44px] disabled:opacity-50 disabled:cursor-not-allowed"
                   [ngClass]="isRTL ? 'flex-row-reverse' : 'flex-row'"
                 >
                   <span class="text-base font-expoArabicMedium">{{ 'SEND' | translate }}</span>

--- a/client/web/src/app/features/chat/chat.component.ts
+++ b/client/web/src/app/features/chat/chat.component.ts
@@ -47,7 +47,7 @@ import {
   HEARTBEAT_TIMEOUT_DESKTOP_SEC,
   HEARTBEAT_TIMEOUT_MOBILE_SEC,
   NAVIGATION_DELAY_MS,
-  CONNECTION_WARNING_THRESHOLD_MS,
+  CONNECTION_WARNING_DELAY_MS,
   SESSION_CODE_KEY,
   THEME_PREFERENCE_KEY,
   PREVIEW_MIME_TYPE,
@@ -167,7 +167,7 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
   private emojiPickerHideTimeout: ReturnType<typeof setTimeout> | null = null;
   private statusCheckIntervalId: ReturnType<typeof setInterval> | null = null;
   private connectionWarningDismissed = false;
-  private disconnectWarningTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+  private connectionWarningTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
 
   appVersion: string = packageJson.version;
 
@@ -375,11 +375,11 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
       this.logger.debug('ngOnDestroy', 'Status check interval cleared');
     }
 
-    // Clear disconnect warning timeouts
-    for (const timeoutId of this.disconnectWarningTimeouts.values()) {
+    // Clear connection warning timeouts
+    for (const timeoutId of this.connectionWarningTimeouts.values()) {
       clearTimeout(timeoutId);
     }
-    this.disconnectWarningTimeouts.clear();
+    this.connectionWarningTimeouts.clear();
 
     if (isPlatformBrowser(this.platformId) && this.visibilityChangeListener) {
       document.removeEventListener('visibilitychange', this.visibilityChangeListener);
@@ -573,18 +573,19 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
           // Filter out the local user's own name
           this.members = allMembers.filter((m) => m !== this.userService.user);
 
-          // Clear disconnect warning timeouts for members who left
-          for (const [member, timeoutId] of this.disconnectWarningTimeouts.entries()) {
+          // Clean up timeouts for members who left
+          for (const [member, timeoutId] of this.connectionWarningTimeouts.entries()) {
             if (!this.members.includes(member)) {
               clearTimeout(timeoutId);
-              this.disconnectWarningTimeouts.delete(member);
+              this.connectionWarningTimeouts.delete(member);
             }
           }
 
-          // Initialize connection status for new members
+          // For new members, start a warning timeout
           this.members.forEach((member) => {
             if (!this.memberConnectionStatus.has(member)) {
-              this.memberConnectionStatus.set(member, false); // Start as disconnected
+              this.memberConnectionStatus.set(member, false);
+              this.scheduleConnectionWarning(member);
             }
           });
 
@@ -636,72 +637,25 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
       })
     );
 
-    // Start precise 5s warning timeout the instant a peer disconnects
+    // When a peer disconnects after being connected, restart warning timeout
     this.subscriptions.push(
       this.webrtcService.peerDisconnected$.subscribe((member) => {
         this.ngZone.run(() => {
           this.memberConnectionStatus.set(member, false);
-          if (!this.disconnectWarningTimeouts.has(member)) {
-            const timeoutId = setTimeout(() => {
-              this.ngZone.run(() => {
-                if (
-                  this.members.includes(member) &&
-                  !this.webrtcService.isConnected(member) &&
-                  !this.connectionWarningDismissed
-                ) {
-                  this.showConnectionWarning = true;
-                  this.cdr.detectChanges();
-                }
-                this.disconnectWarningTimeouts.delete(member);
-              });
-            }, CONNECTION_WARNING_THRESHOLD_MS);
-            this.disconnectWarningTimeouts.set(member, timeoutId);
-          }
+          this.scheduleConnectionWarning(member);
           this.cdr.detectChanges();
         });
       })
     );
 
-    // Cancel the warning timeout the instant a peer reconnects
+    // When a peer connects, cancel its warning timeout and hide banner if all peers are up
     this.subscriptions.push(
       this.webrtcService.peerConnected$.subscribe((member) => {
         this.ngZone.run(() => {
           this.memberConnectionStatus.set(member, true);
-          const timeoutId = this.disconnectWarningTimeouts.get(member);
-          if (timeoutId) {
-            clearTimeout(timeoutId);
-            this.disconnectWarningTimeouts.delete(member);
-          }
-          // Hide warning if all peers are now connected
-          const otherMembers = this.members.filter((m) => m !== this.userService.user);
-          if (
-            otherMembers.length > 0 &&
-            otherMembers.every((m) => this.webrtcService.isConnected(m))
-          ) {
-            this.showConnectionWarning = false;
-            this.connectionWarningDismissed = false;
-          }
+          this.clearConnectionWarning(member);
           this.cdr.detectChanges();
         });
-      })
-    );
-
-    // Also clear warning when data channel opens
-    this.subscriptions.push(
-      this.webrtcService.dataChannelOpen$.subscribe((isOpen) => {
-        if (isOpen && this.showConnectionWarning) {
-          this.ngZone.run(() => {
-            const otherMembers = this.members.filter((m) => m !== this.userService.user);
-            if (
-              otherMembers.length > 0 &&
-              otherMembers.every((m) => this.webrtcService.isConnected(m))
-            ) {
-              this.showConnectionWarning = false;
-              this.connectionWarningDismissed = false;
-              this.cdr.detectChanges();
-            }
-          });
-        }
       })
     );
 
@@ -1774,10 +1728,10 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
         });
 
         // Clean up warning timeouts for members who left
-        for (const [member, timeoutId] of this.disconnectWarningTimeouts.entries()) {
+        for (const [member, timeoutId] of this.connectionWarningTimeouts.entries()) {
           if (!otherMembers.includes(member)) {
             clearTimeout(timeoutId);
-            this.disconnectWarningTimeouts.delete(member);
+            this.connectionWarningTimeouts.delete(member);
           }
         }
 
@@ -1815,6 +1769,41 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
   protected refreshPage(): void {
     if (isPlatformBrowser(this.platformId)) {
       window.location.reload();
+    }
+  }
+
+  private scheduleConnectionWarning(member: string): void {
+    if (this.connectionWarningTimeouts.has(member)) return;
+    const timeoutId = setTimeout(() => {
+      this.ngZone.run(() => {
+        this.connectionWarningTimeouts.delete(member);
+        if (
+          this.members.includes(member) &&
+          !this.webrtcService.isConnected(member) &&
+          !this.connectionWarningDismissed
+        ) {
+          this.showConnectionWarning = true;
+          this.cdr.detectChanges();
+        }
+      });
+    }, CONNECTION_WARNING_DELAY_MS);
+    this.connectionWarningTimeouts.set(member, timeoutId);
+  }
+
+  private clearConnectionWarning(member: string): void {
+    const timeoutId = this.connectionWarningTimeouts.get(member);
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      this.connectionWarningTimeouts.delete(member);
+    }
+    // Hide banner if all peers are now connected
+    const otherMembers = this.members.filter((m) => m !== this.userService.user);
+    if (
+      otherMembers.length > 0 &&
+      otherMembers.every((m) => this.webrtcService.isConnected(m))
+    ) {
+      this.showConnectionWarning = false;
+      this.connectionWarningDismissed = false;
     }
   }
 

--- a/client/web/src/app/features/chat/chat.component.ts
+++ b/client/web/src/app/features/chat/chat.component.ts
@@ -573,6 +573,14 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
           // Filter out the local user's own name
           this.members = allMembers.filter((m) => m !== this.userService.user);
 
+          // Clear disconnect warning timeouts for members who left
+          for (const [member, timeoutId] of this.disconnectWarningTimeouts.entries()) {
+            if (!this.members.includes(member)) {
+              clearTimeout(timeoutId);
+              this.disconnectWarningTimeouts.delete(member);
+            }
+          }
+
           // Initialize connection status for new members
           this.members.forEach((member) => {
             if (!this.memberConnectionStatus.has(member)) {
@@ -636,7 +644,11 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
           if (!this.disconnectWarningTimeouts.has(member)) {
             const timeoutId = setTimeout(() => {
               this.ngZone.run(() => {
-                if (!this.webrtcService.isConnected(member) && !this.connectionWarningDismissed) {
+                if (
+                  this.members.includes(member) &&
+                  !this.webrtcService.isConnected(member) &&
+                  !this.connectionWarningDismissed
+                ) {
                   this.showConnectionWarning = true;
                   this.cdr.detectChanges();
                 }

--- a/client/web/src/app/features/chat/chat.component.ts
+++ b/client/web/src/app/features/chat/chat.component.ts
@@ -686,6 +686,25 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
       })
     );
 
+    // Also clear warning when data channel opens
+    this.subscriptions.push(
+      this.webrtcService.dataChannelOpen$.subscribe((isOpen) => {
+        if (isOpen && this.showConnectionWarning) {
+          this.ngZone.run(() => {
+            const otherMembers = this.members.filter((m) => m !== this.userService.user);
+            if (
+              otherMembers.length > 0 &&
+              otherMembers.every((m) => this.webrtcService.isConnected(m))
+            ) {
+              this.showConnectionWarning = false;
+              this.connectionWarningDismissed = false;
+              this.cdr.detectChanges();
+            }
+          });
+        }
+      })
+    );
+
     // Listen for incoming file offers
     this.subscriptions.push(
       this.fileTransferService.incomingFileOffers$.subscribe((incomingFiles: FileDownload[]) => {

--- a/client/web/src/app/features/chat/chat.component.ts
+++ b/client/web/src/app/features/chat/chat.component.ts
@@ -47,6 +47,7 @@ import {
   HEARTBEAT_TIMEOUT_DESKTOP_SEC,
   HEARTBEAT_TIMEOUT_MOBILE_SEC,
   NAVIGATION_DELAY_MS,
+  CONNECTION_WARNING_THRESHOLD_MS,
   SESSION_CODE_KEY,
   THEME_PREFERENCE_KEY,
   PREVIEW_MIME_TYPE,
@@ -138,6 +139,7 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
   rooms: string[] = [];
   members: string[] = [];
   memberConnectionStatus = new Map<string, boolean>(); // true = connected, false = failed
+  showConnectionWarning = false;
 
   currentRoom = 'main';
   isDarkMode = false;
@@ -164,6 +166,8 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
   private navigationTimeout: ReturnType<typeof setTimeout> | null = null;
   private emojiPickerHideTimeout: ReturnType<typeof setTimeout> | null = null;
   private statusCheckIntervalId: ReturnType<typeof setInterval> | null = null;
+  private connectionWarningDismissed = false;
+  private disconnectWarningTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
 
   appVersion: string = packageJson.version;
 
@@ -371,6 +375,12 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
       this.logger.debug('ngOnDestroy', 'Status check interval cleared');
     }
 
+    // Clear disconnect warning timeouts
+    for (const timeoutId of this.disconnectWarningTimeouts.values()) {
+      clearTimeout(timeoutId);
+    }
+    this.disconnectWarningTimeouts.clear();
+
     if (isPlatformBrowser(this.platformId) && this.visibilityChangeListener) {
       document.removeEventListener('visibilitychange', this.visibilityChangeListener);
     }
@@ -487,7 +497,9 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
   onEnterKey(event: KeyboardEvent, messageForm: NgForm): void {
     if (!event.shiftKey) {
       event.preventDefault();
-      void this.sendMessage(messageForm);
+      if (!this.isSendDisabled) {
+        void this.sendMessage(messageForm);
+      }
     }
   }
 
@@ -611,6 +623,52 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
             return msg;
           });
           this.chatService.replaceMessages(updatedMessages);
+          this.cdr.detectChanges();
+        });
+      })
+    );
+
+    // Start precise 5s warning timeout the instant a peer disconnects
+    this.subscriptions.push(
+      this.webrtcService.peerDisconnected$.subscribe((member) => {
+        this.ngZone.run(() => {
+          this.memberConnectionStatus.set(member, false);
+          if (!this.disconnectWarningTimeouts.has(member)) {
+            const timeoutId = setTimeout(() => {
+              this.ngZone.run(() => {
+                if (!this.webrtcService.isConnected(member) && !this.connectionWarningDismissed) {
+                  this.showConnectionWarning = true;
+                  this.cdr.detectChanges();
+                }
+                this.disconnectWarningTimeouts.delete(member);
+              });
+            }, CONNECTION_WARNING_THRESHOLD_MS);
+            this.disconnectWarningTimeouts.set(member, timeoutId);
+          }
+          this.cdr.detectChanges();
+        });
+      })
+    );
+
+    // Cancel the warning timeout the instant a peer reconnects
+    this.subscriptions.push(
+      this.webrtcService.peerConnected$.subscribe((member) => {
+        this.ngZone.run(() => {
+          this.memberConnectionStatus.set(member, true);
+          const timeoutId = this.disconnectWarningTimeouts.get(member);
+          if (timeoutId) {
+            clearTimeout(timeoutId);
+            this.disconnectWarningTimeouts.delete(member);
+          }
+          // Hide warning if all peers are now connected
+          const otherMembers = this.members.filter((m) => m !== this.userService.user);
+          if (
+            otherMembers.length > 0 &&
+            otherMembers.every((m) => this.webrtcService.isConnected(m))
+          ) {
+            this.showConnectionWarning = false;
+            this.connectionWarningDismissed = false;
+          }
           this.cdr.detectChanges();
         });
       })
@@ -1666,7 +1724,7 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
       this.statusCheckIntervalId = null;
     }
 
-    // Periodically update connection status
+    // Periodically sync connection status map for the UI (red/green circles)
     this.statusCheckIntervalId = setInterval(() => {
       if (this.members.length === 0) {
         if (this.statusCheckIntervalId) {
@@ -1677,10 +1735,21 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
       }
 
       this.ngZone.run(() => {
-        this.members.forEach((member) => {
-          const isConnected = this.webrtcService.isConnected(member);
-          this.memberConnectionStatus.set(member, isConnected);
+        const otherMembers = this.members.filter((m) => m !== this.userService.user);
+
+        // Keep the status map in sync for the UI (red/green circles)
+        otherMembers.forEach((member) => {
+          this.memberConnectionStatus.set(member, this.webrtcService.isConnected(member));
         });
+
+        // Clean up warning timeouts for members who left
+        for (const [member, timeoutId] of this.disconnectWarningTimeouts.entries()) {
+          if (!otherMembers.includes(member)) {
+            clearTimeout(timeoutId);
+            this.disconnectWarningTimeouts.delete(member);
+          }
+        }
+
         this.cdr.detectChanges();
       });
     }, 3000);
@@ -1694,6 +1763,28 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
    */
   protected isConnectedToMember(member: string): boolean {
     return this.memberConnectionStatus.get(member) ?? false;
+  }
+
+  protected get hasNoConnectedPeers(): boolean {
+    const otherMembers = this.members.filter((m) => m !== this.userService.user);
+    if (otherMembers.length === 0) return true;
+    return !otherMembers.some((m) => this.isConnectedToMember(m));
+  }
+
+  protected get isSendDisabled(): boolean {
+    return !this.message.trim() || this.hasNoConnectedPeers;
+  }
+
+  protected dismissConnectionWarning(): void {
+    this.showConnectionWarning = false;
+    this.connectionWarningDismissed = true;
+    this.cdr.detectChanges();
+  }
+
+  protected refreshPage(): void {
+    if (isPlatformBrowser(this.platformId)) {
+      window.location.reload();
+    }
   }
 
   /**

--- a/client/web/src/app/features/chat/chat.component.ts
+++ b/client/web/src/app/features/chat/chat.component.ts
@@ -1798,10 +1798,7 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
     }
     // Hide banner if all peers are now connected
     const otherMembers = this.members.filter((m) => m !== this.userService.user);
-    if (
-      otherMembers.length > 0 &&
-      otherMembers.every((m) => this.webrtcService.isConnected(m))
-    ) {
+    if (otherMembers.length > 0 && otherMembers.every((m) => this.webrtcService.isConnected(m))) {
       this.showConnectionWarning = false;
       this.connectionWarningDismissed = false;
     }

--- a/client/web/src/app/utils/constants.ts
+++ b/client/web/src/app/utils/constants.ts
@@ -27,7 +27,7 @@ export const NAVIGATION_DELAY_MS = 100;
 // Inactivity timeout constants
 export const IDLE_TIMEOUT = 12 * 60 * 60 * 1000; // 12 hours
 export const BACKGROUND_EXPIRY_THRESHOLD = 5 * 60 * 1000; // 5 minutes
-export const CONNECTION_WARNING_THRESHOLD_MS = 5_000; // 5 seconds
+export const CONNECTION_WARNING_DELAY_MS = 5_000; // 5 seconds before showing connection warning
 
 // WebRTC constants
 export const MAX_RECONNECT_ATTEMPTS = 5;

--- a/client/web/src/app/utils/constants.ts
+++ b/client/web/src/app/utils/constants.ts
@@ -27,6 +27,7 @@ export const NAVIGATION_DELAY_MS = 100;
 // Inactivity timeout constants
 export const IDLE_TIMEOUT = 12 * 60 * 60 * 1000; // 12 hours
 export const BACKGROUND_EXPIRY_THRESHOLD = 5 * 60 * 1000; // 5 minutes
+export const CONNECTION_WARNING_THRESHOLD_MS = 5_000; // 5 seconds
 
 // WebRTC constants
 export const MAX_RECONNECT_ATTEMPTS = 5;


### PR DESCRIPTION
- Shows a warning banner when peer-to-peer connections are lost for over 5 seconds.
- Disables the send button and file attachment options when no peers are connected.
- Adds English and Arabic translations for troubleshooting network issues.
- Includes UI buttons to refresh the page or dismiss the warning banner.
- Tracks peer connection states in real-time to provide immediate feedback.