### PR TITLE
Web: Fix RTL layout and icon mirroring; bump version to 0.21.1

### DIFF
--- a/client/web/package-lock.json
+++ b/client/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "dependencies": {
         "@angular/cdk": "^21.2.9",
         "@angular/common": "^21.2.17",

--- a/client/web/package.json
+++ b/client/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/client/web/src/app/features/chat/chat.component.html
+++ b/client/web/src/app/features/chat/chat.component.html
@@ -163,7 +163,7 @@
       </div>
 
       <!-- toolbar -->
-      <div class="ml-auto flex items-center gap-1">
+      <div class="ms-auto flex items-center gap-1">
         <!-- theme toggle -->
         <button
           type="button"

--- a/client/web/src/app/features/chat/components/chat-input/chat-input.component.css
+++ b/client/web/src/app/features/chat/components/chat-input/chat-input.component.css
@@ -24,6 +24,10 @@
   background-color: #6366f1; /* brandDark */
 }
 
+.chat-send-icon {
+  transform-origin: center;
+}
+
 /* emoji-picker-element — sized and themed to match the app */
 emoji-picker {
   width: 100%;

--- a/client/web/src/app/features/chat/components/chat-input/chat-input.component.html
+++ b/client/web/src/app/features/chat/components/chat-input/chat-input.component.html
@@ -3,6 +3,7 @@
   #messageForm="ngForm"
   (submit)="messageSubmit.emit(messageForm); $event.preventDefault()"
   class="flex w-full"
+  [attr.dir]="isRTL ? 'rtl' : 'ltr'"
 >
   <div class="relative mt-4 mb-0 flex w-full flex-col gap-2">
     <!-- MARK: - Staged Attachments (chips above the input, sent on submit) -->
@@ -55,10 +56,7 @@
     }
 
     <!-- MARK: - Input Row -->
-    <div
-      class="relative flex w-full items-end gap-1.5 md:gap-2"
-      [ngClass]="isRTL ? 'flex-row-reverse' : 'flex-row'"
-    >
+    <div class="relative flex w-full items-end gap-1.5 md:gap-2">
       <!-- MARK: - Attach & Emoji -->
       <div class="flex items-center gap-0.5 md:gap-1">
         <button
@@ -119,6 +117,7 @@
 
       <!-- MARK: - Send -->
       <button
+        type="submit"
         [disabled]="isSendDisabled"
         class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-white bg-brand disabled:opacity-50 disabled:cursor-not-allowed dark:bg-brandDark md:h-9 md:w-9"
         [attr.aria-label]="'SEND' | translate"
@@ -127,8 +126,8 @@
         <img
           [src]="'/icons/send.svg'"
           alt="Send"
-          class="h-4 w-4 md:h-[18px] md:w-[18px]"
-          [class.-scale-x-100]="isRTL"
+          class="chat-send-icon h-4 w-4 md:h-[18px] md:w-[18px]"
+          [style.transform]="isRTL ? 'scaleX(-1)' : null"
           loading="lazy"
           width="18"
           height="18"

--- a/client/web/src/app/features/chat/components/chat-sidebar/chat-sidebar.component.html
+++ b/client/web/src/app/features/chat/components/chat-sidebar/chat-sidebar.component.html
@@ -25,7 +25,7 @@
       <button
         type="button"
         (click)="isMenuOpenChange.emit(false)"
-        class="ml-auto flex h-9 w-9 items-center justify-center rounded-lg text-content transition-colors hover:bg-inputBackground dark:text-white dark:hover:bg-borderDark md:hidden"
+        class="ms-auto flex h-9 w-9 items-center justify-center rounded-lg text-content transition-colors hover:bg-inputBackground dark:text-white dark:hover:bg-borderDark md:hidden"
         aria-label="Close"
         title="Close"
       >
@@ -277,7 +277,7 @@
                   [attr.title]="memberDotTitle(member)"
                 ></div>
                 <p class="truncate text-sm font-expoArabicLight">{{ member }}</p>
-                <div class="ml-auto">
+                <div class="ms-auto">
                   <button
                     type="button"
                     [disabled]="!isConnectedToMember(member)"
@@ -307,7 +307,7 @@
 
               <!-- Per-member transfers -->
               @if (uploadsForMember(member).length > 0 || downloadsForMember(member).length > 0) {
-                <div class="mt-2 flex flex-col gap-2 pl-[18px]">
+                <div class="mt-2 flex flex-col gap-2 ps-[18px]">
                   @for (upload of uploadsForMember(member); track upload) {
                     <div>
                       <div class="flex items-center gap-2">

--- a/server/config/development.toml
+++ b/server/config/development.toml
@@ -16,8 +16,8 @@ latest = "0.10.0"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]
-minimum = "0.21.0"
-latest = "0.21.0"
+minimum = "0.21.1"
+latest = "0.21.1"
 url = "https://127.0.0.1"
 
 [sentry]

--- a/server/config/docker-dev.toml
+++ b/server/config/docker-dev.toml
@@ -16,8 +16,8 @@ latest = "0.10.0"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]
-minimum = "0.21.0"
-latest = "0.21.0"
+minimum = "0.21.1"
+latest = "0.21.1"
 url = "https://127.0.0.1"
 
 [sentry]

--- a/server/config/production.toml
+++ b/server/config/production.toml
@@ -16,8 +16,8 @@ latest = "0.10.0"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]
-minimum = "0.21.0"
-latest = "0.21.0"
+minimum = "0.21.1"
+latest = "0.21.1"
 url = "https://pastepoint.com"
 
 [sentry]


### PR DESCRIPTION
### Summary

- Apply `dir="rtl"` to the chat input form when in RTL mode.

- Replace directional Tailwind margin/padding classes (`ml-`, `pl-`) with logical equivalents (`ms-`, `ps-`) for automatic RTL support.

- Ensure the send icon mirrors correctly using a CSS transform instead of a conditional class.

- Add an explicit `type="submit"` to the send button.