### PR TITLE
iOS: Implement file transfer previews and enhance transfer management

### DIFF
--- a/client/ios/.swiftlint.yml
+++ b/client/ios/.swiftlint.yml
@@ -11,8 +11,12 @@ line_length:
   ignores_urls: true
 
 file_length:
-  warning: 900
-  error: 1000
+  warning: 1000
+  error: 1200
+
+large_tuple:
+  warning: 3
+  error: 4
 
 type_body_length:
   warning: 400
@@ -69,6 +73,7 @@ opt_in_rules:
 disabled_rules:
   - todo                          # TODOs are tracked in code; not a lint error
   - trailing_comma                # handled by SwiftFormat
+  - opening_brace                 # SwiftFormat owns brace placement; its multi-line condition style (brace on its own line) conflicts with this rule
 
 # ── Identifier name exceptions ────────────────────────────────────────────────
 identifier_name:

--- a/client/ios/PastePoint.xcodeproj/project.pbxproj
+++ b/client/ios/PastePoint.xcodeproj/project.pbxproj
@@ -443,7 +443,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.6.1;
+				MARKETING_VERSION = 0.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pastepoint.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -482,7 +482,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.6.1;
+				MARKETING_VERSION = 0.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pastepoint.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/client/ios/PastePoint/App/ContentView.swift
+++ b/client/ios/PastePoint/App/ContentView.swift
@@ -84,6 +84,9 @@ struct ContentView: View {
     .onReceive(services.fileTransferService.outgoingGroupStatus) { update in
       updateOutgoingGroup(groupId: update.groupId, status: update.status, delivered: update.delivered, total: update.total)
     }
+    .onReceive(services.fileTransferService.attachmentPreviewUpdated) { update in
+      updatePreview(fileId: update.fileId, previewDataUrl: update.previewDataUrl, previewMime: update.previewMime)
+    }
     .onReceive(services.fileTransferService.fileTransferCancelled) { fileId in
       updateFileStatus(fileId: fileId, status: .cancelled)
     }
@@ -225,6 +228,14 @@ struct ContentView: View {
     messages[idx].fileTransfer?.status = status
     messages[idx].fileTransfer?.deliveredCount = delivered
     messages[idx].fileTransfer?.recipientCount = total
+  }
+
+  private func updatePreview(fileId: String, previewDataUrl: String, previewMime: String?) {
+    guard let idx = messages.firstIndex(where: { $0.fileTransfer?.fileId == fileId }) else {
+      return
+    }
+    messages[idx].fileTransfer?.previewDataUrl = previewDataUrl
+    messages[idx].fileTransfer?.previewMime = previewMime
   }
 
   private func peerWarning() -> ToastItem {

--- a/client/ios/PastePoint/Core/Models/FileTransfer/FileTransfer.swift
+++ b/client/ios/PastePoint/Core/Models/FileTransfer/FileTransfer.swift
@@ -63,6 +63,8 @@ struct FileTransferData: Codable, Sendable, Equatable {
   let fromUser: String
   var status: FileTransferStatus
   var fileURL: URL?
+  var previewDataUrl: String?
+  var previewMime: String?
   var groupId: String?
   var deliveredCount: Int?
   var recipientCount: Int?
@@ -101,8 +103,8 @@ struct FileDownload: Identifiable, Sendable {
   var isAccepted: Bool
   var expectedHash: String?
   var fileURL: URL?
-  // TODO: file-transfer preview — add `previewDataUrl: String?` and `previewMime: String?`
-  //       and generate a JPEG thumbnail (≤150KB) at send time to match web's
+  var previewDataUrl: String?
+  var previewMime: String?
 }
 
 // MARK: Soruce Kind

--- a/client/ios/PastePoint/Core/Services/App/AppServices.swift
+++ b/client/ios/PastePoint/Core/Services/App/AppServices.swift
@@ -117,6 +117,7 @@ final class AppServices: ObservableObject {
   func handleBackground() {
     logger.info("handleBackground — disconnecting")
     isInBackground = true
+    fileTransferService.cancelAllTransfers()
     wsService.disconnect(manual: false)
   }
 

--- a/client/ios/PastePoint/Core/Services/FileTransfer/FileTransferService.swift
+++ b/client/ios/PastePoint/Core/Services/FileTransfer/FileTransferService.swift
@@ -332,6 +332,15 @@ final class FileTransferService: ObservableObject {
       fileTransferCancelled.send(fileId)
     }
   }
+
+  func cancelAllTransfers() {
+    let peers = Set(activeUploads.map(\.targetUser))
+      .union(activeDownloads.map(\.fromUser))
+      .union(incomingFileOffers.map(\.fromUser))
+    for peer in peers {
+      purgeTransfers(for: peer)
+    }
+  }
 }
 
 // MARK: - Sending

--- a/client/ios/PastePoint/Core/Services/FileTransfer/FileTransferService.swift
+++ b/client/ios/PastePoint/Core/Services/FileTransfer/FileTransferService.swift
@@ -21,6 +21,7 @@ final class FileTransferService: ObservableObject {
   let outgoingAttachment = PassthroughSubject<ChatMessage, Never>()
   let downloadCompleted = PassthroughSubject<(fileId: String, fileURL: URL?), Never>()
   let outgoingGroupStatus = PassthroughSubject<OutgoingGroupStatus, Never>()
+  let attachmentPreviewUpdated = PassthroughSubject<(fileId: String, previewDataUrl: String, previewMime: String?), Never>()
   let fileTransferCancelled = PassthroughSubject<String, Never>()
   let fileTransferFailed = PassthroughSubject<(fileId: String, reason: FileTransferFailureReason), Never>()
 
@@ -68,6 +69,7 @@ final class FileTransferService: ObservableObject {
     targetUser: String,
     groupId: String,
     hashTask: Task<String?, Never>? = nil,
+    preview: PreviewGenerator.Preview? = nil,
   ) async -> Bool {
     guard stagedFile.size > 0 else {
       logger.warning("skipping empty file \(stagedFile.name)")
@@ -124,6 +126,7 @@ final class FileTransferService: ObservableObject {
         sender: sender,
         to: targetUser,
         hashTask: hashTask,
+        preview: preview,
       )
       self?.offerTasks[fileId] = nil
     }
@@ -140,6 +143,7 @@ final class FileTransferService: ObservableObject {
     let sender = userService.user
     let groupId = UUID().uuidString
     outgoingGroups[groupId] = UploadGroup(total: peers.count)
+    let preview = await PreviewGenerator.make(forFileAt: stagedFile.url)
 
     outgoingAttachment.send(
       ChatMessage(
@@ -152,6 +156,8 @@ final class FileTransferService: ObservableObject {
           fileSize: stagedFile.size,
           fromUser: sender,
           status: .pending,
+          previewDataUrl: preview?.dataUrl,
+          previewMime: preview?.mime,
           groupId: groupId,
           deliveredCount: 0,
           recipientCount: peers.count,
@@ -164,7 +170,13 @@ final class FileTransferService: ObservableObject {
       try? BinaryChunk.sha256Hex(ofFileAt: stagedFile.url)
     }
     for peer in peers {
-      await prepareFileForSending(stagedFile: stagedFile, targetUser: peer, groupId: groupId, hashTask: hashTask)
+      await prepareFileForSending(
+        stagedFile: stagedFile,
+        targetUser: peer,
+        groupId: groupId,
+        hashTask: hashTask,
+        preview: preview,
+      )
     }
   }
 
@@ -450,6 +462,7 @@ extension FileTransferService {
     sender: String,
     to targetUser: String,
     hashTask: Task<String?, Never>? = nil,
+    preview: PreviewGenerator.Preview? = nil,
   ) async {
     let hash: String?
     if let hashTask {
@@ -467,14 +480,21 @@ extension FileTransferService {
       return
     }
 
+    let resolvedPreview: PreviewGenerator.Preview?
+    if let preview {
+      resolvedPreview = preview
+    } else {
+      resolvedPreview = await PreviewGenerator.make(forFileAt: stagedFile.url)
+    }
+
     let enriched = FileOfferPayload(
       fileId: fileId,
       fileName: stagedFile.name,
       fileSize: stagedFile.size,
       fromUser: sender,
       fileHash: hash,
-      previewDataUrl: nil,
-      previewMime: nil,
+      previewDataUrl: resolvedPreview?.dataUrl,
+      previewMime: resolvedPreview?.mime,
     )
 
     do {
@@ -512,6 +532,18 @@ extension FileTransferService {
         incomingFileOffers[i].expectedHash = hash
         logger.info("merged hash into pending offer \(payload.fileId)")
       }
+
+      if
+        let preview = payload.previewDataUrl,
+        let previewMime = payload.previewMime,
+        incomingFileOffers[i].previewDataUrl == nil
+      {
+        incomingFileOffers[i].previewDataUrl = preview
+        incomingFileOffers[i].previewMime = previewMime
+
+        attachmentPreviewUpdated.send((fileId: payload.fileId, previewDataUrl: preview, previewMime: previewMime))
+        logger.info("merged preview into pending offer \(payload.fileId)")
+      }
       return
     }
 
@@ -519,6 +551,18 @@ extension FileTransferService {
       if let hash = payload.fileHash, activeDownloads[i].expectedHash == nil {
         activeDownloads[i].expectedHash = hash
         logger.info("merged hash into accepted download \(payload.fileId)")
+      }
+
+      if
+        let preview = payload.previewDataUrl,
+        let previewMime = payload.previewMime,
+        activeDownloads[i].previewDataUrl == nil
+      {
+        activeDownloads[i].previewDataUrl = preview
+        activeDownloads[i].previewMime = previewMime
+
+        attachmentPreviewUpdated.send((fileId: payload.fileId, previewDataUrl: preview, previewMime: previewMime))
+        logger.info("merged preview into accepted download \(payload.fileId)")
       }
       return
     }
@@ -535,6 +579,8 @@ extension FileTransferService {
       progress: 0,
       isAccepted: false,
       expectedHash: payload.fileHash,
+      previewDataUrl: payload.previewDataUrl,
+      previewMime: payload.previewMime,
     )
     incomingFileOffers.append(download)
 
@@ -544,6 +590,8 @@ extension FileTransferService {
       fileSize: payload.fileSize,
       fromUser: peer,
       status: .pending,
+      previewDataUrl: payload.previewDataUrl,
+      previewMime: payload.previewMime,
     )
     let message = ChatMessage(
       from: peer,

--- a/client/ios/PastePoint/Core/Services/FileTransfer/PreviewGenerator.swift
+++ b/client/ios/PastePoint/Core/Services/FileTransfer/PreviewGenerator.swift
@@ -1,0 +1,110 @@
+//
+//  Copyright © 2026 PastePoint. All rights reserved.
+//  SPDX-License-Identifier: GPL-3.0-only
+//
+
+import Foundation
+import ImageIO
+import Logging
+import PDFKit
+import UniformTypeIdentifiers
+
+enum PreviewGenerator {
+  private nonisolated static let logger = Logger(label: "PreviewGenerator")
+
+  private nonisolated static let maxPixelSize = 320
+  private nonisolated static let jpegQuality: CGFloat = 0.7
+  private nonisolated static let maxDataUrlBytes = 150 * 1024
+  private nonisolated static let maxPdfBytesForPreview = 100 * 1024 * 1024
+
+  struct Preview: Sendable {
+    let dataUrl: String
+    let mime: String
+  }
+
+  nonisolated static func make(forFileAt url: URL) async -> Preview? {
+    await Task.detached(priority: .utility) {
+      generate(url)
+    }.value
+  }
+
+  private nonisolated static func generate(_ url: URL) -> Preview? {
+    let type = UTType(filenameExtension: url.pathExtension)
+
+    if type?.conforms(to: .image) == true {
+      return imagePreview(at: url)
+    }
+    if type?.conforms(to: .pdf) == true {
+      return pdfPreview(at: url)
+    }
+
+    return nil
+  }
+
+  private nonisolated static func imagePreview(at url: URL) -> Preview? {
+    let options: [CFString: Any] = [
+      kCGImageSourceCreateThumbnailFromImageAlways: true,
+      kCGImageSourceCreateThumbnailWithTransform: true,
+      kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
+    ]
+
+    guard
+      let src = CGImageSourceCreateWithURL(url as CFURL, nil),
+      let cg = CGImageSourceCreateThumbnailAtIndex(src, 0, options as CFDictionary)
+    else {
+      logger.warning("image preview failed")
+      return nil
+    }
+
+    let image = UIImage(cgImage: cg)
+
+    if let png = image.pngData(), let preview = dataUrl(png, mime: "image/png") {
+      return preview
+    }
+
+    if
+      let jpeg = image.jpegData(compressionQuality: jpegQuality),
+      let preview = dataUrl(jpeg, mime: "image/jpeg")
+    {
+      logger.info("image preview: PNG over cap, used JPEG fallback")
+      return preview
+    }
+
+    logger.warning("image preview over cap even as JPEG, dropping")
+    return nil
+  }
+
+  private nonisolated static func pdfPreview(at url: URL) -> Preview? {
+    if let size = try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int, size > maxPdfBytesForPreview {
+      return nil
+    }
+
+    guard
+      let doc = PDFDocument(url: url),
+      let page = doc.page(at: 0)
+    else {
+      logger.warning("pdf preview failed")
+      return nil
+    }
+
+    let bounds = page.bounds(for: .mediaBox)
+    let ratio = min(CGFloat(maxPixelSize) / bounds.width, 1)
+    let target = CGSize(width: bounds.width * ratio, height: bounds.height * ratio)
+    guard let data = page.thumbnail(of: target, for: .mediaBox).jpegData(compressionQuality: jpegQuality) else {
+      return nil
+    }
+
+    guard let preview = dataUrl(data, mime: "image/jpeg") else {
+      logger.warning("pdf preview over cap, dropping")
+      return nil
+    }
+
+    return preview
+  }
+
+  private nonisolated static func dataUrl(_ data: Data, mime: String) -> Preview? {
+    let dataUrl = "data:\(mime);base64,\(data.base64EncodedString())"
+    guard dataUrl.utf8.count <= maxDataUrlBytes else { return nil }
+    return Preview(dataUrl: dataUrl, mime: mime)
+  }
+}

--- a/client/ios/PastePoint/Views/Chat/ChatView.swift
+++ b/client/ios/PastePoint/Views/Chat/ChatView.swift
@@ -118,7 +118,7 @@ struct ChatView: View {
     guard
       let transfer = message.fileTransfer,
       transfer.status == .pending,
-      message.from != services.userService.user
+      !message.isMine
     else {
       return nil
     }
@@ -132,7 +132,7 @@ struct ChatView: View {
     guard
       let transfer = message.fileTransfer,
       transfer.status == .pending,
-      message.from != services.userService.user
+      !message.isMine
     else {
       return nil
     }

--- a/client/ios/PastePoint/Views/Chat/Components/ChatMessageBubble.swift
+++ b/client/ios/PastePoint/Views/Chat/Components/ChatMessageBubble.swift
@@ -11,6 +11,8 @@ enum MessageAlignment {
 }
 
 struct ChatMessageBubble: View {
+  @State private var previewImage: UIImage?
+
   let alignment: MessageAlignment
   let name: String
   let time: String
@@ -97,6 +99,15 @@ struct ChatMessageBubble: View {
 
   private func attachmentBody(transfer: FileTransferData) -> some View {
     VStack(alignment: .leading, spacing: 8) {
+      if let previewImage {
+        Image(uiImage: previewImage)
+          .resizable()
+          .scaledToFill()
+          .frame(maxWidth: .infinity, minHeight: 150, maxHeight: 150)
+          .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+          .allowsHitTesting(false)
+      }
+
       HStack(spacing: 8) {
         Image(systemName: "doc")
           .font(.title3)
@@ -144,6 +155,9 @@ struct ChatMessageBubble: View {
           .foregroundStyle(.secondary)
       }
     }
+    .task(id: transfer.previewDataUrl) {
+      previewImage = Self.decodePreview(transfer.previewDataUrl)
+    }
     .foregroundStyle(alignment == .trailing ? .textPrimary : .white)
     .padding(.horizontal, 12)
     .padding(.vertical, 10)
@@ -161,6 +175,18 @@ struct ChatMessageBubble: View {
 
   private func formatBytes(_ bytes: Int64) -> String {
     ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+  }
+
+  private static func decodePreview(_ dataUrl: String?) -> UIImage? {
+    guard
+      let dataUrl,
+      let comma = dataUrl.firstIndex(of: ","),
+      let data = Data(base64Encoded: String(dataUrl[dataUrl.index(after: comma)...]))
+    else {
+      return nil
+    }
+
+    return UIImage(data: data)
   }
 
   private func statusLabel(_ status: FileTransferStatus) -> String {

--- a/client/web/package-lock.json
+++ b/client/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.18.5",
+  "version": "0.18.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.18.5",
+      "version": "0.18.6",
       "dependencies": {
         "@angular/cdk": "^21.2.9",
         "@angular/common": "^21.2.17",

--- a/client/web/package.json
+++ b/client/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.18.5",
+  "version": "0.18.6",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/client/web/src/app/core/services/file-management/file-upload.service.ts
+++ b/client/web/src/app/core/services/file-management/file-upload.service.ts
@@ -482,8 +482,9 @@ export class FileUploadService extends FileTransferBaseService {
       try {
         const mime = fileTransfer.file.type || '';
         if (mime.startsWith('image/')) {
-          previewDataUrl = await this.previewService.createImageThumbnail(fileTransfer.file);
-          previewMime = 'image/png';
+          const thumb = await this.previewService.createImageThumbnail(fileTransfer.file);
+          previewDataUrl = thumb.dataUrl;
+          previewMime = thumb.mime;
         } else if (mime === 'application/pdf') {
           previewDataUrl = await this.previewService.createPdfThumbnailFromFile(fileTransfer.file);
           if (previewDataUrl) {

--- a/client/web/src/app/core/services/file-management/file-upload.service.ts
+++ b/client/web/src/app/core/services/file-management/file-upload.service.ts
@@ -606,6 +606,9 @@ export class FileUploadService extends FileTransferBaseService {
           const errorCount = this.consecutiveErrorCounts.get(transferId) ?? 0;
           this.consecutiveErrorCounts.set(transferId, errorCount + 1);
           if (errorCount > this.maxConsecutiveErrors) {
+            span.setAttribute('outcome', 'aborted_channel_unavailable');
+            span.setStatus({ code: 2, message: 'channel_unavailable' });
+            await this.stopFileUpload(fileTransfer.targetUser, fileTransfer.fileId);
             break;
           }
           continue;

--- a/client/web/src/app/core/services/ui/preview.service.ts
+++ b/client/web/src/app/core/services/ui/preview.service.ts
@@ -1,6 +1,10 @@
 import { Injectable, PLATFORM_ID, inject } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
-import { PREVIEW_MIME_TYPE, PREVIEW_QUALITY } from '../../../utils/constants';
+import {
+  MAX_PREVIEW_DATA_URL_SIZE,
+  PREVIEW_MIME_TYPE,
+  PREVIEW_QUALITY,
+} from '../../../utils/constants';
 
 @Injectable({
   providedIn: 'root',
@@ -48,8 +52,8 @@ export class PreviewService {
     file: File,
     maxWidth: number = 320,
     maxHeight: number = 192
-  ): Promise<string> {
-    return new Promise<string>((resolve, reject) => {
+  ): Promise<{ dataUrl: string; mime: string }> {
+    return new Promise<{ dataUrl: string; mime: string }>((resolve, reject) => {
       // Use createObjectURL - more memory efficient than readAsDataURL
       // It creates a reference to the file, not a copy
       const objectUrl = URL.createObjectURL(file);
@@ -75,13 +79,21 @@ export class PreviewService {
         }
 
         ctx.drawImage(img, 0, 0, width, height);
-        const dataUrl = canvas.toDataURL('image/png');
+
+        const png = canvas.toDataURL('image/png');
+        const result =
+          png.length > MAX_PREVIEW_DATA_URL_SIZE
+            ? {
+                dataUrl: canvas.toDataURL(PREVIEW_MIME_TYPE, PREVIEW_QUALITY),
+                mime: PREVIEW_MIME_TYPE,
+              }
+            : { dataUrl: png, mime: 'image/png' };
 
         // Clear canvas to help garbage collection
         canvas.width = 0;
         canvas.height = 0;
 
-        resolve(dataUrl);
+        resolve(result);
       };
       img.onerror = () => {
         URL.revokeObjectURL(objectUrl);

--- a/client/web/src/app/features/chat/chat.component.ts
+++ b/client/web/src/app/features/chat/chat.component.ts
@@ -1244,7 +1244,7 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
 
         return {
           ...msg,
-          text: `${this.truncateFilename(msg.fileTransfer.fileName)} (${fileSizeLabel}) - ${statusText}`,
+          text: `${this.truncateFilename(msg.fileTransfer.fileName)} (${fileSizeLabel})\n${statusText}`,
           fileTransfer: {
             ...msg.fileTransfer,
             status,

--- a/client/web/src/app/features/chat/components/chat-messages/chat-messages.component.html
+++ b/client/web/src/app/features/chat/components/chat-messages/chat-messages.component.html
@@ -373,13 +373,13 @@
                               </div>
                             }
                             <p
-                              class="flex items-center gap-2 break-all text-xs text-white font-expoArabic"
+                              class="flex items-start gap-2 whitespace-pre-line break-all text-xs text-white font-expoArabic max-w-[280px] mx-auto"
                             >
                               <img
                                 src="/icons/file-white.svg"
                                 alt="File"
                                 title="File"
-                                class="h-4 w-4"
+                                class="h-4 w-4 shrink-0 mt-[2px]"
                                 loading="lazy"
                                 width="16"
                                 height="16"


### PR DESCRIPTION
Adds image/PDF preview thumbnails to the iOS file-transfer flow (matching web), plus a set of related cross-client parity and UI fixes.

### iOS — attachment previews (the main feature)
- New `PreviewGenerator` (iOS twin of web's `preview.service.ts`): downsamples to a 320px thumbnail and emits a self-describing `data:<mime>;base64,…` URL on the phase-2 file offer — wire-compatible with web.
  - Images: **PNG first, JPEG@0.7 fallback** when PNG exceeds the 150KB cap, so detailed photos still preview instead of being dropped.
  - PDFs: page-1 → JPEG@0.7.
  - Runs off the main actor (`Task.detached`); generated once per send and threaded through the offer path.
- `FileTransferService` / `FileTransfer` / `ContentView` / `ChatMessageBubble` wired to carry, publish, and render the preview (decoded image pinned with `.allowsHitTesting(false)` so the thumbnail can't steal taps from Accept/Decline).

### iOS — fixes found along the way
- **Ownership checks use `isMine`, not name comparison** — under the ephemeral-identity model a reconnect rename made the sender see Accept/Decline on their own offer bubble. Gated on `ChatMessage.isMine` instead.
- **Cancel in-flight transfers on background** — `cancelAllTransfers()` runs synchronously in `handleBackground()` before WS disconnect, so bubbles resolve deterministically (upload → "Not delivered") instead of staying stuck at "Sending…" through app suspension.

### Web — parity & UI fixes
- **JPEG fallback for image previews** — `createImageThumbnail` now encodes PNG first, falls back to JPEG@0.7 over the 150KB cap, and returns `{ dataUrl, mime }` (parity with iOS; previously a too-big PNG was dropped entirely).
- **Accepted-bubble layout** — capped the status line to the 280px image width so the bubble stops widening past the pending state, and moved the transfer status onto its own line (no more mid-word `break-all` on "File").
- **Resolve sender bubble on peer-disconnect** — `sendFileChunksInner` calls `stopFileUpload` on the channel-unavailable abort path (was a bare `break`), so the sender bubble moves to "Not delivered" instead of hanging at "Sending…".

### CI / config
- Relaxed SwiftLint file-length limits and added `large_tuple`; disabled `opening_brace` to resolve a SwiftFormat brace conflict (relax rule rather than contort code).
- Version bumps: iOS 0.7.0, web 0.18.6.