### PR TITLE
Chore: Bump build

### DIFF
--- a/client/web/package-lock.json
+++ b/client/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "dependencies": {
         "@angular/cdk": "^21.2.5",
         "@angular/common": "^21.2.7",

--- a/client/web/package.json
+++ b/client/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1980,7 +1980,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "actix",
  "actix-broker",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 authors = ["Sulaiman AlRomaih"]
 license = "GPL-3"


### PR DESCRIPTION
This pull request updates the version numbers for both the frontend and backend components. These changes ensure consistency in versioning across the project and prepare for a new release.

Version updates:

* Bumped the frontend version in `client/web/package.json` and `client/web/package-lock.json` from `0.15.0` to `0.15.1`. [[1]](diffhunk://#diff-f669e832b021e795b7206497424085a6c20db1401e0d86b41ca88e7bd5dd73e4L3-R3) [[2]](diffhunk://#diff-9755dd05075a9dc0626315acf42fc5b61b030985b8580ef0d626d2a8339e2ef8L3-R9)
* Bumped the backend version in `server/Cargo.toml` from `0.9.0` to `0.9.1`.