### PR TITLE
Optimize Docker builds and enhance trace sampling rate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ENV_FILE ?= $(firstword $(wildcard .env.development .env.production))
 prod:
 	@echo "Starting production environment..."
 	@test -f .env.production || (echo "Error: .env.production not found. Copy .env.production.example to .env.production on this host and fill in real values." && exit 1)
-	docker compose --env-file .env.production build --parallel
+	docker compose --env-file .env.production build
 	docker compose --env-file .env.production up --force-recreate -d
 	@echo "Production services are starting. View logs with: make logs"
 
@@ -24,7 +24,7 @@ prod:
 dev:
 	@echo "Starting development environment..."
 	@test -f .env.development || (echo "Error: .env.development not found. Copy .env.development.example to .env.development and configure it." && exit 1)
-	docker compose --env-file .env.development build --parallel
+	docker compose --env-file .env.development build
 	docker compose --env-file .env.development up --force-recreate -d
 	@echo "Development services are starting. View logs with: make logs"
 

--- a/client/web/Dockerfile
+++ b/client/web/Dockerfile
@@ -14,8 +14,11 @@ RUN --mount=type=cache,target=/root/.npm \
 # Copy application code
 COPY client/web/ ./
 
-# Build the application
-RUN npm run build -- --configuration=$NPM_BUILD_CONFIG
+# Build the application. The .angular/cache mount persists Angular's build cache
+# across builds so unchanged code isn't recompiled.
+RUN --mount=type=cache,target=/root/.npm \
+    --mount=type=cache,target=/usr/src/app/.angular/cache \
+    npm run build -- --configuration=$NPM_BUILD_CONFIG
 
 # ---------- Stage 2: SSR Server ----------
 FROM node:24.16.0-alpine AS ssr

--- a/client/web/src/environments/environment.docker-dev.ts
+++ b/client/web/src/environments/environment.docker-dev.ts
@@ -11,7 +11,7 @@ export const environment = {
     enabled: false,
     dsn: '',
     environment: 'docker-dev',
-    tracesSampleRate: 0.1,
+    tracesSampleRate: 0.25,
     enableLogs: true,
   },
 };

--- a/client/web/src/environments/environment.prod.ts
+++ b/client/web/src/environments/environment.prod.ts
@@ -11,7 +11,7 @@ export const environment = {
     enabled: true,
     dsn: '',
     environment: 'production',
-    tracesSampleRate: 0.1,
+    tracesSampleRate: 0.25,
     enableLogs: true,
   },
 };

--- a/client/web/src/environments/environment.ts
+++ b/client/web/src/environments/environment.ts
@@ -11,7 +11,7 @@ export const environment = {
     enabled: false,
     dsn: '',
     environment: 'development',
-    tracesSampleRate: 0.1,
+    tracesSampleRate: 0.25,
     enableLogs: true,
   },
 };

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -37,3 +37,7 @@ sentry-actix = "0.48"
 [dev-dependencies]
 actix-test = "0.1.5"
 awc = "3.8.2"
+
+[profile.release]
+opt-level = 2   # 3 -> 2 trims LLVM codegen time; negligible runtime cost for a signaling server
+strip = true    # strip symbols at link time

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -12,36 +12,25 @@ RUN apk add --no-cache openssl-dev openssl-libs-static musl-dev pkgconf
 # Statically link OpenSSL so runtime image doesn't need libssl
 ENV OPENSSL_STATIC=1 OPENSSL_NO_VENDOR=1
 
-# Copy the Cargo.toml and Cargo.lock files
+# Copy manifests and sources
 COPY server/Cargo.toml server/Cargo.lock ./
 COPY rust-toolchain rust-toolchain
-
-# Create an empty main.rs to allow cargo to build dependencies
-RUN mkdir -p src && echo "fn main() {}" > src/main.rs
-
-# Build dependencies
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-  --mount=type=cache,target=/usr/local/cargo/git/db \
-  if [ "$RUST_BUILD_MODE" = "release" ]; then \
-  cargo build --release; \
-  else \
-  cargo build; \
-  fi
-
-# Now copy the source files and overwrite the dummy files
 COPY server/src ./src
 COPY server/config ./config
 
-# Final build with actual source code
+# Build. The target/ cache mount keeps compiled dependencies across builds, so a
+# source-only change recompiles just the server crate instead of the whole tree.
+# target/ is not visible to later stages, so the binary is copied out within this
+# same RUN. Stripping is handled by `strip = true` in Cargo.toml's release profile.
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
   --mount=type=cache,target=/usr/local/cargo/git/db \
+  --mount=type=cache,target=/usr/src/app/target,sharing=locked \
+  set -eux; \
   if [ "$RUST_BUILD_MODE" = "release" ]; then \
-  cargo build --release && \
-  strip target/release/server_bin && \
+  cargo build --release; \
   cp target/release/server_bin /usr/src/app/server_bin; \
   else \
-  cargo build && \
-  strip target/debug/server_bin && \
+  cargo build; \
   cp target/debug/server_bin /usr/src/app/server_bin; \
   fi
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -36,7 +36,7 @@ fn init_sentry(cfg: &SentryConfig) -> Option<sentry::ClientInitGuard> {
         enable_logs: true,
         server_name: Some(Cow::Borrowed("pastepoint-server")),
         traces_sampler: Some(Arc::new(move |ctx| match ctx.name() {
-            "signaling.relay" => 0.01,
+            "signaling.relay" => 0.1,
             name if name.starts_with("GET /ws") => 0.0,
             _ => global_traces_rate,
         })),


### PR DESCRIPTION
#### Docker: Optimize builds
- Remove `--parallel` from docker builds to reduce resource contention.
- Persist Angular build cache to optimize subsequent builds by recompiling only changed files.
- Implement persistent cache for Rust dependencies, speeding up recompilation of the server.
- Improve development and production environment consistency and reliability.


#### Web & Server: Increase trace sampling rate
- Enhance monitoring by increasing `tracesSampleRate` from 0.1 to 0.25.
- Improves trace visibility in both development and production environments.

#### Server: Enhance release build efficiency
- Reduce LLVM codegen time with updated optimization level.
- Enable symbol stripping to minimize binary size.