### PR TITLE
iOS: Redesign chat input and standardize component previews

### DIFF
--- a/client/ios/PastePoint.xcodeproj/project.pbxproj
+++ b/client/ios/PastePoint.xcodeproj/project.pbxproj
@@ -443,7 +443,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.6.0;
+				MARKETING_VERSION = 0.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pastepoint.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -482,7 +482,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.6.0;
+				MARKETING_VERSION = 0.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pastepoint.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/client/ios/PastePoint/App/ContentView.swift
+++ b/client/ios/PastePoint/App/ContentView.swift
@@ -44,9 +44,9 @@ struct ContentView: View {
         onSendFiles: handleSendFiles,
         hasConnectedPeers: !services.signalingService.connectedPeers.isEmpty,
       )
-      .padding(.horizontal, 16)
-      .padding(.top, 6)
-      .padding(.bottom, 8)
+      .padding(.horizontal, 8)
+      .padding(.top, 4)
+      .padding(.bottom, 0)
       .frame(maxWidth: .infinity)
       .background {
         AppColors.Background.background

--- a/client/ios/PastePoint/Core/Utils/PreviewStage.swift
+++ b/client/ios/PastePoint/Core/Utils/PreviewStage.swift
@@ -1,0 +1,22 @@
+//
+//  Copyright © 2026 PastePoint. All rights reserved.
+//  SPDX-License-Identifier: GPL-3.0-only
+//
+
+#if DEBUG
+import SwiftUI
+
+/// Shared backdrop for component previews: fills the canvas with the app
+/// background and anchors the content. Use `.bottom` for the input bar,
+/// `.top` for nav/header bars, default (`.center`) for standalone pieces.
+struct PreviewStage<Content: View>: View {
+  var alignment: Alignment = .center
+  @ViewBuilder var content: () -> Content
+
+  var body: some View {
+    content()
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: alignment)
+      .background(AppColors.Background.background)
+  }
+}
+#endif

--- a/client/ios/PastePoint/Views/Chat/Components/ChatInputBar.swift
+++ b/client/ios/PastePoint/Views/Chat/Components/ChatInputBar.swift
@@ -147,34 +147,35 @@ extension ChatInputBar {
 }
 
 #Preview {
-  ChatInputBar(
-    onSend: { _ in true },
-    onSendFiles: { _ in true },
-    hasConnectedPeers: true,
-    stagedFiles: [
-      StagedFile(
-        id: UUID(),
-        name: "Quarterly-Report.pdf",
-        size: 248_000,
-        url: URL(fileURLWithPath: "/dev/null"),
-        kind: .ownedTemp,
-      ),
-      StagedFile(
-        id: UUID(),
-        name: "Photo-2026-06-20.heic",
-        size: 1_900_000,
-        url: URL(fileURLWithPath: "/dev/null"),
-        kind: .ownedTemp,
-      ),
-      StagedFile(
-        id: UUID(),
-        name: "archive.zip",
-        size: 5_400_000,
-        url: URL(fileURLWithPath: "/dev/null"),
-        kind: .ownedTemp,
-      ),
-    ],
-  )
-  .frame(maxHeight: .infinity, alignment: .bottom)
+  PreviewStage(alignment: .bottom) {
+    ChatInputBar(
+      onSend: { _ in true },
+      onSendFiles: { _ in true },
+      hasConnectedPeers: true,
+      stagedFiles: [
+        StagedFile(
+          id: UUID(),
+          name: "Quarterly-Report.pdf",
+          size: 248_000,
+          url: URL(fileURLWithPath: "/dev/null"),
+          kind: .ownedTemp,
+        ),
+        StagedFile(
+          id: UUID(),
+          name: "Photo-2026-06-20.heic",
+          size: 1_900_000,
+          url: URL(fileURLWithPath: "/dev/null"),
+          kind: .ownedTemp,
+        ),
+        StagedFile(
+          id: UUID(),
+          name: "archive.zip",
+          size: 5_400_000,
+          url: URL(fileURLWithPath: "/dev/null"),
+          kind: .ownedTemp,
+        ),
+      ],
+    )
+  }
 }
 #endif

