### PR TITLE
Feat: Improve session navigation, state handling, and connection management

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 # PastePoint
 
-PastePoint is a secure, feature-rich file-sharing service designed for local networks. It enables users to share files and communicate efficiently through peer-to-peer WebRTC connections. Built with a Rust-based backend using Actix Web and an Angular frontend with SSR support, PastePoint prioritizes security, performance, and usability.
+PastePoint is a secure, feature-rich file-sharing service designed for local networks. It enables users to share files and communicate efficiently through peer-to-peer WebRTC connections. Built with a Rust-based backend using Actix Web and an Angular 21 frontend with SSR support, PastePoint prioritizes security, performance, and usability.
 
 ## Usage Disclaimer
 
@@ -24,7 +24,10 @@ PastePoint is a secure, feature-rich file-sharing service designed for local net
 
   - Establish WebSocket-based local chat between computers on the same network
   - List available sessions, create new sessions, or join existing ones
+  - Multiple rooms within a session — create, list, and switch between rooms
+  - QR code session sharing — generate a code from one device and scan it from another to join instantly
   - Real-time messaging with emoji support and dark/light theme
+  - Resilient WebSocket signaling with automatic reconnect, heartbeat, and bfcache support
 
 - **File Sharing**:
 
@@ -62,10 +65,10 @@ PastePoint is a secure, feature-rich file-sharing service designed for local net
 
 ### Server (Rust)
 
