### PR TITLE
Fix: Enhance UI for text inputs and manage pending join spans

### DIFF
--- a/client/web/src/app/core/i18n/localizations/ar.json
+++ b/client/web/src/app/core/i18n/localizations/ar.json
@@ -12,6 +12,10 @@
   "ACCEPT": "قبول",
   "DECLINE": "رفض",
   "CANCEL": "إلغاء",
+  "ATTACH_FILES": "إرفاق ملفات",
+  "NO_PEERS_CONNECTED": "لا يوجد مستخدمون متصلون",
+  "SEND_FILE_TO_USER": "إرسال ملف للمستخدم",
+  "NOT_CONNECTED_TO_USER": "غير متصل بهذا المستخدم",
 
   "_ROOMS_SECTION": "==== ROOMS ====",
   "ROOMS": "الغرف",

--- a/client/web/src/app/core/i18n/localizations/en.json
+++ b/client/web/src/app/core/i18n/localizations/en.json
@@ -12,6 +12,10 @@
   "ACCEPT": "Accept",
   "DECLINE": "Decline",
   "CANCEL": "Cancel",
+  "ATTACH_FILES": "Attach files",
+  "NO_PEERS_CONNECTED": "No connected users",
+  "SEND_FILE_TO_USER": "Send file to user",
+  "NOT_CONNECTED_TO_USER": "Not connected to this user",
 
   "_ROOMS_SECTION": "==== ROOMS ====",
   "ROOMS": "Chat Rooms",

--- a/client/web/src/app/core/i18n/localizations/es.json
+++ b/client/web/src/app/core/i18n/localizations/es.json
@@ -12,6 +12,10 @@
   "ACCEPT": "Aceptar",
   "DECLINE": "Rechazar",
   "CANCEL": "Cancelar",
+  "ATTACH_FILES": "Adjuntar archivos",
+  "NO_PEERS_CONNECTED": "Sin usuarios conectados",
+  "SEND_FILE_TO_USER": "Enviar archivo al usuario",
+  "NOT_CONNECTED_TO_USER": "No conectado a este usuario",
 
   "_ROOMS_SECTION": "==== ROOMS ====",
   "ROOMS": "Salas de chat",

--- a/client/web/src/app/core/i18n/localizations/fr.json
+++ b/client/web/src/app/core/i18n/localizations/fr.json
@@ -12,6 +12,10 @@
   "ACCEPT": "Accepter",
   "DECLINE": "Refuser",
   "CANCEL": "Annuler",
+  "ATTACH_FILES": "Joindre des fichiers",
+  "NO_PEERS_CONNECTED": "Aucun utilisateur connecté",
+  "SEND_FILE_TO_USER": "Envoyer un fichier à l'utilisateur",
+  "NOT_CONNECTED_TO_USER": "Non connecté à cet utilisateur",
 
   "_ROOMS_SECTION": "==== ROOMS ====",
   "ROOMS": "Salons de discussion",

--- a/client/web/src/app/core/i18n/localizations/ru.json
+++ b/client/web/src/app/core/i18n/localizations/ru.json
@@ -12,6 +12,10 @@
   "ACCEPT": "Принять",
   "DECLINE": "Отклонить",
   "CANCEL": "Отмена",
+  "ATTACH_FILES": "Прикрепить файлы",
+  "NO_PEERS_CONNECTED": "Нет подключённых пользователей",
+  "SEND_FILE_TO_USER": "Отправить файл пользователю",
+  "NOT_CONNECTED_TO_USER": "Нет соединения с этим пользователем",
 
   "_ROOMS_SECTION": "==== ROOMS ====",
   "ROOMS": "Комнаты чата",

--- a/client/web/src/app/core/i18n/localizations/zh-CN.json
+++ b/client/web/src/app/core/i18n/localizations/zh-CN.json
@@ -12,6 +12,10 @@
   "ACCEPT": "接受",
   "DECLINE": "拒绝",
   "CANCEL": "取消",
+  "ATTACH_FILES": "附加文件",
+  "NO_PEERS_CONNECTED": "没有已连接的用户",
+  "SEND_FILE_TO_USER": "发送文件给用户",
+  "NOT_CONNECTED_TO_USER": "未连接到此用户",
 
   "_ROOMS_SECTION": "==== ROOMS ====",
   "ROOMS": "聊天室",

