### PR TITLE
Feat: Add WebRTC support notices and handle chunk load errors in Web

### DIFF
--- a/client/web/src/app/app.config.ts
+++ b/client/web/src/app/app.config.ts
@@ -24,6 +24,34 @@ import { DatePipe } from '@angular/common';
 import { provideHotToastConfig } from '@ngxpert/hot-toast';
 import { SentryLoggerMonitor } from './core/services/monitoring/sentry-logger-monitor';
 
+// A new deploy renames chunks, so old tabs fail to load them. Reload once to
+// fetch the fresh bundle; if this load was already a reload, report instead.
+function createAppErrorHandler(): ErrorHandler {
+  const sentryHandler = Sentry.createErrorHandler({ showDialog: false });
+
+  const wasReloaded = (): boolean => {
+    const [navigation] = performance.getEntriesByType('navigation');
+    return (navigation as PerformanceNavigationTiming | undefined)?.type === 'reload';
+  };
+
+  return {
+    handleError(error: unknown): void {
+      const message = error instanceof Error ? error.message : String(error);
+      const isChunkLoadError =
+        /Failed to fetch dynamically imported module|Loading chunk \d+ failed|ChunkLoadError/i.test(
+          message
+        );
+
+      if (isChunkLoadError && typeof window !== 'undefined' && !wasReloaded()) {
+        window.location.reload();
+        return;
+      }
+
+      sentryHandler.handleError(error);
+    },
+  };
+}
+
 // Theme initialization function
 export function initializeTheme(themeService: ThemeService): () => Promise<void> {
   return () => {
@@ -48,7 +76,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     {
       provide: ErrorHandler,
-      useValue: Sentry.createErrorHandler({ showDialog: false }),
+      useValue: createAppErrorHandler(),
     },
     { provide: Sentry.TraceService, deps: [Router] },
     provideAppInitializer(() => void inject(Sentry.TraceService)),

--- a/client/web/src/app/core/i18n/localizations/ar.json
+++ b/client/web/src/app/core/i18n/localizations/ar.json
@@ -149,6 +149,7 @@
   "RECONNECTING_TO_USER": "جارٍ إعادة الاتصال بالمستخدم {{userName}}...",
   "CANNOT_CONNECT_TO_USER": "تعذّر الاتصال بالمستخدم {{userName}}. قد لا يكون متصلاً.",
   "CONNECTION_CLOSED_WITH_USER": "تم إغلاق الاتصال مع المستخدم {{userName}}.",
+  "WEBRTC_NOT_SUPPORTED": "متصفحك لا يدعم تقنية WebRTC. يرجى تجربة متصفح آخر (Chrome أو Firefox أو Safari أو Edge).",
   "SERVER_CONNECTION_FAILED": "فشل الاتصال بالخادم. يرجى التحقق من اتصال الإنترنت.",
   "SESSION_JOIN_FAILED": "تعذر الانضمام إلى الجلسة. قد يكون الرمز غير صالح أو منتهي الصلاحية، أو أن الخادم غير متاح.",
   "SERVER_CONNECTION_LOST_PERMANENTLY": "تم فقد الاتصال بالخادم. يرجى تحديث الصفحة.",

--- a/client/web/src/app/core/i18n/localizations/en.json
+++ b/client/web/src/app/core/i18n/localizations/en.json
@@ -149,6 +149,7 @@
   "RECONNECTING_TO_USER": "Reconnecting to {{userName}}...",
   "CANNOT_CONNECT_TO_USER": "Cannot connect to {{userName}}. They may be offline.",
   "CONNECTION_CLOSED_WITH_USER": "Connection with {{userName}} was closed.",
+  "WEBRTC_NOT_SUPPORTED": "Your browser doesn't support peer-to-peer connections. Please try a different browser (Chrome, Firefox, Safari, or Edge).",
   "SERVER_CONNECTION_FAILED": "Failed to connect to server. Please check your internet connection.",
   "SESSION_JOIN_FAILED": "Couldn't join the session. The code may be invalid or expired, or the server may be unreachable.",
   "SERVER_CONNECTION_LOST_PERMANENTLY": "Lost connection to server. Please refresh the page.",

--- a/client/web/src/app/core/i18n/localizations/es.json
+++ b/client/web/src/app/core/i18n/localizations/es.json
@@ -149,6 +149,7 @@
   "RECONNECTING_TO_USER": "Reconectando con {{userName}}...",
   "CANNOT_CONNECT_TO_USER": "No se puede conectar con {{userName}}. Puede estar desconectado.",
   "CONNECTION_CLOSED_WITH_USER": "Se cerró la conexión con {{userName}}.",
+  "WEBRTC_NOT_SUPPORTED": "Tu navegador no es compatible con WebRTC. Prueba con otro navegador (Chrome, Firefox, Safari o Edge).",
   "SERVER_CONNECTION_FAILED": "No se pudo conectar al servidor. Comprueba tu conexión a internet.",
   "SESSION_JOIN_FAILED": "No se pudo unir a la sesión. El código puede no ser válido o haber caducado, o el servidor puede no estar disponible.",
   "SERVER_CONNECTION_LOST_PERMANENTLY": "Se perdió la conexión con el servidor. Por favor, recarga la página.",

--- a/client/web/src/app/core/i18n/localizations/fr.json
+++ b/client/web/src/app/core/i18n/localizations/fr.json
@@ -149,6 +149,7 @@
   "RECONNECTING_TO_USER": "Reconnexion à {{userName}}...",
   "CANNOT_CONNECT_TO_USER": "Impossible de se connecter à {{userName}}. Cette personne est peut-être hors ligne.",
   "CONNECTION_CLOSED_WITH_USER": "La connexion avec {{userName}} a été fermée.",
+  "WEBRTC_NOT_SUPPORTED": "Votre navigateur ne prend pas en charge WebRTC. Veuillez essayer un autre navigateur (Chrome, Firefox, Safari ou Edge).",
   "SERVER_CONNECTION_FAILED": "Impossible de se connecter au serveur. Vérifiez votre connexion Internet.",
   "SESSION_JOIN_FAILED": "Impossible de rejoindre la session. Le code est peut-être invalide ou expiré, ou le serveur est inaccessible.",
   "SERVER_CONNECTION_LOST_PERMANENTLY": "Connexion au serveur perdue. Veuillez recharger la page.",

--- a/client/web/src/app/core/i18n/localizations/ru.json
+++ b/client/web/src/app/core/i18n/localizations/ru.json
@@ -149,6 +149,7 @@
   "RECONNECTING_TO_USER": "Переподключение к {{userName}}...",
   "CANNOT_CONNECT_TO_USER": "Не удаётся подключиться к {{userName}}. Возможно, пользователь не в сети.",
   "CONNECTION_CLOSED_WITH_USER": "Соединение с {{userName}} закрыто.",
+  "WEBRTC_NOT_SUPPORTED": "Ваш браузер не поддерживает WebRTC. Попробуйте другой браузер (Chrome, Firefox, Safari или Edge).",
   "SERVER_CONNECTION_FAILED": "Не удалось подключиться к серверу. Проверьте интернет-соединение.",
   "SESSION_JOIN_FAILED": "Не удалось войти в сессию. Возможно, код недействителен или истёк, либо сервер недоступен.",
   "SERVER_CONNECTION_LOST_PERMANENTLY": "Связь с сервером потеряна. Пожалуйста, обновите страницу.",

--- a/client/web/src/app/core/i18n/localizations/zh-CN.json
+++ b/client/web/src/app/core/i18n/localizations/zh-CN.json
@@ -149,6 +149,7 @@
   "RECONNECTING_TO_USER": "正在重新连接到 {{userName}}……",
   "CANNOT_CONNECT_TO_USER": "无法连接到 {{userName}},对方可能不在线。",
   "CONNECTION_CLOSED_WITH_USER": "已关闭与 {{userName}} 的连接。",
+  "WEBRTC_NOT_SUPPORTED": "您的浏览器不支持 WebRTC。请尝试使用其他浏览器(Chrome、Firefox、Safari 或 Edge)。",
   "SERVER_CONNECTION_FAILED": "无法连接到服务器,请检查您的网络连接。",
   "SESSION_JOIN_FAILED": "无法加入会话。代码可能无效或已过期,或服务器不可达。",
   "SERVER_CONNECTION_LOST_PERMANENTLY": "已与服务器断开连接,请刷新页面。",

--- a/client/web/src/app/core/services/communication/webrtc-signaling.service.ts
+++ b/client/web/src/app/core/services/communication/webrtc-signaling.service.ts
@@ -52,6 +52,8 @@ export class WebRTCSignalingService {
   private activeConnectSpans = new Map<string, Sentry.Span>();
   private connectAttemptCounts = new Map<string, number>();
 
+  private unsupportedNotified = false;
+
   constructor() {
     this.initializeSignalMessageHandler();
 
@@ -511,6 +513,18 @@ export class WebRTCSignalingService {
   private createPeerConnection(targetUser: string): RTCPeerConnection | undefined {
     if (this.userService.user === targetUser) {
       this.logger.warn('createPeerConnection', `Skipping connection creation with self`);
+      return;
+    }
+
+    if (typeof RTCPeerConnection === 'undefined') {
+      this.logger.error(
+        'createPeerConnection',
+        'RTCPeerConnection is unavailable in this environment'
+      );
+      if (!this.unsupportedNotified) {
+        this.unsupportedNotified = true;
+        this.toaster.error(this.translate.instant('WEBRTC_NOT_SUPPORTED'));
+      }
       return;
     }
 


### PR DESCRIPTION
Web: Add WebRTC unsupported browser notices

- Adds translations for WebRTC support warnings in multiple languages.
- Notifies user if WebRTC is unsupported in their browser with a toast message.
- Enhances user guidance by providing browser options (Chrome, Firefox, Safari, Edge).

Web: Handle chunk load errors with auto-reload

- Introduce automatic page reload on chunk load failures to ensure users get updated content.
- Implement Sentry error reporting for load errors that cannot be resolved by a reload.