### PR TITLE
Chore: Bump application and server versions for future enhancements

### DIFF
--- a/client/web/package-lock.json
+++ b/client/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "dependencies": {
         "@angular/cdk": "^21.2.9",
         "@angular/common": "^21.2.11",

--- a/client/web/package.json
+++ b/client/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2812,7 +2812,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "actix",
  "actix-broker",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.9.2"
+version = "0.10.0"
 edition = "2024"
 authors = ["Sulaiman AlRomaih"]
 license = "GPL-3"


### PR DESCRIPTION
This pull request updates the version numbers for both the frontend (`web`) and backend (`server`) components of the project to reflect new releases. No functional code changes are included.

Version updates:

* Bumped the `web` frontend version from `0.17.0` to `0.18.0` in both `package.json` and `package-lock.json` to prepare for a new release. [[1]](diffhunk://#diff-f669e832b021e795b7206497424085a6c20db1401e0d86b41ca88e7bd5dd73e4L3-R3) [[2]](diffhunk://#diff-9755dd05075a9dc0626315acf42fc5b61b030985b8580ef0d626d2a8339e2ef8L3-R9)
* Updated the `server` backend version from `0.9.2` to `0.10.0` in `Cargo.toml` for the upcoming release.