### PR TITLE
iOS: Set non-exempt encryption status and bump version to 0.10.1

### DIFF
--- a/client/ios/PastePoint.xcodeproj/project.pbxproj
+++ b/client/ios/PastePoint.xcodeproj/project.pbxproj
@@ -452,7 +452,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.10.0;
+				MARKETING_VERSION = 0.10.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pastepoint.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -491,7 +491,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.10.0;
+				MARKETING_VERSION = 0.10.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pastepoint.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/client/ios/PastePoint/Resources/Info.plist
+++ b/client/ios/PastePoint/Resources/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/server/config/development.toml
+++ b/server/config/development.toml
@@ -11,8 +11,8 @@ cors_allowed_origins = "https://127.0.0.1"
 # Client update policy (GET /version). minimum = force floor, latest = soft nudge.
 # Raise these only AFTER the build is live on the store/web, or you soft-brick users.
 [client_version.ios]
-minimum = "0.10.0"
-latest = "0.10.0"
+minimum = "0.10.1"
+latest = "0.10.1"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]

--- a/server/config/docker-dev.toml
+++ b/server/config/docker-dev.toml
@@ -11,8 +11,8 @@ cors_allowed_origins = "https://127.0.0.1"
 # Client update policy (GET /version). minimum = force floor, latest = soft nudge.
 # Raise these only AFTER the build is live on the store/web, or you soft-brick users.
 [client_version.ios]
-minimum = "0.10.0"
-latest = "0.10.0"
+minimum = "0.10.1"
+latest = "0.10.1"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]

--- a/server/config/production.toml
+++ b/server/config/production.toml
@@ -11,8 +11,8 @@ cors_allowed_origins = "https://pastepoint.com"
 # Client update policy (GET /version). minimum = force floor, latest = soft nudge.
 # Raise these only AFTER the build is live on the store/web, or you soft-brick users.
 [client_version.ios]
-minimum = "0.10.0"
-latest = "0.10.0"
+minimum = "0.10.1"
+latest = "0.10.1"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]


### PR DESCRIPTION
### Summary

- Sets ITSAppUsesNonExemptEncryption to false to satisfy App Store Connect export compliance requirements and bypass the manual encryption self-certification prompt during the submission process.