--- a/client/web/src/app/core/services/room-management/room.service.ts
+++ b/client/web/src/app/core/services/room-management/room.service.ts
@@ -38,7 +38,10 @@ export class RoomService implements IRoomService {
     }
     if (this.pendingJoinSpan) {
       this.pendingJoinSpan.setAttribute('outcome', outcome);
-      this.pendingJoinSpan.setStatus({ code: statusCode, message: outcome });
+      this.pendingJoinSpan.setStatus({
+        code: statusCode,
+        message: statusCode === 1 ? 'ok' : outcome,
+      });
       this.pendingJoinSpan.end();
       this.pendingJoinSpan = null;
     }

--- a/client/web/src/app/core/services/room-management/room.service.ts
+++ b/client/web/src/app/core/services/room-management/room.service.ts
@@ -25,6 +25,24 @@ export class RoomService implements IRoomService {
   public currentRoom = 'main';
 
   private pendingJoinSpan: Sentry.Span | null = null;
+  private pendingJoinTimeout: ReturnType<typeof setTimeout> | null = null;
+  private static readonly JOIN_SPAN_TIMEOUT_MS = 10_000;
+
+  private clearPendingJoinSpan(
+    outcome: 'cancelled' | 'superseded' | 'timeout' | 'joined',
+    statusCode: 1 | 2
+  ): void {
+    if (this.pendingJoinTimeout) {
+      clearTimeout(this.pendingJoinTimeout);
+      this.pendingJoinTimeout = null;
+    }
+    if (this.pendingJoinSpan) {
+      this.pendingJoinSpan.setAttribute('outcome', outcome);
+      this.pendingJoinSpan.setStatus({ code: statusCode, message: outcome });
+      this.pendingJoinSpan.end();
+      this.pendingJoinSpan = null;
+    }
+  }
 
   /**
    * ==========================================================
@@ -54,11 +72,7 @@ export class RoomService implements IRoomService {
    * replay the previous session's members/rooms into the new view.
    */
   public reset(): void {
-    if (this.pendingJoinSpan) {
-      this.pendingJoinSpan.setStatus({ code: 2, message: 'cancelled' });
-      this.pendingJoinSpan.end();
-      this.pendingJoinSpan = null;
-    }
+    this.clearPendingJoinSpan('cancelled', 2);
     this.ngZone.run(() => {
       this.rooms$.next([]);
       this.members$.next([]);
@@ -82,11 +96,7 @@ export class RoomService implements IRoomService {
       return;
     }
 
-    if (this.pendingJoinSpan) {
-      this.pendingJoinSpan.setStatus({ code: 2, message: 'superseded' });
-      this.pendingJoinSpan.end();
-      this.pendingJoinSpan = null;
-    }
+    this.clearPendingJoinSpan('superseded', 2);
 
     startNewTrace(() => {
       this.pendingJoinSpan = Sentry.startInactiveSpan({
@@ -94,6 +104,10 @@ export class RoomService implements IRoomService {
         op: 'session.join',
       });
     });
+    this.pendingJoinTimeout = setTimeout(() => {
+      this.logger.warn('joinRoom', `Join timed out for room: ${sanitizedRoom}`);
+      this.clearPendingJoinSpan('timeout', 2);
+    }, RoomService.JOIN_SPAN_TIMEOUT_MS);
     this.wsService.send(`[UserCommand] /join ${sanitizedRoom}`);
   }
 
@@ -132,12 +146,7 @@ export class RoomService implements IRoomService {
           this.currentRoom = matchJoin[2];
         });
 
-        if (this.pendingJoinSpan) {
-          this.pendingJoinSpan.setAttribute('outcome', 'joined');
-          this.pendingJoinSpan.setStatus({ code: 1, message: 'ok' });
-          this.pendingJoinSpan.end();
-          this.pendingJoinSpan = null;
-        }
+        this.clearPendingJoinSpan('joined', 1);
       } else {
         this.logger.warn('handleSystemMessage', `No room to join found in message: ${message}`);
       }

--- a/client/web/src/app/features/chat/components/chat-input/chat-input.component.html
+++ b/client/web/src/app/features/chat/components/chat-input/chat-input.component.html
@@ -62,9 +62,11 @@
             type="button"
             [disabled]="hasNoConnectedPeers"
             (click)="fileInput.click()"
-            class="p-0 border-0 bg-transparent disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
-            [attr.aria-label]="'Attach Files'"
-            title="Attach Files"
+            class="p-0 border-0 bg-transparent disabled:opacity-30 disabled:grayscale disabled:cursor-not-allowed cursor-pointer"
+            [attr.aria-label]="
+              (hasNoConnectedPeers ? 'NO_PEERS_CONNECTED' : 'ATTACH_FILES') | translate
+            "
+            [title]="(hasNoConnectedPeers ? 'NO_PEERS_CONNECTED' : 'ATTACH_FILES') | translate"
           >
             <img
               [src]="'/icons/link.svg'"
@@ -77,10 +79,9 @@
           </button>
           <button
             type="button"
-            [disabled]="hasNoConnectedPeers"
             (mouseenter)="openEmojiPicker()"
             (mouseleave)="handleEmojiIconMouseLeave()"
-            class="p-0 border-0 bg-transparent disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+            class="p-0 border-0 bg-transparent cursor-pointer"
             [attr.aria-label]="'Open emoji picker'"
             title="Open emoji picker"
           >

--- a/client/web/src/app/features/chat/components/chat-sidebar/chat-sidebar.component.html
+++ b/client/web/src/app/features/chat/components/chat-sidebar/chat-sidebar.component.html
@@ -226,9 +226,15 @@
                 <button
                   type="button"
                   [disabled]="!isConnectedToMember(member)"
-                  class="rounded-md p-1 text-textMuted hover:text-brand dark:text-textVeryMuted dark:hover:text-brandDark disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:text-textMuted dark:disabled:hover:text-textVeryMuted"
-                  aria-label="Send file to user"
-                  title="Send file to user"
+                  class="rounded-md p-1 text-textMuted hover:text-brand dark:text-textVeryMuted dark:hover:text-brandDark disabled:opacity-30 disabled:grayscale disabled:cursor-not-allowed disabled:hover:text-textMuted dark:disabled:hover:text-textVeryMuted"
+                  [attr.aria-label]="
+                    (!isConnectedToMember(member) ? 'NOT_CONNECTED_TO_USER' : 'SEND_FILE_TO_USER')
+                      | translate
+                  "
+                  [title]="
+                    (!isConnectedToMember(member) ? 'NOT_CONNECTED_TO_USER' : 'SEND_FILE_TO_USER')
+                      | translate
+                  "
                   (click)="filePickerRequested.emit(member)"
                 >
                   <img
@@ -404,9 +410,7 @@
                   <span
                     class="text-xs font-expoArabicMedium text-textMuted dark:text-textVeryMuted"
                   >
-                    {{
-                      progressLabel(download.progress)
-                    }}%
+                    {{ progressLabel(download.progress) }}%
                   </span>
                   <button
                     (click)="
@@ -434,9 +438,7 @@
               >
                 <div
                   class="h-full rounded-full bg-brand dark:bg-brandDark transition-[width] duration-75 ease-linear"
-                  [style.width]="
-                    getProgressBarWidth(download.progress)
-                  "
+                  [style.width]="getProgressBarWidth(download.progress)"
                   [style.max-width]="'100%'"
                 ></div>
               </div>
@@ -738,9 +740,15 @@
                   <button
                     type="button"
                     [disabled]="!isConnectedToMember(member)"
-                    class="rounded-md p-1 text-textMuted hover:text-brand dark:text-textVeryMuted dark:hover:text-brandDark disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:text-textMuted dark:disabled:hover:text-textVeryMuted"
-                    aria-label="Send file to user"
-                    title="Send file to user"
+                    class="rounded-md p-1 text-textMuted hover:text-brand dark:text-textVeryMuted dark:hover:text-brandDark disabled:opacity-30 disabled:grayscale disabled:cursor-not-allowed disabled:hover:text-textMuted dark:disabled:hover:text-textVeryMuted"
+                    [attr.aria-label]="
+                      (!isConnectedToMember(member) ? 'NOT_CONNECTED_TO_USER' : 'SEND_FILE_TO_USER')
+                        | translate
+                    "
+                    [title]="
+                      (!isConnectedToMember(member) ? 'NOT_CONNECTED_TO_USER' : 'SEND_FILE_TO_USER')
+                        | translate
+                    "
                     (click)="filePickerRequested.emit(member)"
                   >
                     <img
@@ -916,9 +924,7 @@
                     <span
                       class="text-xs font-expoArabicMedium text-textMuted dark:text-textVeryMuted"
                     >
-                      {{
-                        progressLabel(download.progress)
-                      }}%
+                      {{ progressLabel(download.progress) }}%
                     </span>
                     <button
                       (click)="
@@ -946,9 +952,7 @@
                 >
                   <div
                     class="h-full rounded-full bg-brand dark:bg-brandDark transition-[width] duration-75 ease-linear"
-                    [style.width]="
-                      getProgressBarWidth(download.progress)
-                    "
+                    [style.width]="getProgressBarWidth(download.progress)"
                     [style.max-width]="'100%'"
                   ></div>
                 </div>


### PR DESCRIPTION
This pull request introduces several improvements to the chat application's accessibility, internationalization, and room management reliability. The main changes include adding new i18n strings for file sharing actions in multiple languages, updating UI components to use these translations and improve accessibility, and enhancing the room join tracing logic for better timeout handling and code clarity.

**Internationalization (i18n) enhancements:**
* Added new translation strings for file sharing actions (e.g., "Attach files", "Send file to user", "Not connected to this user", "No connected users") in English, Arabic, French, Spanish, Russian, and Chinese (`en.json`, `ar.json`, `fr.json`, `es.json`, `ru.json`, `zh-CN.json`). [[1]](diffhunk://#diff-e9c6636d559832356aea9dbf54a6621a68787c2a30d4fa0437f4c0d06540addeR15-R18) [[2]](diffhunk://#diff-e39bc045c03254493d21e0eeec905994fc1481759d0f4edbf4d9165497cd1daaR15-R18) [[3]](diffhunk://#diff-77292263f296a5c5f87ab852692d0b637f3310ba1faa73e8b921a41f4de61e77R15-R18) [[4]](diffhunk://#diff-ca41f3dd4c255a99cb2a33315c1ec7cebe77d20fb54e95bd54f06975bd36b07cR15-R18) [[5]](diffhunk://#diff-1a0421f0c4bf8d9c53cd3029205457ba5da4096edfceb41c8cf730f05d2d5a43R15-R18) [[6]](diffhunk://#diff-dd6a1c41ba0e9673df4ea27484d522acb331af8eaca375b6c1cd9e7265eaffd9R15-R18)

**Accessibility and UI improvements:**
* Updated file sharing buttons in `chat-input` and `chat-sidebar` components to use the new i18n strings for `aria-label` and `title`, improving accessibility and user feedback when actions are unavailable. Also adjusted disabled button styles for better visual cues. [[1]](diffhunk://#diff-5ce037a3de6edda214c2f9dae04d9312d963a49cae5643f373011b9e716610f2L65-R69) [[2]](diffhunk://#diff-5ce037a3de6edda214c2f9dae04d9312d963a49cae5643f373011b9e716610f2L80-R84) [[3]](diffhunk://#diff-26742d07e0a25a1adbbd49263fef0febcd9162b2aa3d1d823d56c0212f5330b1L229-R237) [[4]](diffhunk://#diff-26742d07e0a25a1adbbd49263fef0febcd9162b2aa3d1d823d56c0212f5330b1L741-R751)
* Minor template cleanups for progress bar and label rendering in `chat-sidebar` for improved readability and maintainability. [[1]](diffhunk://#diff-26742d07e0a25a1adbbd49263fef0febcd9162b2aa3d1d823d56c0212f5330b1L407-R413) [[2]](diffhunk://#diff-26742d07e0a25a1adbbd49263fef0febcd9162b2aa3d1d823d56c0212f5330b1L437-R441) [[3]](diffhunk://#diff-26742d07e0a25a1adbbd49263fef0febcd9162b2aa3d1d823d56c0212f5330b1L919-R927) [[4]](diffhunk://#diff-26742d07e0a25a1adbbd49263fef0febcd9162b2aa3d1d823d56c0212f5330b1L949-R955)

**Room management reliability:**
* Refactored the room join tracing logic in `room.service.ts` by introducing a `clearPendingJoinSpan` helper, adding a timeout for join operations, and ensuring that span outcomes are consistently tracked and cleared. This makes join operations more robust and easier to debug. [[1]](diffhunk://#diff-e35b0a411136e2bf28db4eaa5e9941cb4077d17721f40baa7b5f3b1599656907R28-R45) [[2]](diffhunk://#diff-e35b0a411136e2bf28db4eaa5e9941cb4077d17721f40baa7b5f3b1599656907L57-R75) [[3]](diffhunk://#diff-e35b0a411136e2bf28db4eaa5e9941cb4077d17721f40baa7b5f3b1599656907L85-R110) [[4]](diffhunk://#diff-e35b0a411136e2bf28db4eaa5e9941cb4077d17721f40baa7b5f3b1599656907L135-R149)