### PR TITLE
Fix/ios/improve sheets

### DIFF
--- a/client/ios/PastePoint/Views/Settings/SettingsCreateRoom.swift
+++ b/client/ios/PastePoint/Views/Settings/SettingsCreateRoom.swift
@@ -6,11 +6,11 @@
 import Logging
 import SwiftUI
 
-struct SettingsJoinRoom: View {
+struct SettingsCreateRoom: View {
   @Environment(\.dismiss) private var dismiss
   @EnvironmentObject private var services: AppServices
 
-  private let logger = Logger(label: "SettingsJoinRoom")
+  private let logger = Logger(label: "SettingsCreateRoom")
 
   var onRoomCreate: (() -> Void)?
 
@@ -101,11 +101,12 @@ struct SettingsJoinRoom: View {
       .padding(24)
       .frame(maxWidth: .infinity)
       .fixedSize(horizontal: false, vertical: true)
-      .background(
-        GeometryReader { proxy in
-          Color.clear.task { sheetHeight = proxy.size.height + 56 }
-        },
-      )
+      .onGeometryChange(for: CGFloat.self) { proxy in
+          proxy.size.height
+      } action: { height in
+          guard height > 0 else { return }
+          sheetHeight = height + 56
+      }
       .navigationTitle("Create a Room")
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {
@@ -142,7 +143,7 @@ struct SettingsJoinRoom: View {
 
 #if DEBUG
 #Preview {
-  SettingsJoinRoom()
+  SettingsCreateRoom()
     .environmentObject(AppServices.preview)
 }
 #endif

--- a/client/ios/PastePoint/Views/Settings/SettingsCreateRoom.swift
+++ b/client/ios/PastePoint/Views/Settings/SettingsCreateRoom.swift
@@ -102,10 +102,10 @@ struct SettingsCreateRoom: View {
       .frame(maxWidth: .infinity)
       .fixedSize(horizontal: false, vertical: true)
       .onGeometryChange(for: CGFloat.self) { proxy in
-          proxy.size.height
+        proxy.size.height
       } action: { height in
-          guard height > 0 else { return }
-          sheetHeight = height + 56
+        guard height > 0 else { return }
+        sheetHeight = height + 56
       }
       .navigationTitle("Create a Room")
       .navigationBarTitleDisplayMode(.inline)

--- a/client/ios/PastePoint/Views/Settings/SettingsJoinPrivate.swift
+++ b/client/ios/PastePoint/Views/Settings/SettingsJoinPrivate.swift
@@ -112,10 +112,10 @@ struct SettingsJoinPrivate: View {
       .frame(maxWidth: .infinity)
       .fixedSize(horizontal: false, vertical: true)
       .onGeometryChange(for: CGFloat.self) { proxy in
-          proxy.size.height
+        proxy.size.height
       } action: { height in
-          guard height > 0 else { return }
-          sheetHeight = height + 56
+        guard height > 0 else { return }
+        sheetHeight = height + 56
       }
       .navigationTitle("Join a Private Session")
       .navigationBarTitleDisplayMode(.inline)

--- a/client/ios/PastePoint/Views/Settings/SettingsJoinPrivate.swift
+++ b/client/ios/PastePoint/Views/Settings/SettingsJoinPrivate.swift
@@ -111,11 +111,12 @@ struct SettingsJoinPrivate: View {
       .padding(24)
       .frame(maxWidth: .infinity)
       .fixedSize(horizontal: false, vertical: true)
-      .background(
-        GeometryReader { proxy in
-          Color.clear.task { sheetHeight = proxy.size.height + 56 }
-        },
-      )
+      .onGeometryChange(for: CGFloat.self) { proxy in
+          proxy.size.height
+      } action: { height in
+          guard height > 0 else { return }
+          sheetHeight = height + 56
+      }
       .navigationTitle("Join a Private Session")
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {

--- a/client/ios/PastePoint/Views/Settings/SettingsLeaveSession.swift
+++ b/client/ios/PastePoint/Views/Settings/SettingsLeaveSession.swift
@@ -69,10 +69,10 @@ struct SettingsLeaveSession: View {
       .frame(maxWidth: .infinity)
       .fixedSize(horizontal: false, vertical: true)
       .onGeometryChange(for: CGFloat.self) { proxy in
-          proxy.size.height
+        proxy.size.height
       } action: { height in
-          guard height > 0 else { return }
-          sheetHeight = height + 56
+        guard height > 0 else { return }
+        sheetHeight = height + 56
       }
       .navigationTitle("Leave Session")
       .navigationBarTitleDisplayMode(.inline)

--- a/client/ios/PastePoint/Views/Settings/SettingsLeaveSession.swift
+++ b/client/ios/PastePoint/Views/Settings/SettingsLeaveSession.swift
@@ -68,11 +68,12 @@ struct SettingsLeaveSession: View {
       .padding(24)
       .frame(maxWidth: .infinity)
       .fixedSize(horizontal: false, vertical: true)
-      .background(
-        GeometryReader { proxy in
-          Color.clear.task { sheetHeight = proxy.size.height + 56 }
-        },
-      )
+      .onGeometryChange(for: CGFloat.self) { proxy in
+          proxy.size.height
+      } action: { height in
+          guard height > 0 else { return }
+          sheetHeight = height + 56
+      }
       .navigationTitle("Leave Session")
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {

--- a/client/ios/PastePoint/Views/Settings/SettingsQRCode.swift
+++ b/client/ios/PastePoint/Views/Settings/SettingsQRCode.swift
@@ -72,10 +72,10 @@ struct SettingsQRCode: View {
       .fixedSize(horizontal: false, vertical: true)
       .onAppear { logger.info("QR code sheet presented for session: \(services.wsService.currentSessionCode ?? "none")") }
       .onGeometryChange(for: CGFloat.self) { proxy in
-          proxy.size.height
+        proxy.size.height
       } action: { height in
-          guard height > 0 else { return }
-          sheetHeight = height + 56
+        guard height > 0 else { return }
+        sheetHeight = height + 56
       }
       .navigationTitle("QR Code")
       .navigationBarTitleDisplayMode(.inline)

--- a/client/ios/PastePoint/Views/Settings/SettingsQRCode.swift
+++ b/client/ios/PastePoint/Views/Settings/SettingsQRCode.swift
@@ -71,11 +71,12 @@ struct SettingsQRCode: View {
       .frame(maxWidth: .infinity)
       .fixedSize(horizontal: false, vertical: true)
       .onAppear { logger.info("QR code sheet presented for session: \(services.wsService.currentSessionCode ?? "none")") }
-      .background(
-        GeometryReader { proxy in
-          Color.clear.task { sheetHeight = proxy.size.height + 56 }
-        },
-      )
+      .onGeometryChange(for: CGFloat.self) { proxy in
+          proxy.size.height
+      } action: { height in
+          guard height > 0 else { return }
+          sheetHeight = height + 56
+      }
       .navigationTitle("QR Code")
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {

--- a/client/ios/PastePoint/Views/Settings/SettingsScanQRCode.swift
+++ b/client/ios/PastePoint/Views/Settings/SettingsScanQRCode.swift
@@ -13,6 +13,7 @@ import VisionKit
 
 private struct QRCodeScannerRepresentable: UIViewControllerRepresentable {
   var onCodeScanned: (String) -> Void
+  var onInvalidCodeScanned: () -> Void
 
   func makeUIViewController(context: Context) -> DataScannerViewController {
     let scanner = DataScannerViewController(
@@ -29,35 +30,51 @@ private struct QRCodeScannerRepresentable: UIViewControllerRepresentable {
 
   func updateUIViewController(_: DataScannerViewController, context _: Context) {}
 
-  func makeCoordinator() -> Coordinator { Coordinator(onCodeScanned: onCodeScanned) }
+  func makeCoordinator() -> Coordinator {
+    Coordinator(
+      onCodeScanned: onCodeScanned,
+      onInvalidCodeScanned: onInvalidCodeScanned,
+    )
+  }
 
   final class Coordinator: NSObject, DataScannerViewControllerDelegate {
     var onCodeScanned: (String) -> Void
+    var onInvalidCodeScanned: () -> Void
     private var hasScanned = false
+    private var lastInvalidPayload: String?
 
-    init(onCodeScanned: @escaping (String) -> Void) {
+    init(
+      onCodeScanned: @escaping (String) -> Void,
+      onInvalidCodeScanned: @escaping () -> Void,
+    ) {
       self.onCodeScanned = onCodeScanned
+      self.onInvalidCodeScanned = onInvalidCodeScanned
     }
 
-    // Parses https://<host>/private/<code> and returns the code.
-    // Falls back to the raw payload if the URL doesn't match the expected format.
-    static func extractSessionCode(from payload: String) -> String {
+    // Parses PastePoint private-session URLs and returns the embedded code.
+    static func extractSessionCode(from payload: String) -> String? {
+      let trimmedPayload = payload.trimmingCharacters(in: .whitespacesAndNewlines)
+
       guard
-        let url = URL(string: payload),
-        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
-      else { return payload }
+        let url = URL(string: trimmedPayload),
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+        components.scheme == "https",
+        components.host == AppEnvironment.webUrl
+      else { return nil }
 
       let pathComponents = components.path
         .split(separator: "/")
         .map(String.init)
 
-      guard
-        pathComponents.count == 2,
-        pathComponents[0] == "private",
-        !pathComponents[1].isEmpty
-      else { return payload }
+      guard pathComponents.count == 2 else { return nil }
+      
+      guard pathComponents[0] == "private",
+            let sessionCode = pathComponents[1] as String?,
+            SessionService.isValidSessionCode(sessionCode) else {
+        return nil
+      }
 
-      return pathComponents[1]
+      return sessionCode
     }
 
     func dataScanner(
@@ -70,8 +87,15 @@ private struct QRCodeScannerRepresentable: UIViewControllerRepresentable {
         case .barcode(let barcode) = addedItems.first,
         let payload = barcode.payloadStringValue
       else { return }
+
+      guard let code = Self.extractSessionCode(from: payload) else {
+        guard payload != lastInvalidPayload else { return }
+        lastInvalidPayload = payload
+        DispatchQueue.main.async { self.onInvalidCodeScanned() }
+        return
+      }
+
       hasScanned = true
-      let code = Self.extractSessionCode(from: payload)
       DispatchQueue.main.async { self.onCodeScanned(code) }
     }
   }
@@ -172,6 +196,7 @@ struct SettingsScanQRCode: View {
   private let cutoutSize: CGFloat = 240
   @State private var bracketScale: CGFloat = 1.0
   @State private var cameraPermission: AVAuthorizationStatus = CameraPermission.status
+  @State private var toasts: [ToastItem] = []
 
   var onCodeScanned: (String) -> Void
 
@@ -219,6 +244,10 @@ struct SettingsScanQRCode: View {
         logger.info("QR code scanned successfully")
         onCodeScanned(code)
         dismiss()
+      } onInvalidCodeScanned: {
+        UINotificationFeedbackGenerator().notificationOccurred(.error)
+        logger.warning("Invalid QR code scanned")
+        toasts.append(.error("Invalid PastePoint QR code"))
       }
       .ignoresSafeArea()
 
@@ -285,6 +314,7 @@ struct SettingsScanQRCode: View {
       }
     }
     .ignoresSafeArea()
+    .appToast(items: $toasts)
   }
 }
 

--- a/client/ios/PastePoint/Views/Settings/SettingsScanQRCode.swift
+++ b/client/ios/PastePoint/Views/Settings/SettingsScanQRCode.swift
@@ -67,10 +67,12 @@ private struct QRCodeScannerRepresentable: UIViewControllerRepresentable {
         .map(String.init)
 
       guard pathComponents.count == 2 else { return nil }
-      
-      guard pathComponents[0] == "private",
-            let sessionCode = pathComponents[1] as String?,
-            SessionService.isValidSessionCode(sessionCode) else {
+
+      guard
+        pathComponents[0] == "private",
+        let sessionCode = pathComponents[1] as String?,
+        SessionService.isValidSessionCode(sessionCode)
+      else {
         return nil
       }
 

--- a/client/ios/PastePoint/Views/Settings/SettingsView.swift
+++ b/client/ios/PastePoint/Views/Settings/SettingsView.swift
@@ -146,7 +146,7 @@ struct SettingsView: View {
       }
     }
     .sheet(isPresented: $isJoinRoomSheetPresented) {
-      SettingsJoinRoom {
+      SettingsCreateRoom {
         logger.info("User created a room")
         toasts.append(.success("Room created successfully!"))
       }

--- a/client/ios/PastePoint/Views/Settings/SettingsView.swift
+++ b/client/ios/PastePoint/Views/Settings/SettingsView.swift
@@ -28,6 +28,7 @@ struct SettingsView: View {
 
   var body: some View {
     VStack(spacing: 0) {
+
       // MARK: - Header
 
       HStack(alignment: .center, spacing: 0) {
@@ -45,6 +46,7 @@ struct SettingsView: View {
 
       ScrollView {
         VStack(spacing: 0) {
+
           // MARK: - Create New Room Button
 
           Button {


### PR DESCRIPTION
This pull request refactors several settings-related views in the iOS client for PastePoint, focusing on improving code clarity, user feedback, and session code validation. The main changes include renaming and updating the "Join Room" view to "Create Room," enhancing geometry handling in multiple views, and strengthening QR code scanning logic with better validation and user feedback.

**View Renaming and Refactoring:**
- Renamed `SettingsJoinRoom` to `SettingsCreateRoom`, updating all references, logger labels, and preview code accordingly for clarity and consistency. (`client/ios/PastePoint/Views/Settings/SettingsCreateRoom.swift`) [[1]](diffhunk://#diff-bf802ba36983ab742db6a6fce0de3d33f4ed7c1ab967ee64b80f6446d164ba50L9-R13) [[2]](diffhunk://#diff-bf802ba36983ab742db6a6fce0de3d33f4ed7c1ab967ee64b80f6446d164ba50L145-R146) [[3]](diffhunk://#diff-c2542c575c13f36923475761b5d48f939358a67aa79740e1959f7e5a1c3ffb83L149-R149)

**UI Geometry Handling Improvements:**
- Replaced `.background(GeometryReader...)` with a custom `.onGeometryChange` modifier in several views (`SettingsCreateRoom`, `SettingsJoinPrivate`, `SettingsLeaveSession`, `SettingsQRCode`) for more readable and reusable sheet height calculation. [[1]](diffhunk://#diff-bf802ba36983ab742db6a6fce0de3d33f4ed7c1ab967ee64b80f6446d164ba50L104-R109) [[2]](diffhunk://#diff-811d918d6668980e52522fe4a8fcb16801f240572932fec4e04bed5556af4ad9L114-R119) [[3]](diffhunk://#diff-82854d67a0178e4d0fa328ded0cf7e88fa3969afc21f160be5050fd1b8f05902L71-R76) [[4]](diffhunk://#diff-9c43e800e4fd8a5fbcd7094c2759ff45860dd1e468e1c60b88614a5ddb258e01L74-R79)

**QR Code Scanning Enhancements:**
- Improved QR code session code extraction: Now strictly validates PastePoint private-session URLs, checks host and path, and verifies session code format. Invalid codes are rejected instead of falling back to the raw payload. (`SettingsScanQRCode.swift`)
- Added an `onInvalidCodeScanned` callback to the QR code scanner, which triggers error haptics, logs a warning, and displays a user-facing toast notification when an invalid QR code is scanned. (`SettingsScanQRCode.swift`) [[1]](diffhunk://#diff-d56d82a67ab2ac06a8e76e524711823b225d03f29714eb27f4840184e87618bfR16) [[2]](diffhunk://#diff-d56d82a67ab2ac06a8e76e524711823b225d03f29714eb27f4840184e87618bfR90-L74) [[3]](diffhunk://#diff-d56d82a67ab2ac06a8e76e524711823b225d03f29714eb27f4840184e87618bfR247-R250) [[4]](diffhunk://#diff-d56d82a67ab2ac06a8e76e524711823b225d03f29714eb27f4840184e87618bfR317)
- Prevents duplicate error notifications for the same invalid payload by tracking the last invalid scan. (`SettingsScanQRCode.swift`)

These changes collectively improve user experience, code maintainability, and the robustness of session joining via QR codes.