--- a/client/ios/PastePoint/Views/Chat/Components/ChatInputBar.swift
+++ b/client/ios/PastePoint/Views/Chat/Components/ChatInputBar.swift
@@ -19,50 +19,27 @@ struct ChatInputBar: View {
     message.trimmingCharacters(in: .whitespacesAndNewlines)
   }
 
+  private var isSendDisabled: Bool {
+    trimmed.isEmpty && stagedFiles.isEmpty
+  }
+
   var body: some View {
-    VStack(spacing: 10) {
+    VStack(spacing: 8) {
 
       if !stagedFiles.isEmpty {
         ScrollView(.horizontal, showsIndicators: false) {
           HStack(spacing: 8) {
             ForEach(stagedFiles) { file in
-              HStack(spacing: 6) {
-                Image(systemName: "doc")
-                  .font(.caption)
-                Text(file.name)
-                  .font(.caption)
-                  .lineLimit(1)
-                Button {
-                  if let idx = stagedFiles.firstIndex(where: { $0.id == file.id }) {
-                    let removed = stagedFiles.remove(at: idx)
-                    removed.kind.releaseSource(at: removed.url)
-                  }
-                } label: {
-                  Image(systemName: "xmark.circle.fill")
-                    .font(.caption)
-                }
-                .buttonStyle(.plain)
-              }
-              .padding(.horizontal, 8)
-              .padding(.vertical, 4)
-              .background {
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                  .fill(.textSecondary.opacity(0.15))
+              ChatStagedFileTile(file: file) {
+                removeStagedFile(file)
               }
             }
           }
+          .padding(.horizontal, 4)
         }
       }
 
-      TextField("Type your message", text: $message, axis: .vertical)
-        .lineLimit(1...5)
-        .textFieldStyle(.plain)
-        .font(.body)
-        .foregroundStyle(.textPrimary)
-        .autocorrectionDisabled()
-        .textInputAutocapitalization(.never)
-
-      HStack(alignment: .center) {
+      HStack(alignment: .bottom, spacing: 8) {
 
         // TODO: Show toast on picker/stage failure (see logger.error sites)
         AttachmentMenu { staged in
@@ -72,47 +49,58 @@ struct ChatInputBar: View {
             .renderingMode(.template)
             .resizable()
             .scaledToFit()
-            .frame(width: 18, height: 18)
+            .frame(width: 16, height: 16)
+            .frame(width: 22, height: 32)
         }
         .foregroundStyle(.textSecondary)
         .disabled(!hasConnectedPeers)
         .opacity(hasConnectedPeers ? 1 : 0.3)
 
-        Spacer()
+        TextField("Type your message", text: $message, axis: .vertical)
+          .lineLimit(1...5)
+          .textFieldStyle(.plain)
+          .textInputAutocapitalization(.never)
+          .autocorrectionDisabled(true)
+          .font(.subheadline)
+          .foregroundStyle(.textPrimary)
+          .padding(.horizontal, 14)
+          .padding(.vertical, 5)
+          .frame(maxWidth: .infinity)
+          .background(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+              .fill(.inputBackground),
+          )
 
         Button {
           handleSubmit()
         } label: {
-          HStack(spacing: 8) {
-            Text("Send")
-              .font(.headline)
-              .fontWeight(.bold)
-
-            Image("send")
-              .renderingMode(.template)
-              .resizable()
-              .scaledToFit()
-              .frame(width: 16, height: 16)
-          }
-          .foregroundStyle(.white)
-          .padding(.horizontal, 14)
-          .padding(.vertical, 8)
-          .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-              .fill(.brand),
-          )
+          Image("send")
+            .renderingMode(.template)
+            .resizable()
+            .scaledToFit()
+            .frame(width: 18, height: 18)
+            .foregroundStyle(.white)
+            .frame(width: 32, height: 32)
+            .background(
+              Circle()
+                .fill(.brand),
+            )
+            .frame(width: 30, height: 32)
         }
         .buttonStyle(.plain)
-        .disabled(trimmed.isEmpty && stagedFiles.isEmpty)
-        .opacity((trimmed.isEmpty && stagedFiles.isEmpty) ? 0.6 : 1)
+        .disabled(isSendDisabled)
+        .opacity(isSendDisabled ? 0.6 : 1)
       }
     }
-    .padding(.horizontal, 18)
-    .padding(.vertical, 14)
-    .background(
-      RoundedRectangle(cornerRadius: 18, style: .continuous)
-        .fill(.inputBackground),
-    )
+    .padding(.horizontal, 4)
+    .padding(.top, 8)
+    .padding(.bottom, 6)
+  }
+
+  private func removeStagedFile(_ file: StagedFile) {
+    guard let idx = stagedFiles.firstIndex(where: { $0.id == file.id }) else { return }
+    let removed = stagedFiles.remove(at: idx)
+    removed.kind.releaseSource(at: removed.url)
   }
 
   private func handleSubmit() {
@@ -144,11 +132,49 @@ struct ChatInputBar: View {
 // MARK: - Preview
 
 #if DEBUG
+extension ChatInputBar {
+  init(
+    onSend: @escaping (String) -> Bool,
+    onSendFiles: @escaping ([StagedFile]) -> Bool,
+    hasConnectedPeers: Bool,
+    stagedFiles: [StagedFile],
+  ) {
+    self.onSend = onSend
+    self.onSendFiles = onSendFiles
+    self.hasConnectedPeers = hasConnectedPeers
+    self._stagedFiles = State(initialValue: stagedFiles)
+  }
+}
+
 #Preview {
   ChatInputBar(
     onSend: { _ in true },
     onSendFiles: { _ in true },
     hasConnectedPeers: true,
+    stagedFiles: [
+      StagedFile(
+        id: UUID(),
+        name: "Quarterly-Report.pdf",
+        size: 248_000,
+        url: URL(fileURLWithPath: "/dev/null"),
+        kind: .ownedTemp,
+      ),
+      StagedFile(
+        id: UUID(),
+        name: "Photo-2026-06-20.heic",
+        size: 1_900_000,
+        url: URL(fileURLWithPath: "/dev/null"),
+        kind: .ownedTemp,
+      ),
+      StagedFile(
+        id: UUID(),
+        name: "archive.zip",
+        size: 5_400_000,
+        url: URL(fileURLWithPath: "/dev/null"),
+        kind: .ownedTemp,
+      ),
+    ],
   )
+  .frame(maxHeight: .infinity, alignment: .bottom)
 }
 #endif

--- a/client/ios/PastePoint/Views/Chat/Components/ChatMessageBubble.swift
+++ b/client/ios/PastePoint/Views/Chat/Components/ChatMessageBubble.swift
@@ -192,31 +192,36 @@ struct ChatMessageBubble: View {
 
 #if DEBUG
 #Preview {
-  ChatMessageBubble(
-    alignment: .leading,
-    name: "Garry Schulist",
-    time: "9:04 PM",
-    text: "Hello",
-    fileTransfer: FileTransferData(
-      fileId: "preview-id",
-      fileName: "report.pdf",
-      fileSize: 4_127_524,
-      fromUser: "Garry Schulist",
-      status: .pending,
-      fileURL: nil,
-    ),
-    onAccept: { },
-    onDecline: { },
-  )
+  PreviewStage {
+    VStack(spacing: 12) {
+      ChatMessageBubble(
+        alignment: .leading,
+        name: "Garry Schulist",
+        time: "9:04 PM",
+        text: "Hello",
+        fileTransfer: FileTransferData(
+          fileId: "preview-id",
+          fileName: "report.pdf",
+          fileSize: 4_127_524,
+          fromUser: "Garry Schulist",
+          status: .pending,
+          fileURL: nil,
+        ),
+        onAccept: { },
+        onDecline: { },
+      )
 
-  ChatMessageBubble(
-    alignment: .trailing,
-    name: "Gwen Kuphal",
-    time: "9:05 PM",
-    text: "Hi",
-    fileTransfer: nil,
-    onAccept: nil,
-    onDecline: nil,
-  )
+      ChatMessageBubble(
+        alignment: .trailing,
+        name: "Gwen Kuphal",
+        time: "9:05 PM",
+        text: "Hi",
+        fileTransfer: nil,
+        onAccept: nil,
+        onDecline: nil,
+      )
+    }
+    .padding()
+  }
 }
 #endif

--- a/client/ios/PastePoint/Views/Chat/Components/ChatNavBar.swift
+++ b/client/ios/PastePoint/Views/Chat/Components/ChatNavBar.swift
@@ -81,6 +81,8 @@ struct ChatNavBar: View {
 
 #if DEBUG
 #Preview {
-  ChatNavBar()
+  PreviewStage(alignment: .top) {
+    ChatNavBar()
+  }
 }
 #endif

--- a/client/ios/PastePoint/Views/Chat/Components/ChatRoomHeader.swift
+++ b/client/ios/PastePoint/Views/Chat/Components/ChatRoomHeader.swift
@@ -32,6 +32,11 @@ struct ChatRoomHeader: View {
 
 #if DEBUG
 #Preview {
-  ChatRoomHeader(isPrivate: false)
+  PreviewStage(alignment: .top) {
+    VStack(spacing: 0) {
+      ChatRoomHeader(isPrivate: false)
+      ChatRoomHeader(isPrivate: true)
+    }
+  }
 }
 #endif

--- a/client/ios/PastePoint/Views/Chat/Components/ChatStagedFileTile.swift
+++ b/client/ios/PastePoint/Views/Chat/Components/ChatStagedFileTile.swift
@@ -1,0 +1,109 @@
+//
+//  Copyright © 2026 PastePoint. All rights reserved.
+//  SPDX-License-Identifier: GPL-3.0-only
+//
+
+import SwiftUI
+
+struct ChatStagedFileTile: View {
+  let file: StagedFile
+  let onRemove: () -> Void
+
+  var body: some View {
+    HStack(spacing: 8) {
+      Image(systemName: file.symbolName)
+        .font(.system(size: 12, weight: .medium))
+        .foregroundStyle(.brand)
+        .frame(width: 26, height: 26)
+        .background(
+          Circle()
+            .fill(.brand.opacity(0.15)),
+        )
+
+      VStack(alignment: .leading, spacing: 1) {
+        Text(file.name)
+          .font(.caption2)
+          .lineLimit(1)
+          .truncationMode(.middle)
+          .foregroundStyle(.textPrimary)
+
+        Text(file.sizeDescription)
+          .font(.system(size: 10))
+          .foregroundStyle(.textSecondary)
+      }
+      .frame(maxWidth: 120, alignment: .leading)
+
+      Button(action: onRemove) {
+        Image(systemName: "xmark")
+          .font(.system(size: 8, weight: .bold))
+          .foregroundStyle(.textPrimary)
+          .frame(width: 16, height: 16)
+          .background(Circle().fill(.textSecondary.opacity(0.25)))
+      }
+      .buttonStyle(.plain)
+    }
+    .padding(.leading, 6)
+    .padding(.trailing, 8)
+    .padding(.vertical, 4)
+    .background(
+      Capsule(style: .continuous)
+        .fill(.textSecondary.opacity(0.12)),
+    )
+  }
+}
+
+// MARK: - Presentation helpers
+
+private extension StagedFile {
+  /// SF Symbol representing the file, chosen by extension.
+  var symbolName: String {
+    switch (name as NSString).pathExtension.lowercased() {
+    case "jpg", "jpeg", "png", "heic", "gif":
+      "photo"
+    case "mp4", "mov":
+      "film"
+    case "mp3", "m4a", "wav":
+      "music.note"
+    case "pdf":
+      "doc.richtext"
+    case "zip", "rar":
+      "doc.zipper"
+    case "txt", "md":
+      "doc.text"
+    default:
+      "doc"
+    }
+  }
+
+  var sizeDescription: String {
+    ByteCountFormatter.string(fromByteCount: size, countStyle: .file)
+  }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview {
+  VStack(spacing: 8) {
+    ChatStagedFileTile(
+      file: StagedFile(
+        id: UUID(),
+        name: "Quarterly-Report.pdf",
+        size: 248_000,
+        url: URL(fileURLWithPath: "/dev/null"),
+        kind: .ownedTemp,
+      )
+    )      {}
+    ChatStagedFileTile(
+      file: StagedFile(
+        id: UUID(),
+        name: "archive.zip",
+        size: 5_400_000,
+        url: URL(fileURLWithPath: "/dev/null"),
+        kind: .ownedTemp,
+      )
+    )      {}
+  }
+  .padding()
+}
+#endif

--- a/client/ios/PastePoint/Views/Chat/Components/ChatStagedFileTile.swift
+++ b/client/ios/PastePoint/Views/Chat/Components/ChatStagedFileTile.swift
@@ -84,26 +84,28 @@ private extension StagedFile {
 
 #if DEBUG
 #Preview {
-  VStack(spacing: 8) {
-    ChatStagedFileTile(
-      file: StagedFile(
-        id: UUID(),
-        name: "Quarterly-Report.pdf",
-        size: 248_000,
-        url: URL(fileURLWithPath: "/dev/null"),
-        kind: .ownedTemp,
-      )
-    )      {}
-    ChatStagedFileTile(
-      file: StagedFile(
-        id: UUID(),
-        name: "archive.zip",
-        size: 5_400_000,
-        url: URL(fileURLWithPath: "/dev/null"),
-        kind: .ownedTemp,
-      )
-    )      {}
+  PreviewStage {
+    VStack(spacing: 8) {
+      ChatStagedFileTile(
+        file: StagedFile(
+          id: UUID(),
+          name: "Quarterly-Report.pdf",
+          size: 248_000,
+          url: URL(fileURLWithPath: "/dev/null"),
+          kind: .ownedTemp,
+        ),
+      ) {}
+      ChatStagedFileTile(
+        file: StagedFile(
+          id: UUID(),
+          name: "archive.zip",
+          size: 5_400_000,
+          url: URL(fileURLWithPath: "/dev/null"),
+          kind: .ownedTemp,
+        ),
+      ) {}
+    }
+    .padding()
   }
-  .padding()
 }
 #endif

--- a/client/ios/PastePoint/Views/Welcome/WelcomeStepBadge.swift
+++ b/client/ios/PastePoint/Views/Welcome/WelcomeStepBadge.swift
@@ -23,6 +23,12 @@ struct WelcomeStepBadge: View {
 
 #if DEBUG
 #Preview {
-  WelcomeStepBadge(number: 1)
+  PreviewStage {
+    HStack(spacing: 12) {
+      WelcomeStepBadge(number: 1)
+      WelcomeStepBadge(number: 2)
+      WelcomeStepBadge(number: 3)
+    }
+  }
 }
 #endif

--- a/client/ios/PastePoint/Views/Welcome/WelcomeStepList.swift
+++ b/client/ios/PastePoint/Views/Welcome/WelcomeStepList.swift
@@ -34,10 +34,12 @@ struct WelcomeStepList: View {
 
 #if DEBUG
 #Preview {
-  WelcomeStepList(steps: [
-    "Invite others on the same network to join this room",
-    "Start the conversation by sending a message",
-  ])
-  .padding()
+  PreviewStage {
+    WelcomeStepList(steps: [
+      "Invite others on the same network to join this room",
+      "Start the conversation by sending a message",
+    ])
+    .padding()
+  }
 }
 #endif


### PR DESCRIPTION
### Description
  Redesign the iOS chat input bar into a cleaner single-row layout, extract staged-file chips
  into a reusable component, and standardize SwiftUI component previews. Bumps iOS to 0.6.1.

###   What Changed
  - **Input bar**: Single-row layout — leading + attachment button, a pill-shaped text field that grows up to 5
  lines, and a circular send button, all bottom-aligned (centered at rest, anchored to the bottom as the field
  grows). Pill spans the available width; tightened outer margins for more typing space.
  - **Staged-file chips**: Extracted the per-file chip into a reusable ChatStagedFileTile (extension-based icon,
  name, human-readable size); removal stays in the input bar via an onRemove closure. 
  - **Previews**: Added a shared PreviewStage utility giving component previews a consistent background and
  alignment (top/center/bottom), and migrated chat + welcome components onto it with realistic sample data.
  - **Version**: Bump iOS to 0.6.1.