### PR TITLE
iOS: Handle universal links and bump version to 0.10.2

### DIFF
--- a/client/ios/PastePoint.xcodeproj/project.pbxproj
+++ b/client/ios/PastePoint.xcodeproj/project.pbxproj
@@ -452,7 +452,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.10.1;
+				MARKETING_VERSION = 0.10.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pastepoint.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -491,7 +491,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.10.1;
+				MARKETING_VERSION = 0.10.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pastepoint.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/client/ios/PastePoint/App/ContentView+Events.swift
+++ b/client/ios/PastePoint/App/ContentView+Events.swift
@@ -26,6 +26,13 @@ private struct ChatEventHandlers: ViewModifier {
   /// Universal links (`https://pastepoint.com/private/<code>`) join the invited session.
   private func deepLinkHandlers(_ content: some View) -> some View {
     content
+      .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { activity in
+        guard let url = activity.webpageURL else {
+          owner.logger.error("Ignoring universal-link activity without URL")
+          return
+        }
+        owner.handleIncomingURL(url)
+      }
       .onOpenURL { url in
         owner.handleIncomingURL(url)
       }

--- a/server/config/development.toml
+++ b/server/config/development.toml
@@ -11,8 +11,8 @@ cors_allowed_origins = "https://127.0.0.1"
 # Client update policy (GET /version). minimum = force floor, latest = soft nudge.
 # Raise these only AFTER the build is live on the store/web, or you soft-brick users.
 [client_version.ios]
-minimum = "0.10.1"
-latest = "0.10.1"
+minimum = "0.10.2"
+latest = "0.10.2"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]

--- a/server/config/docker-dev.toml
+++ b/server/config/docker-dev.toml
@@ -11,8 +11,8 @@ cors_allowed_origins = "https://127.0.0.1"
 # Client update policy (GET /version). minimum = force floor, latest = soft nudge.
 # Raise these only AFTER the build is live on the store/web, or you soft-brick users.
 [client_version.ios]
-minimum = "0.10.1"
-latest = "0.10.1"
+minimum = "0.10.2"
+latest = "0.10.2"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]

--- a/server/config/production.toml
+++ b/server/config/production.toml
@@ -11,8 +11,8 @@ cors_allowed_origins = "https://pastepoint.com"
 # Client update policy (GET /version). minimum = force floor, latest = soft nudge.
 # Raise these only AFTER the build is live on the store/web, or you soft-brick users.
 [client_version.ios]
-minimum = "0.10.1"
-latest = "0.10.1"
+minimum = "0.10.2"
+latest = "0.10.2"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]


### PR DESCRIPTION
### Summary

- Handle universal links via browsing web user activity
  -  Adds the onContinueUserActivity handler for NSUserActivityTypeBrowsingWeb to ensure universal links are correctly captured, as onOpenURL is used for custom schemes.