### PR TITLE
Fix: Enhance room name validation and sanitization, update versions

### DIFF
--- a/client/web/package-lock.json
+++ b/client/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "dependencies": {
         "@angular/cdk": "^21.2.9",
         "@angular/common": "^21.2.11",

--- a/client/web/package.json
+++ b/client/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/client/web/src/app/core/services/room-management/room.service.ts
+++ b/client/web/src/app/core/services/room-management/room.service.ts
@@ -85,7 +85,7 @@ export class RoomService implements IRoomService {
 
   public joinRoom(room: string): void {
     const sanitizedRoom = room
-      .replace(/[^a-zA-Z0-9\-_ ]/g, '')
+      .replace(/[^\p{L}\p{N}\-_ ]/gu, '')
       .trim()
       .substring(0, 64);
 

--- a/client/web/src/main.ts
+++ b/client/web/src/main.ts
@@ -60,6 +60,13 @@ if (typeof window !== 'undefined' && environment.sentry?.enabled && environment.
             !(span.op === 'http.client' && span.description?.includes('.js.map'))
         );
       }
+      if (event.contexts?.['device']) {
+        delete event.contexts['device']['timezone'];
+        delete event.contexts['device']['locale'];
+      }
+      if (event.contexts?.['culture']) {
+        delete event.contexts['culture'];
+      }
       return event;
     },
     beforeSend(event) {

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2812,7 +2812,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "actix",
  "actix-broker",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 authors = ["Sulaiman AlRomaih"]
 license = "GPL-3"

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -11,10 +11,10 @@ impl WsChatServer {
     pub fn is_valid_room_name(name: &str) -> bool {
         let trimmed = name.trim();
         !trimmed.is_empty()
-            && trimmed.len() <= 64
+            && trimmed.chars().count() <= 64
             && trimmed
                 .chars()
-                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == ' ')
+                .all(|c| c.is_alphanumeric() || c == '-' || c == '_' || c == ' ')
     }
 
     pub fn take_room(&mut self, session_id: &str, room_name: &str) -> Option<Room> {

--- a/server/src/session.rs
+++ b/server/src/session.rs
@@ -122,7 +122,7 @@ impl WsChatSession {
                     let room_name = room_name.trim();
                     if !WsChatServer::is_valid_room_name(room_name) {
                         ctx.text(format!(
-                            "{WS_PREFIX_SYSTEM_ERROR} Invalid room name. Must be 1-64 characters, alphanumeric, hyphens, underscores, or spaces only."
+                            "{WS_PREFIX_SYSTEM_ERROR} Invalid room name. Must be 1-64 letters, digits, hyphens, underscores, or spaces only."
                         ));
                     } else {
                         log::debug!(target: "Websocket", "Received join command for room '{room_name}'");


### PR DESCRIPTION
This pull request introduces a minor version bump for both the web client and server, and updates the logic for validating and sanitizing room names to support full Unicode letters and digits (not just ASCII). It also includes improvements to Sentry error reporting by removing sensitive device and culture information from the error context.

**Room name validation and sanitization improvements:**

* Updated the client-side `joinRoom` method in `room.service.ts` to allow all Unicode letters and digits (using `\p{L}` and `\p{N}`), instead of only ASCII alphanumerics, when sanitizing room names.
* Updated the server-side `is_valid_room_name` method in `server.rs` to allow all Unicode letters and digits, and to count characters using `.chars().count()` for proper Unicode support.
* Updated the error message in `session.rs` to clarify that room names can include letters, digits, hyphens, underscores, or spaces (not just ASCII alphanumerics).

**Sentry error reporting:**

* Modified `main.ts` to remove `timezone` and `locale` from the device context, and to remove the entire culture context from Sentry error events, reducing the risk of leaking sensitive or locale-specific information.

**Version bumps:**

* Bumped the web client version to `0.18.1` in both `package.json` and `package-lock.json`. [[1]](diffhunk://#diff-f669e832b021e795b7206497424085a6c20db1401e0d86b41ca88e7bd5dd73e4L3-R3) [[2]](diffhunk://#diff-9755dd05075a9dc0626315acf42fc5b61b030985b8580ef0d626d2a8339e2ef8L3-R9)
* Bumped the server version to `0.10.1` in `Cargo.toml`.