-[![Actix](https://img.shields.io/badge/Actix-4.7-blue)](https://actix.rs/)
+[![Actix](https://img.shields.io/badge/Actix-4.13-blue)](https://actix.rs/)
 [![OpenSSL](https://img.shields.io/badge/OpenSSL-0.10-yellow)](https://www.openssl.org/)
 
-- **Framework**: Actix Web with WebSocket support
+- **Framework**: Actix Web with WebSocket support (Rust edition 2024, toolchain 1.93.1)
 - **Security**: OpenSSL for TLS termination
 - **Utilities**: UUID generation, Serde serialization
 - **Rate Limiting**: Actix-governor for request throttling
@@ -74,22 +77,24 @@ PastePoint is a secure, feature-rich file-sharing service designed for local net
 
 #### Web (Angular)
 
-[![Angular](https://img.shields.io/badge/Angular-19-red)](https://angular.io/)
+[![Angular](https://img.shields.io/badge/Angular-21-red)](https://angular.io/)
 [![Tailwind](https://img.shields.io/badge/Tailwind-3.4-blue)](https://tailwindcss.com/)
-[![Flowbite](https://img.shields.io/badge/Flowbite-3.0-cyan)](https://flowbite.com/)
+[![Flowbite](https://img.shields.io/badge/Flowbite-3.1-cyan)](https://flowbite.com/)
 
-- **Rendering**: Server-Side Rendering with Angular Universal
+- **Rendering**: Server-Side Rendering with Angular SSR
 - **State Management**: RxJS observables
 - **Styling**: Tailwind CSS with dark mode
-- **I18n**: ngx-translate integration (English, Arabic) (WIP)
+- **I18n**: ngx-translate integration (English, Arabic with RTL)
 - **WebRTC**: Native WebRTC API for file transfers
+- **QR Sharing**: `qrcode` for generation, `jsqr` for camera-based scanning
+- **Integrity**: `hash-wasm` for fast file hashing
 - **Notifications**: Hot-toast for real-time feedback
 
 ### Infrastructure
 
 [![Nginx](https://img.shields.io/badge/Nginx-Reverse_Proxy-green)](https://nginx.org)
 [![Docker](https://img.shields.io/badge/Docker-24.0-blue)](https://www.docker.com)
-[![Express](https://img.shields.io/badge/Express-4.21-purple)](https://expressjs.com/)
+[![Express](https://img.shields.io/badge/Express-4.22-purple)](https://expressjs.com/)
 
 - **Container Orchestration**: Docker Compose with multi-stage builds
 - **Reverse Proxy**: Nginx with enhanced security features
@@ -103,8 +108,7 @@ PastePoint is a secure, feature-rich file-sharing service designed for local net
 pastepoint/
 ├── client/                         # Frontend clients
 │   ├── web/                        # Angular SSR frontend
-│   ├── ios/                        # iOS client (WIP)
-│   └── android/                    # Android client (WIP)
+│   └── ios/                        # iOS client (WIP)
 ├── server/                         # Rust backend with WebSockets
 ├── nginx/                          # Reverse proxy & SSL termination
 ├── scripts/                        # Development & deployment scripts
@@ -131,7 +135,7 @@ pastepoint/
 
 ##### Android:
 
-- Work in progress
+- Planned
 
 #### Deployment:
 
@@ -162,7 +166,7 @@ pastepoint/
 
 - Docker and Docker Compose
 - Node.js (v22.14.0 as specified in `.nvmrc`)
-- Rust (stable, specified in `rust-toolchain`)
+- Rust 1.93.1 (specified in `rust-toolchain`, edition 2024)
 
 #### Windows-Specific Requirements:
 
@@ -205,9 +209,9 @@ pastepoint/
    - Frontend:
      - Localhost: [https://localhost](https://localhost)
      - Local Network: `https://<your-local-ip>`
-   - Server API:
-     - Localhost: [https://localhost:9000](https://localhost:9000)
-     - Local Network: `https://<your-local-ip>:9000`
+   - WebSocket signaling:
+     - Localhost: `wss://localhost:9000/ws`
+     - Local Network: `wss://<your-local-ip>:9000/ws`
 
 ## Contributing
 

--- a/client/web/package-lock.json
+++ b/client/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "dependencies": {
         "@angular/cdk": "^21.2.9",
         "@angular/common": "^21.2.11",

--- a/client/web/package.json
+++ b/client/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/client/web/src/app/core/i18n/localizations/ar.json
+++ b/client/web/src/app/core/i18n/localizations/ar.json
@@ -134,6 +134,7 @@
   "CANNOT_CONNECT_TO_USER": "تعذّر الاتصال بالمستخدم {{userName}}. قد لا يكون متصلاً.",
   "CONNECTION_CLOSED_WITH_USER": "تم إغلاق الاتصال مع المستخدم {{userName}}.",
   "SERVER_CONNECTION_FAILED": "فشل الاتصال بالخادم. يرجى التحقق من اتصال الإنترنت.",
+  "SESSION_JOIN_FAILED": "تعذر الانضمام إلى الجلسة. قد يكون الرمز غير صالح أو منتهي الصلاحية، أو أن الخادم غير متاح.",
   "SERVER_CONNECTION_LOST_PERMANENTLY": "تم فقد الاتصال بالخادم. يرجى تحديث الصفحة.",
   "RECONNECTING_TO_SERVER": "جارٍ إعادة الاتصال بالخادم...",
   "CANCELLED": "تم الإلغاء",

--- a/client/web/src/app/core/i18n/localizations/en.json
+++ b/client/web/src/app/core/i18n/localizations/en.json
@@ -134,6 +134,7 @@
   "CANNOT_CONNECT_TO_USER": "Cannot connect to {{userName}}. They may be offline.",
   "CONNECTION_CLOSED_WITH_USER": "Connection with {{userName}} was closed.",
   "SERVER_CONNECTION_FAILED": "Failed to connect to server. Please check your internet connection.",
+  "SESSION_JOIN_FAILED": "Couldn't join the session. The code may be invalid or expired, or the server may be unreachable.",
   "SERVER_CONNECTION_LOST_PERMANENTLY": "Lost connection to server. Please refresh the page.",
   "RECONNECTING_TO_SERVER": "Reconnecting to server...",
   "CANCELLED": "Canceled",

--- a/client/web/src/app/core/interfaces/webrtc.interface.ts
+++ b/client/web/src/app/core/interfaces/webrtc.interface.ts
@@ -25,5 +25,6 @@ export interface IWebRTCService {
 
   initiateConnection(targetUser: string): void;
   sendData(data: DataChannelMessage, targetUser: string): void;
+  closeConnection(targetUser: string): void;
   closeAllConnections(): void;
 }

--- a/client/web/src/app/core/services/communication/webrtc-signaling.service.ts
+++ b/client/web/src/app/core/services/communication/webrtc-signaling.service.ts
@@ -239,10 +239,8 @@ export class WebRTCSignalingService {
   }
 
   /**
-   * Fully stops WebRTC work for a peer that is no longer in the room.
-   * This is stronger than closing the current RTCPeerConnection because it
-   * also cancels pending retries and delayed connection requests.
-   * @param targetUser The user to stop connecting to
+   * Stronger than closePeerConnection — also cancels pending retries and
+   * queued requests. Use when the peer is gone for good (left the room).
    */
   public closeConnection(targetUser: string): void {
     this.closePeerConnection(targetUser, true);

--- a/client/web/src/app/core/services/communication/webrtc-signaling.service.ts
+++ b/client/web/src/app/core/services/communication/webrtc-signaling.service.ts
@@ -239,6 +239,28 @@ export class WebRTCSignalingService {
   }
 
   /**
+   * Fully stops WebRTC work for a peer that is no longer in the room.
+   * This is stronger than closing the current RTCPeerConnection because it
+   * also cancels pending retries and delayed connection requests.
+   * @param targetUser The user to stop connecting to
+   */
+  public closeConnection(targetUser: string): void {
+    this.closePeerConnection(targetUser, true);
+
+    this.connectionLocks.delete(targetUser);
+    this.reconnectAttempts.delete(targetUser);
+    this.lastSequences.delete(targetUser);
+
+    const reconnectionTimeout = this.reconnectionTimeouts.get(targetUser);
+    if (reconnectionTimeout) {
+      clearTimeout(reconnectionTimeout);
+      this.reconnectionTimeouts.delete(targetUser);
+    }
+
+    this.communicationService.deleteMessageQueue(targetUser);
+  }
+
+  /**
    * Closes a peer connection with the target user
    * @param targetUser The user to disconnect from
    * @param force Whether to force close the connection
@@ -246,8 +268,8 @@ export class WebRTCSignalingService {
   public closePeerConnection(targetUser: string, force = false) {
     const peerConnection = this.peerConnections.get(targetUser);
     if (peerConnection) {
-      peerConnection.close();
       this.peerConnections.delete(targetUser);
+      peerConnection.close();
     }
 
     // Clear connection request timeout
@@ -286,7 +308,9 @@ export class WebRTCSignalingService {
       peerConnection.close();
     });
     this.peerConnections.clear();
+    this.connectionLocks.clear();
     this.reconnectAttempts.clear();
+    this.lastSequences.clear();
     this.candidateQueues.clear();
     this.collectedCandidates.clear();
 
@@ -923,7 +947,6 @@ export class WebRTCSignalingService {
     this.logger.info('reconnect', `Reconnecting WebRTC with ${targetUser}...`);
 
     this.closePeerConnection(targetUser, true);
-    this.reconnectAttempts.set(targetUser, 0);
     this.initiateConnection(targetUser);
   }
 

--- a/client/web/src/app/core/services/communication/webrtc.service.ts
+++ b/client/web/src/app/core/services/communication/webrtc.service.ts
@@ -171,10 +171,6 @@ export class WebRTCService implements IWebRTCService {
     return this.communicationService.isConnected(targetUser);
   }
 
-  /**
-   * Closes connection with a single target user and cancels pending retries
-   * @param targetUser The user to disconnect from
-   */
   public closeConnection(targetUser: string): void {
     this.signalingService.closeConnection(targetUser);
   }

--- a/client/web/src/app/core/services/communication/webrtc.service.ts
+++ b/client/web/src/app/core/services/communication/webrtc.service.ts
@@ -172,6 +172,14 @@ export class WebRTCService implements IWebRTCService {
   }
 
   /**
+   * Closes connection with a single target user and cancels pending retries
+   * @param targetUser The user to disconnect from
+   */
+  public closeConnection(targetUser: string): void {
+    this.signalingService.closeConnection(targetUser);
+  }
+
+  /**
    * Closes all connections
    */
   public closeAllConnections(): void {

--- a/client/web/src/app/core/services/communication/websocket-connection.service.ts
+++ b/client/web/src/app/core/services/communication/websocket-connection.service.ts
@@ -265,9 +265,6 @@ export class WebSocketConnectionService implements OnDestroy {
         this.isConnecting = false;
         this.stopKeepAlive();
         this.socket = undefined;
-        if (this.reconnectAttempts === 0 && !this.manualDisconnect) {
-          this.toaster.error(this.translate.instant('SERVER_CONNECTION_FAILED'));
-        }
         reject(error);
       };
     });

--- a/client/web/src/app/core/services/communication/websocket-connection.service.ts
+++ b/client/web/src/app/core/services/communication/websocket-connection.service.ts
@@ -178,6 +178,21 @@ export class WebSocketConnectionService implements OnDestroy {
       const socket = new WebSocket(wsUri);
       this.socket = socket;
 
+      // Settle once — onclose may fire without onopen/onerror, e.g. when a
+      // concurrent disconnect replaces this.socket and the stale-event guards
+      // below skip the natural reject path.
+      let settled = false;
+      const settleResolve = () => {
+        if (settled) return;
+        settled = true;
+        resolve();
+      };
+      const settleReject = (err: unknown) => {
+        if (settled) return;
+        settled = true;
+        reject(err);
+      };
+
       socket.onopen = () => {
         if (socket !== this.socket) return;
         this.logger.info('connect', 'WebSocket connected');
@@ -188,7 +203,7 @@ export class WebSocketConnectionService implements OnDestroy {
         this.reconnectDelay = 1000;
         this.isConnecting = false;
         this.startKeepAlive();
-        resolve();
+        settleResolve();
       };
 
       socket.onmessage = (ev) => {
@@ -219,6 +234,10 @@ export class WebSocketConnectionService implements OnDestroy {
       };
 
       socket.onclose = (event) => {
+        // Must run before the stale-event guard — the promise belongs to
+        // this socket, even if it's already been replaced.
+        settleReject(new Error(`WebSocket closed before opening (code ${event.code})`));
+
         // Ignore stale close events from a socket that has already been replaced.
         // Without this guard, a late-firing onclose from a previous socket would
         // null-out the current `this.socket` and trigger a phantom reconnect,
@@ -265,7 +284,7 @@ export class WebSocketConnectionService implements OnDestroy {
         this.isConnecting = false;
         this.stopKeepAlive();
         this.socket = undefined;
-        reject(error);
+        settleReject(error);
       };
     });
   }

--- a/client/web/src/app/core/services/room-management/room.service.ts
+++ b/client/web/src/app/core/services/room-management/room.service.ts
@@ -46,10 +46,8 @@ export class RoomService implements IRoomService {
   }
 
   /**
-   * Clears all session-scoped state. Called during session transitions
-   * (entering/leaving a private session) so the singleton's BehaviorSubjects
-   * don't replay stale members/rooms from the previous session into the
-   * newly-mounted view.
+   * Resets singleton state on session transition so BehaviorSubjects don't
+   * replay the previous session's members/rooms into the new view.
    */
   public reset(): void {
     this.ngZone.run(() => {

--- a/client/web/src/app/core/services/room-management/room.service.ts
+++ b/client/web/src/app/core/services/room-management/room.service.ts
@@ -45,6 +45,20 @@ export class RoomService implements IRoomService {
     this.wsService.send('[UserCommand] /list');
   }
 
+  /**
+   * Clears all session-scoped state. Called during session transitions
+   * (entering/leaving a private session) so the singleton's BehaviorSubjects
+   * don't replay stale members/rooms from the previous session into the
+   * newly-mounted view.
+   */
+  public reset(): void {
+    this.ngZone.run(() => {
+      this.rooms$.next([]);
+      this.members$.next([]);
+      this.currentRoom = 'main';
+    });
+  }
+
   public joinRoom(room: string): void {
     const sanitizedRoom = room
       .replace(/[^a-zA-Z0-9\-_ ]/g, '')

--- a/client/web/src/app/features/chat/chat.component.html
+++ b/client/web/src/app/features/chat/chat.component.html
@@ -295,9 +295,8 @@
       </div>
       <div class="flex items-center gap-4">
         <a
-          href="/privacy"
+          routerLink="/privacy"
           title="Privacy and Terms"
-          target="_self"
           rel="noopener noreferrer nofollow"
           class="inline-flex items-center gap-2 text-brand dark:text-brandDark"
         >

--- a/client/web/src/app/features/chat/chat.component.ts
+++ b/client/web/src/app/features/chat/chat.component.ts
@@ -148,6 +148,7 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
   activeDownloads: FileDownload[] = [];
 
   private isNavigatingIntentionally = false;
+  private isInitialBootstrap = true;
   private lastMessagesLength: number = 0;
   private connectionInitTimeouts: ReturnType<typeof setTimeout>[] = [];
   private navigationTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -220,15 +221,8 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
     }
 
     if (!isPlatformBrowser(this.platformId)) {
-      this.route.paramMap.subscribe((params) => {
-        const privateSession = params.get('code');
-
-        if (privateSession) {
-          this.metaService.updateChatMetadata(true);
-        } else {
-          this.metaService.updateChatMetadata(false);
-        }
-      });
+      const privateSession = this.route.snapshot.paramMap.get('code');
+      this.metaService.updateChatMetadata(!!privateSession);
       return;
     }
 
@@ -248,33 +242,59 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
       this.logger.debug('ngOnInit', `Flowbite loaded`);
     });
 
-    // Check if route has a session code in URL but don't connect yet
-    this.route.paramMap.subscribe((params) => {
-      this.ngZone.run(() => {
-        const sessionCode = params.get('code');
-        const storedSessionCode = localStorage.getItem(SESSION_CODE_KEY);
+    // Check if route has a session code in URL but don't connect yet.
+    // First emission seeds SessionCode for ngAfterViewInit's initial connect();
+    // subsequent emissions (from in-app navigation) trigger a full session
+    // transition via enterSession().
+    this.subscriptions.push(
+      this.route.paramMap.subscribe((params) => {
+        this.ngZone.run(() => {
+          const sessionCode = params.get('code');
+          const storedSessionCode = localStorage.getItem(SESSION_CODE_KEY);
 
-        if (sessionCode && this.sessionService.isValidSessionCode(sessionCode)) {
-          this.SessionCode = this.sessionService.sanitizeSessionCode(sessionCode);
-          this.metaService.updateChatMetadata(true);
-        } else if (storedSessionCode && this.sessionService.isValidSessionCode(storedSessionCode)) {
-          this.SessionCode = this.sessionService.sanitizeSessionCode(storedSessionCode);
-          this.metaService.updateChatMetadata(true);
-        } else {
-          if (sessionCode && !this.sessionService.isValidSessionCode(sessionCode)) {
-            this.logger.warn('ngOnInit', 'Invalid session code in URL, clearing');
+          if (this.isInitialBootstrap) {
+            this.isInitialBootstrap = false;
+
+            if (sessionCode && this.sessionService.isValidSessionCode(sessionCode)) {
+              const sanitized = this.sessionService.sanitizeSessionCode(sessionCode);
+              this.SessionCode = sanitized;
+              localStorage.setItem(SESSION_CODE_KEY, sanitized);
+              this.metaService.updateChatMetadata(true);
+            } else if (
+              storedSessionCode &&
+              this.sessionService.isValidSessionCode(storedSessionCode)
+            ) {
+              this.SessionCode = this.sessionService.sanitizeSessionCode(storedSessionCode);
+              this.metaService.updateChatMetadata(true);
+            } else {
+              if (sessionCode && !this.sessionService.isValidSessionCode(sessionCode)) {
+                this.logger.warn('ngOnInit', 'Invalid session code in URL, clearing');
+              }
+              if (storedSessionCode && !this.sessionService.isValidSessionCode(storedSessionCode)) {
+                this.logger.warn('ngOnInit', 'Invalid session code in localStorage, clearing');
+                this.clearSessionCode();
+              }
+              this.chatService.clearMessages();
+              this.messages = [];
+              this.metaService.updateChatMetadata(false);
+            }
+            this.cdr.detectChanges();
+            return;
           }
-          if (storedSessionCode && !this.sessionService.isValidSessionCode(storedSessionCode)) {
-            this.logger.warn('ngOnInit', 'Invalid session code in localStorage, clearing');
-            this.clearSessionCode();
+
+          // Subsequent emission: in-app navigation between sessions.
+          const newCode =
+            sessionCode && this.sessionService.isValidSessionCode(sessionCode)
+              ? this.sessionService.sanitizeSessionCode(sessionCode)
+              : null;
+          const currentCode = this.SessionCode || null;
+          if (newCode !== currentCode) {
+            this.isNavigatingIntentionally = true;
+            void this.enterSession(newCode);
           }
-          this.chatService.clearMessages();
-          this.messages = [];
-          this.metaService.updateChatMetadata(false);
-        }
-        this.cdr.detectChanges();
-      });
-    });
+        });
+      })
+    );
 
     // Listen to changes in the user's name
     this.subscriptions.push(
@@ -793,6 +813,74 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
 
   /**
    * ==========================================================
+   * ENTER SESSION
+   * Single point of state-transition: tears down everything related
+   * to the current session, updates SessionCode + storage + metadata,
+   * then connects to the new one. Called by the paramMap subscription
+   * whenever the route's :code segment changes after initial bootstrap.
+   * ==========================================================
+   */
+  private async enterSession(code: string | null): Promise<void> {
+    if (!isPlatformBrowser(this.platformId)) return;
+
+    this.logger.info('enterSession', `Switching to session: ${code ?? 'public'}`);
+
+    // ---- Tear down previous session ----
+    this.webrtcService.closeAllConnections();
+    this.wsConnectionService.disconnect();
+
+    this.connectionInitTimeouts.forEach((id) => clearTimeout(id));
+    this.connectionInitTimeouts = [];
+    this.connectionWarningTimeouts.forEach((id) => clearTimeout(id));
+    this.connectionWarningTimeouts.clear();
+    if (this.statusCheckIntervalId) {
+      clearInterval(this.statusCheckIntervalId);
+      this.statusCheckIntervalId = null;
+    }
+
+    this.roomService.reset();
+    this.chatService.clearMessages();
+
+    this.messages = [];
+    this.members = [];
+    this.rooms = [];
+    this.activeUploads = [];
+    this.activeDownloads = [];
+    this.memberConnectionStatus.clear();
+    this.showConnectionWarning = false;
+    this.connectionWarningDismissed = false;
+    this.currentRoom = 'main';
+    this.overrideRecipients = null;
+    this.lastMessagesLength = 0;
+
+    // ---- Update session code (memory + storage + meta) ----
+    if (code) {
+      const sanitized = this.sessionService.sanitizeSessionCode(code);
+      this.SessionCode = sanitized;
+      localStorage.setItem(SESSION_CODE_KEY, sanitized);
+      this.metaService.updateChatMetadata(true);
+    } else {
+      this.SessionCode = '';
+      localStorage.removeItem(SESSION_CODE_KEY);
+      this.metaService.updateChatMetadata(false);
+    }
+
+    this.cdr.detectChanges();
+
+    // ---- Connect to the new session ----
+    try {
+      await this.connect(this.SessionCode || undefined);
+    } catch (err) {
+      this.logger.error('enterSession', `Failed to connect to new session: ${err}`);
+    } finally {
+      // Settle the navigation intent so beforeUnload semantics remain correct
+      // for whatever the user does next.
+      this.isNavigatingIntentionally = false;
+    }
+  }
+
+  /**
+   * ==========================================================
    * SEND MESSAGE
    * Sends the chat message to other members via WebRTC, then clears
    * the input field and scrolls chat down.
@@ -1252,17 +1340,20 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
     requestAnimationFrame(() => {
       this.isOpenEndSessionPopup = false;
       this.cdr.detectChanges();
-      this.clearSessionCode();
-      this.wsConnectionService.disconnect();
       this.toaster.success(this.translate.instant('SESSION_ENDED_SUCCESS'));
-      this.router.navigate([`/`]);
+      // paramMap subscription detects the code change and calls enterSession(null),
+      // which tears down WebRTC/WS and reconnects to public.
+      void this.router.navigateByUrl('/');
     });
   }
 
   /**
    * ==========================================================
    * OPEN CHAT SESSION
-   * Redirects the user to /private/:code in the same browser tab.
+   * Validates the code and triggers SPA navigation to /private/:code.
+   * The actual session-state teardown and reconnection is handled by
+   * the paramMap subscription -> enterSession() flow, so this method
+   * is only responsible for the navigation itself.
    * ==========================================================
    */
   private openChatSession(code: string): void {
@@ -1272,46 +1363,26 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
       return;
     }
 
-    if (this.SessionCode) {
-      // Close all WebRTC connections
-      this.webrtcService.closeAllConnections();
+    if (!isPlatformBrowser(this.platformId)) return;
 
-      // Clear all state
-      this.clearSessionCode();
-      this.clearMessages();
-      this.members = [];
-      this.rooms = [];
-      this.activeUploads = [];
-      this.activeDownloads = [];
-      this.overrideRecipients = null;
-
-      // Disconnect WebSocket
-      this.wsConnectionService.disconnect();
-
-      // Reset room to default
-      this.currentRoom = 'main';
+    const sanitizedCode = this.sessionService.sanitizeSessionCode(code);
+    if (sanitizedCode === this.SessionCode) {
+      this.logger.debug('openChatSession', `Already in session: ${sanitizedCode}`);
+      return;
     }
 
-    if (isPlatformBrowser(this.platformId)) {
-      this.logger.debug('openChatSession', `Opening chat session with code: ${code}`);
-      this.ngZone.run(() => {
-        this.isNavigatingIntentionally = true;
-        this.cdr.detectChanges();
-      });
+    this.logger.debug('openChatSession', `Opening chat session with code: ${sanitizedCode}`);
 
-      const sanitizedCode = this.sessionService.sanitizeSessionCode(code);
-      localStorage.setItem(SESSION_CODE_KEY, sanitizedCode);
-
-      // Clear any existing navigation timeout
-      if (this.navigationTimeout) {
-        clearTimeout(this.navigationTimeout);
-      }
-
-      this.navigationTimeout = setTimeout(() => {
-        this.navigationTimeout = null;
-        window.open(`/private/${sanitizedCode}`, '_self');
-      }, NAVIGATION_DELAY_MS);
+    if (this.navigationTimeout) {
+      clearTimeout(this.navigationTimeout);
     }
+
+    // Small delay so the popup close animation and toast can render before
+    // the URL change kicks off the session-transition pipeline.
+    this.navigationTimeout = setTimeout(() => {
+      this.navigationTimeout = null;
+      void this.router.navigateByUrl(`/private/${sanitizedCode}`);
+    }, NAVIGATION_DELAY_MS);
   }
 
   /**

--- a/client/web/src/app/features/chat/chat.component.ts
+++ b/client/web/src/app/features/chat/chat.component.ts
@@ -12,7 +12,8 @@ import {
   ViewChild,
   inject,
 } from '@angular/core';
-import { Subscription } from 'rxjs';
+import { combineLatest, Subscription } from 'rxjs';
+import { distinctUntilChanged, filter, map } from 'rxjs/operators';
 import { isPlatformBrowser, NgOptimizedImage, UpperCasePipe } from '@angular/common';
 
 import { ThemeService } from '../../core/services/ui/theme.service';
@@ -296,13 +297,14 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
       })
     );
 
+    this.initializeChat();
+
     // Listen to changes in the user's name
     this.subscriptions.push(
       this.userService.user$.subscribe((username: unknown) => {
         if (username) {
           this.ngZone.run(() => {
             this.logger.info('ngOnInit', `Username is set to: ${username}`);
-            this.initializeChat();
           });
         }
       })
@@ -547,31 +549,54 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
 
     // Listen for current members in the room
     this.subscriptions.push(
-      this.roomService.members$.subscribe((allMembers: string[]) => {
-        this.ngZone.run(() => {
-          // Filter out the local user's own name
-          this.members = allMembers.filter((m) => m !== this.userService.user);
+      combineLatest([this.roomService.members$, this.userService.user$])
+        .pipe(
+          filter(([, currentUser]) => currentUser.trim().length > 0),
+          map(([allMembers, currentUser]) => allMembers.filter((m) => m !== currentUser)),
+          distinctUntilChanged(
+            (previous, current) =>
+              previous.length === current.length &&
+              previous.every((member, index) => member === current[index])
+          )
+        )
+        .subscribe((nextMembers: string[]) => {
+          this.ngZone.run(() => {
+            const previousMembers = this.members;
+            const departedMembers = previousMembers.filter(
+              (member) => !nextMembers.includes(member)
+            );
 
-          // Clean up timeouts for members who left
-          for (const [member, timeoutId] of this.connectionWarningTimeouts.entries()) {
-            if (!this.members.includes(member)) {
-              clearTimeout(timeoutId);
-              this.connectionWarningTimeouts.delete(member);
-            }
-          }
+            this.members = nextMembers;
 
-          // For new members, start a warning timeout
-          this.members.forEach((member) => {
-            if (!this.memberConnectionStatus.has(member)) {
-              this.memberConnectionStatus.set(member, false);
-              this.scheduleConnectionWarning(member);
+            departedMembers.forEach((member) => {
+              this.logger.info(
+                'members',
+                `Closing WebRTC connection for departed member: ${member}`
+              );
+              this.webrtcService.closeConnection(member);
+              this.memberConnectionStatus.delete(member);
+            });
+
+            // Clean up timeouts for members who left
+            for (const [member, timeoutId] of this.connectionWarningTimeouts.entries()) {
+              if (!this.members.includes(member)) {
+                clearTimeout(timeoutId);
+                this.connectionWarningTimeouts.delete(member);
+              }
             }
+
+            // For new members, start a warning timeout
+            this.members.forEach((member) => {
+              if (!this.memberConnectionStatus.has(member)) {
+                this.memberConnectionStatus.set(member, false);
+                this.scheduleConnectionWarning(member);
+              }
+            });
+
+            this.cdr.detectChanges();
+            this.initiateConnectionsWithMembers();
           });
-
-          this.cdr.detectChanges();
-          this.initiateConnectionsWithMembers();
-        });
-      })
+        })
     );
 
     // Listen for active file uploads
@@ -620,6 +645,7 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
     this.subscriptions.push(
       this.webrtcService.peerDisconnected$.subscribe((member) => {
         this.ngZone.run(() => {
+          if (!this.members.includes(member)) return;
           this.memberConnectionStatus.set(member, false);
           this.scheduleConnectionWarning(member);
           this.cdr.detectChanges();
@@ -631,6 +657,7 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
     this.subscriptions.push(
       this.webrtcService.peerConnected$.subscribe((member) => {
         this.ngZone.run(() => {
+          if (!this.members.includes(member)) return;
           this.memberConnectionStatus.set(member, true);
           this.clearConnectionWarning(member);
           this.cdr.detectChanges();
@@ -724,11 +751,14 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
   ngAfterViewInit(): void {
     if (!isPlatformBrowser(this.platformId)) return;
 
-    if (this.SessionCode) {
-      this.connect(this.SessionCode);
-    } else {
-      void this.connect();
-    }
+    const attemptedCode = this.SessionCode;
+    this.connect(attemptedCode || undefined).catch(() => {
+      if (attemptedCode) {
+        this.fallbackToPublic();
+      } else {
+        this.toaster.error(this.translate.instant('SERVER_CONNECTION_FAILED'));
+      }
+    });
 
     document.addEventListener('visibilitychange', this.visibilityChangeListener);
     window.addEventListener('beforeunload', this.beforeUnloadHandler);
@@ -872,6 +902,11 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
       await this.connect(this.SessionCode || undefined);
     } catch (err) {
       this.logger.error('enterSession', `Failed to connect to new session: ${err}`);
+      if (code) {
+        this.fallbackToPublic();
+      } else {
+        this.toaster.error(this.translate.instant('SERVER_CONNECTION_FAILED'));
+      }
     } finally {
       // Settle the navigation intent so beforeUnload semantics remain correct
       // for whatever the user does next.
@@ -1446,6 +1481,18 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   /**
+   * Called when joining a private session fails (invalid/expired code,
+   * network error, etc). The browser's WebSocket API doesn't expose the
+   * HTTP status of a failed upgrade, so we can't reliably distinguish
+   * "wrong code" from "server unreachable" — the toast covers both.
+   */
+  private fallbackToPublic(): void {
+    this.clearSessionCode();
+    this.toaster.error(this.translate.instant('SESSION_JOIN_FAILED'));
+    void this.router.navigateByUrl('/');
+  }
+
+  /**
    * ==========================================================
    * WAIT FOR FILE TRANSFER CONNECTION
    * Waits for WebRTC connection to be ready for file transfer with retry logic
@@ -1483,17 +1530,23 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
    * ==========================================================
    */
   private initiateConnectionsWithMembers(): void {
+    // Clear any existing connection initialization timeouts before reacting
+    // to the latest membership snapshot.
+    this.connectionInitTimeouts.forEach((timeout) => clearTimeout(timeout));
+    this.connectionInitTimeouts = [];
+
     if (!this.members || this.members.length === 0) {
       this.logger.info(
         'initiateConnectionsWithMembers',
         'No members in the room, skipping WebRTC.'
       );
+
+      if (this.statusCheckIntervalId) {
+        clearInterval(this.statusCheckIntervalId);
+        this.statusCheckIntervalId = null;
+      }
       return;
     }
-
-    // Clear any existing connection initialization timeouts
-    this.connectionInitTimeouts.forEach((timeout) => clearTimeout(timeout));
-    this.connectionInitTimeouts = [];
 
     this.logger.info('initiateConnectionsWithMembers', 'Initiating connections with other members');
 

--- a/client/web/src/app/features/chat/chat.component.ts
+++ b/client/web/src/app/features/chat/chat.component.ts
@@ -150,6 +150,7 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
 
   private isNavigatingIntentionally = false;
   private isInitialBootstrap = true;
+  private currentTransitionId = 0;
   private lastMessagesLength: number = 0;
   private connectionInitTimeouts: ReturnType<typeof setTimeout>[] = [];
   private navigationTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -853,6 +854,7 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
   private async enterSession(code: string | null): Promise<void> {
     if (!isPlatformBrowser(this.platformId)) return;
 
+    const transitionId = ++this.currentTransitionId;
     this.logger.info('enterSession', `Switching to session: ${code ?? 'public'}`);
 
     // ---- Tear down previous session ----
@@ -900,7 +902,10 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
     // ---- Connect to the new session ----
     try {
       await this.connect(this.SessionCode || undefined);
+      // Superseded by a newer transition — leave its state alone.
+      if (transitionId !== this.currentTransitionId) return;
     } catch (err) {
+      if (transitionId !== this.currentTransitionId) return;
       this.logger.error('enterSession', `Failed to connect to new session: ${err}`);
       if (code) {
         this.fallbackToPublic();
@@ -908,9 +913,9 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
         this.toaster.error(this.translate.instant('SERVER_CONNECTION_FAILED'));
       }
     } finally {
-      // Settle the navigation intent so beforeUnload semantics remain correct
-      // for whatever the user does next.
-      this.isNavigatingIntentionally = false;
+      if (transitionId === this.currentTransitionId) {
+        this.isNavigatingIntentionally = false;
+      }
     }
   }
 
@@ -1376,8 +1381,8 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
       this.isOpenEndSessionPopup = false;
       this.cdr.detectChanges();
       this.toaster.success(this.translate.instant('SESSION_ENDED_SUCCESS'));
-      // paramMap subscription detects the code change and calls enterSession(null),
-      // which tears down WebRTC/WS and reconnects to public.
+      // Cross-route nav: Angular tears down this component, ngOnDestroy
+      // handles cleanup, and the new instance at '/' connects to public.
       void this.router.navigateByUrl('/');
     });
   }
@@ -1385,10 +1390,9 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
   /**
    * ==========================================================
    * OPEN CHAT SESSION
-   * Validates the code and triggers SPA navigation to /private/:code.
-   * The actual session-state teardown and reconnection is handled by
-   * the paramMap subscription -> enterSession() flow, so this method
-   * is only responsible for the navigation itself.
+   * Navigates to /private/:code. Cross-route transitions (public -> private)
+   * destroy/recreate the component; only same-route /private/A -> /private/B
+   * goes through the paramMap -> enterSession() path.
    * ==========================================================
    */
   private openChatSession(code: string): void {
@@ -1481,10 +1485,8 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   /**
-   * Called when joining a private session fails (invalid/expired code,
-   * network error, etc). The browser's WebSocket API doesn't expose the
-   * HTTP status of a failed upgrade, so we can't reliably distinguish
-   * "wrong code" from "server unreachable" — the toast covers both.
+   * The browser hides the HTTP status of a failed WS upgrade, so a join
+   * failure could be a bad code or an unreachable server — toast covers both.
    */
   private fallbackToPublic(): void {
     this.clearSessionCode();

--- a/client/web/src/app/features/chat/components/chat-sidebar/chat-sidebar.component.html
+++ b/client/web/src/app/features/chat/components/chat-sidebar/chat-sidebar.component.html
@@ -1064,9 +1064,8 @@
       <!-- Version & Privacy Mobile -->
       <div class="order-2 flex items-center gap-2">
         <a
-          href="/privacy"
+          routerLink="/privacy"
           title="Privacy and Terms"
-          target="_self"
           rel="noopener noreferrer nofollow"
           class="inline-flex items-center gap-2 text-brand dark:text-brandDark"
         >

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1568,15 +1568,14 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -1594,9 +1593,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2031,7 +2031,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "actix",
  "actix-broker",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2024"
 authors = ["Sulaiman AlRomaih"]
 license = "GPL-3"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -22,7 +22,7 @@ actix-rt = "2.11.0"
 uuid = { version = "1.23.1", features = ["v4"] }
 fake = "5.1.0"
 derive_more = { version = "2.1.1", features = ["full"] }
-openssl = { version = "0.10.78" }
+openssl = { version = "0.10.79" }
 serde_json = "1.0.149"
 serde = { version = "1.0.228", features = ["derive"] }
 env_logger = "0.11.10"


### PR DESCRIPTION
This pull request introduces significant improvements to session management, WebRTC connection handling, and user experience during session transitions in the chat application. The main focus is on ensuring that all session-scoped state is properly reset when switching between sessions, that WebRTC connections are robustly cleaned up when members leave, and that navigation between sessions is seamless and reliable. Additionally, several minor enhancements and bug fixes are included.

**Session management and navigation improvements:**

* Added a robust `enterSession` method to `ChatComponent` that centralizes teardown and re-initialization of all session-scoped state when the session code changes, ensuring clean transitions between public and private sessions.
* Modified the route `paramMap` subscription to distinguish between initial bootstrap and in-app navigation, triggering `enterSession` only on actual session changes after the first load. [[1]](diffhunk://#diff-6d91c4056923b00a018a501a02e9cadcfef83f27d3e244b5f211ce12577605d9L251-R267) [[2]](diffhunk://#diff-6d91c4056923b00a018a501a02e9cadcfef83f27d3e244b5f211ce12577605d9R283-L285)
* Updated the "End Session" and "Open Session" flows to rely on SPA navigation and the new session management logic, removing redundant teardown code.

**WebRTC connection cleanup and reliability:**

* Added `closeConnection(targetUser: string)` to the WebRTC service and signaling service, which fully cleans up all state, timeouts, and message queues for a departed peer, preventing resource leaks and stale connections. [[1]](diffhunk://#diff-3f8c86fbd3352ffdafdb66d15ce87b2b02673c1d713bbe744ba859bc6f8247ccR28) [[2]](diffhunk://#diff-09e5035412e85cf44519a1e98bfbfde5efdc496202ad86f89ac1828dc7bad487R174-R181) [[3]](diffhunk://#diff-4f351ca7f71964a52505fd33b07b990de5fd46924e0fd7eb031e818b489866a7R241-R262)
* Enhanced the member list subscription to detect when members leave, automatically closing WebRTC connections and clearing related state for departed users.
* Improved `closeAllConnections` and related cleanup methods to clear additional internal maps and state, ensuring no stale data persists between sessions.

**User experience and UI updates:**

* Improved error handling during connection attempts: if joining a private session fails, the app now gracefully falls back to the public session or displays an error toast.
* Updated localization files (`en.json`, `ar.json`) to add a new error message for session join failures. [[1]](diffhunk://#diff-e9c6636d559832356aea9dbf54a6621a68787c2a30d4fa0437f4c0d06540addeR137) [[2]](diffhunk://#diff-e39bc045c03254493d21e0eeec905994fc1481759d0f4edbf4d9165497cd1daaR137)
* Changed the privacy link in `chat.component.html` to use Angular's `routerLink` for SPA navigation.

**Performance and correctness enhancements:**

* Updated the member list subscription to use `combineLatest` and RxJS operators for efficient updates, and to avoid unnecessary re-renders or connection attempts for the local user.
* Added a `reset` method to `RoomService` to clear all session-scoped state on session transitions.

**Bug fixes:**

* Fixed an issue where WebRTC connection status updates could occur for users no longer in the room, by checking membership before updating status. [[1]](diffhunk://#diff-6d91c4056923b00a018a501a02e9cadcfef83f27d3e244b5f211ce12577605d9R648) [[2]](diffhunk://#diff-6d91c4056923b00a018a501a02e9cadcfef83f27d3e244b5f211ce12577605d9R660)
* Removed a redundant error toast on WebSocket connection failure that could appear during intentional disconnects.

These changes collectively make session transitions more reliable, reduce the risk of stale or leaking resources, and improve the user experience during navigation between chat sessions.