### PR TITLE
Add transfer status labels to incoming file bubbles

### DIFF
--- a/client/web/package-lock.json
+++ b/client/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.18.7",
+  "version": "0.18.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.18.7",
+      "version": "0.18.8",
       "dependencies": {
         "@angular/cdk": "^21.2.9",
         "@angular/common": "^21.2.17",

--- a/client/web/package.json
+++ b/client/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.18.7",
+  "version": "0.18.8",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/client/web/src/app/core/i18n/localizations/ar.json
+++ b/client/web/src/app/core/i18n/localizations/ar.json
@@ -88,6 +88,9 @@
   "FILE_SEND_NONE": "لم يتم التسليم",
   "FILE_TRANSFER_ACCEPTED": "تم قبول الملف",
   "FILE_TRANSFER_DECLINED": "تم رفض الملف",
+  "FILE_TRANSFER_COMPLETED": "اكتمل نقل الملف",
+  "FILE_TRANSFER_CANCELLED": "تم إلغاء نقل الملف",
+  "FILE_TRANSFER_FAILED": "فشل نقل الملف",
 
   "_404_PAGE_SECTION": "==== 404 PAGE ====",
   "PAGE_NOT_FOUND": "الصفحة غير موجودة",

--- a/client/web/src/app/core/i18n/localizations/en.json
+++ b/client/web/src/app/core/i18n/localizations/en.json
@@ -88,6 +88,9 @@
   "FILE_SEND_NONE": "Not delivered",
   "FILE_TRANSFER_ACCEPTED": "File transfer accepted",
   "FILE_TRANSFER_DECLINED": "File transfer declined",
+  "FILE_TRANSFER_COMPLETED": "File transfer completed",
+  "FILE_TRANSFER_CANCELLED": "File transfer cancelled",
+  "FILE_TRANSFER_FAILED": "File transfer failed",
 
   "_404_PAGE_SECTION": "==== 404 PAGE ====",
   "PAGE_NOT_FOUND": "Page Not Found",

--- a/client/web/src/app/core/i18n/localizations/es.json
+++ b/client/web/src/app/core/i18n/localizations/es.json
@@ -88,6 +88,9 @@
   "FILE_SEND_NONE": "No entregado",
   "FILE_TRANSFER_ACCEPTED": "Transferencia aceptada",
   "FILE_TRANSFER_DECLINED": "Transferencia rechazada",
+  "FILE_TRANSFER_COMPLETED": "Transferencia completada",
+  "FILE_TRANSFER_CANCELLED": "Transferencia cancelada",
+  "FILE_TRANSFER_FAILED": "Transferencia fallida",
 
   "_404_PAGE_SECTION": "==== 404 PAGE ====",
   "PAGE_NOT_FOUND": "Página no encontrada",

--- a/client/web/src/app/core/i18n/localizations/fr.json
+++ b/client/web/src/app/core/i18n/localizations/fr.json
@@ -88,6 +88,9 @@
   "FILE_SEND_NONE": "Non remis",
   "FILE_TRANSFER_ACCEPTED": "Transfert accepté",
   "FILE_TRANSFER_DECLINED": "Transfert refusé",
+  "FILE_TRANSFER_COMPLETED": "Transfert terminé",
+  "FILE_TRANSFER_CANCELLED": "Transfert annulé",
+  "FILE_TRANSFER_FAILED": "Échec du transfert",
 
   "_404_PAGE_SECTION": "==== 404 PAGE ====",
   "PAGE_NOT_FOUND": "Page introuvable",

--- a/client/web/src/app/core/i18n/localizations/ru.json
+++ b/client/web/src/app/core/i18n/localizations/ru.json
@@ -88,6 +88,9 @@
   "FILE_SEND_NONE": "Не доставлено",
   "FILE_TRANSFER_ACCEPTED": "Передача принята",
   "FILE_TRANSFER_DECLINED": "Передача отклонена",
+  "FILE_TRANSFER_COMPLETED": "Передача завершена",
+  "FILE_TRANSFER_CANCELLED": "Передача отменена",
+  "FILE_TRANSFER_FAILED": "Ошибка передачи",
 
   "_404_PAGE_SECTION": "==== 404 PAGE ====",
   "PAGE_NOT_FOUND": "Страница не найдена",

--- a/client/web/src/app/core/i18n/localizations/zh-CN.json
+++ b/client/web/src/app/core/i18n/localizations/zh-CN.json
@@ -88,6 +88,9 @@
   "FILE_SEND_NONE": "未送达",
   "FILE_TRANSFER_ACCEPTED": "文件传输已接受",
   "FILE_TRANSFER_DECLINED": "文件传输已拒绝",
+  "FILE_TRANSFER_COMPLETED": "文件传输已完成",
+  "FILE_TRANSFER_CANCELLED": "文件传输已取消",
+  "FILE_TRANSFER_FAILED": "文件传输失败",
 
   "_404_PAGE_SECTION": "==== 404 PAGE ====",
   "PAGE_NOT_FOUND": "页面未找到",

--- a/client/web/src/app/core/services/file-management/file-download.service.ts
+++ b/client/web/src/app/core/services/file-management/file-download.service.ts
@@ -1,9 +1,11 @@
 import { Injectable, inject } from '@angular/core';
 import * as Sentry from '@sentry/angular';
 import { startNewTrace } from '@sentry/core';
+import { Subject } from 'rxjs';
 import {
   FILE_TRANSFER_MESSAGE_TYPES,
   FileDownload,
+  FileTransferStatus,
   PREVIEW_MIME_TYPE,
 } from '../../../utils/constants';
 import { FileTransferBaseService } from './file-transfer-base.service';
@@ -26,6 +28,11 @@ export class FileDownloadService extends FileTransferBaseService {
 
   private activeReceiveSpans = new Map<string, Sentry.Span>();
   private stallWatchdog: ReturnType<typeof setInterval> | null = null;
+
+  // Receiver-side terminal status of an incoming download, keyed by fileId.
+  // Drives the incoming (receiver) bubble's COMPLETED/CANCELLED/FAILED label
+  // — parity with iOS, where ChatMessageBubble renders the full status set.
+  public downloadStatus$ = new Subject<{ fileId: string; status: FileTransferStatus }>();
 
   // =============== Constructor ===============
   constructor() {
@@ -62,6 +69,11 @@ export class FileDownloadService extends FileTransferBaseService {
       | 'cancelled',
     extra?: Record<string, number | string | boolean>
   ): void {
+    // Drive the receiver bubble first — every terminal transition flows through
+    // here, and we must emit even when no span exists yet (e.g. early no_hash
+    // reject, before the first chunk starts the span), so this precedes the guard.
+    this.downloadStatus$.next({ fileId, status: this.receiverBubbleStatus(outcome) });
+
     const key = this.receiveSpanKey(fromUser, fileId);
     const span = this.activeReceiveSpans.get(key);
     if (!span) return;
@@ -76,6 +88,28 @@ export class FileDownloadService extends FileTransferBaseService {
     );
     span.end();
     this.activeReceiveSpans.delete(key);
+  }
+
+  /** Maps a receive-span outcome to the receiver bubble's terminal status. */
+  private receiverBubbleStatus(
+    outcome:
+      | 'completed'
+      | 'crc_failed'
+      | 'missing_chunks'
+      | 'hash_mismatch'
+      | 'no_hash'
+      | 'stalled'
+      | 'cancelled'
+  ): FileTransferStatus {
+    switch (outcome) {
+      case 'completed':
+        return FileTransferStatus.COMPLETED;
+      case 'cancelled':
+        return FileTransferStatus.CANCELLED;
+      default:
+        // crc_failed | missing_chunks | hash_mismatch | no_hash | stalled
+        return FileTransferStatus.FAILED;
+    }
   }
 
   // =============== Data Handling Methods ===============

--- a/client/web/src/app/core/services/file-management/file-download.service.ts
+++ b/client/web/src/app/core/services/file-management/file-download.service.ts
@@ -28,10 +28,6 @@ export class FileDownloadService extends FileTransferBaseService {
 
   private activeReceiveSpans = new Map<string, Sentry.Span>();
   private stallWatchdog: ReturnType<typeof setInterval> | null = null;
-
-  // Receiver-side terminal status of an incoming download, keyed by fileId.
-  // Drives the incoming (receiver) bubble's COMPLETED/CANCELLED/FAILED label
-  // — parity with iOS, where ChatMessageBubble renders the full status set.
   public downloadStatus$ = new Subject<{ fileId: string; status: FileTransferStatus }>();
 
   // =============== Constructor ===============
@@ -69,9 +65,6 @@ export class FileDownloadService extends FileTransferBaseService {
       | 'cancelled',
     extra?: Record<string, number | string | boolean>
   ): void {
-    // Drive the receiver bubble first — every terminal transition flows through
-    // here, and we must emit even when no span exists yet (e.g. early no_hash
-    // reject, before the first chunk starts the span), so this precedes the guard.
     this.downloadStatus$.next({ fileId, status: this.receiverBubbleStatus(outcome) });
 
     const key = this.receiveSpanKey(fromUser, fileId);

--- a/client/web/src/app/core/services/file-management/file-transfer.service.ts
+++ b/client/web/src/app/core/services/file-management/file-transfer.service.ts
@@ -124,6 +124,14 @@ export class FileTransferService implements IFileTransferService {
     return this.fileUploadService.outgoingGroupStatus$;
   }
 
+  /**
+   * Receiver-side terminal status of an incoming download (drives the incoming
+   * bubble's COMPLETED/CANCELLED/FAILED label).
+   */
+  public get downloadStatus$() {
+    return this.fileDownloadService.downloadStatus$;
+  }
+
   // =============== Upload Methods ===============
   /** Registers a logical send to `total` recipients before per-peer prep. */
   public beginUploadGroup(groupId: string, total: number): void {

--- a/client/web/src/app/features/chat/chat.component.ts
+++ b/client/web/src/app/features/chat/chat.component.ts
@@ -694,7 +694,7 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
     );
 
     // Receiver bubble: reflect the terminal status of an incoming download
-    // (completed / cancelled / failed) once it stops, matching iOS.
+    // (completed / cancelled / failed) once it stops.
     this.subscriptions.push(
       this.fileTransferService.downloadStatus$.subscribe(({ fileId, status }) => {
         this.ngZone.run(() => {

--- a/client/web/src/app/features/chat/chat.component.ts
+++ b/client/web/src/app/features/chat/chat.component.ts
@@ -693,6 +693,17 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
       })
     );
 
+    // Receiver bubble: reflect the terminal status of an incoming download
+    // (completed / cancelled / failed) once it stops, matching iOS.
+    this.subscriptions.push(
+      this.fileTransferService.downloadStatus$.subscribe(({ fileId, status }) => {
+        this.ngZone.run(() => {
+          this.updateFileTransferMessageStatus(fileId, status);
+          this.cdr.detectChanges();
+        });
+      })
+    );
+
     // When a peer disconnects after being connected, restart warning timeout
     this.subscriptions.push(
       this.webrtcService.peerDisconnected$.subscribe((member) => {
@@ -1239,17 +1250,11 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
    * Updates the status and text of a file transfer message
    * ==========================================================
    */
-  private updateFileTransferMessageStatus(
-    fileId: string,
-    status: FileTransferStatus.ACCEPTED | FileTransferStatus.DECLINED
-  ): void {
+  private updateFileTransferMessageStatus(fileId: string, status: FileTransferStatus): void {
     const currentMessages = this.chatService.messages$.value;
     const updatedMessages = currentMessages.map((msg) => {
       if (msg.type === ChatMessageType.ATTACHMENT && msg.fileTransfer?.fileId === fileId) {
-        const statusText =
-          status === FileTransferStatus.ACCEPTED
-            ? this.translate.instant('FILE_TRANSFER_ACCEPTED')
-            : this.translate.instant('FILE_TRANSFER_DECLINED');
+        const statusText = this.translate.instant(this.fileTransferStatusLabelKey(status));
         const fileSizeLabel = this.fileSizePipe.transform(msg.fileTransfer.fileSize, 2);
 
         return {
@@ -1265,6 +1270,24 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
     });
 
     this.chatService.replaceMessages(updatedMessages);
+  }
+
+  /** i18n key for the status line shown under a file-transfer bubble. */
+  private fileTransferStatusLabelKey(status: FileTransferStatus): string {
+    switch (status) {
+      case FileTransferStatus.ACCEPTED:
+        return 'FILE_TRANSFER_ACCEPTED';
+      case FileTransferStatus.DECLINED:
+        return 'FILE_TRANSFER_DECLINED';
+      case FileTransferStatus.COMPLETED:
+        return 'FILE_TRANSFER_COMPLETED';
+      case FileTransferStatus.CANCELLED:
+        return 'FILE_TRANSFER_CANCELLED';
+      case FileTransferStatus.FAILED:
+        return 'FILE_TRANSFER_FAILED';
+      default:
+        return 'FILE_TRANSFER_ACCEPTED';
+    }
   }
 
   /**

--- a/client/web/src/app/utils/constants.ts
+++ b/client/web/src/app/utils/constants.ts
@@ -174,6 +174,8 @@ export enum FileTransferStatus {
   ACCEPTED = 'accepted',
   DECLINED = 'declined',
   COMPLETED = 'completed',
+  CANCELLED = 'cancelled',
+  FAILED = 'failed',
 }
 
 export interface FileUpload {


### PR DESCRIPTION
### What changed

#### Render terminal transfer status on receiver file bubbles

- Add COMPLETED, CANCELLED, and FAILED status labels to incoming file transfer bubbles to achieve parity with the iOS client. This wires the file download service to emit terminal outcomes and updates the chat component to reflect these states in the UI.

#### Bump version to 0.18.8