### PR TITLE
Update launch splash to wait for WebSocket connection

### DIFF
--- a/client/ios/PastePoint/App/ContentView.swift
+++ b/client/ios/PastePoint/App/ContentView.swift
@@ -10,12 +10,28 @@ import SwiftUI
 
 struct ContentView: View {
   @AppStorage(AppColors.Scheme.storageKey) private var colorSchemeRaw: String = AppColors.Scheme.default
-  @EnvironmentObject var services: AppServices
+
   @Environment(\.scenePhase) var scenePhase
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.isIPad) private var isIPad
 
+  @EnvironmentObject var toast: ToastCenter
+  @EnvironmentObject var services: AppServices
+
   let logger = Logger(label: "ContentView")
+
+  @State private var showSplash = true
+  @State private var splashStart = Date()
+  @State private var splashDismissing = false
+
+  @State var messages: [ChatMessage] = []
+  @State var hasConnectedBefore = false
+  @State var showSettings = false
+  @State var pendingPrivateJoin = false
+  @State var suppressNextConnectToast = false
+
+  private let splashCeiling: Double = 5.0
+  private let splashFloor: Double = 0.6
 
   @ViewBuilder
   private var connectionBanner: some View {
@@ -30,15 +46,6 @@ struct ContentView: View {
     }
   }
 
-  @EnvironmentObject var toast: ToastCenter
-
-  @State var messages: [ChatMessage] = []
-  @State private var showSplash = true
-  @State var hasConnectedBefore = false
-  @State var showSettings = false
-  @State var pendingPrivateJoin = false
-  @State var suppressNextConnectToast = false
-
   private var isPrivateRoom: Bool {
     services.wsService.currentSessionCode != nil
   }
@@ -48,13 +55,17 @@ struct ContentView: View {
       chatScreen.chatEventHandlers(self)
 
       if showSplash {
-        SplashView {
-          withAnimation(.easeOut(duration: 0.4)) {
-            showSplash = false
+        SplashView()
+          .transition(.opacity)
+          .zIndex(1)
+          .onReceive(services.wsService.didConnect) { dismissSplash() }
+          .task {
+            if services.wsService.isConnected { dismissSplash() }
           }
-        }
-        .transition(.opacity)
-        .zIndex(1)
+          .task {
+            try? await Task.sleep(for: .seconds(splashCeiling))
+            dismissSplash()
+          }
       }
     }
     .fullScreenCover(isPresented: forcedUpdatePresented) {
@@ -66,6 +77,22 @@ struct ContentView: View {
       if case let .optional(latest, url) = services.updateService.recommendation {
         UpdateView(kind: .optional, storeURL: url, latest: latest)
       }
+    }
+  }
+
+  // MARK: - Splash dismissal
+
+  private func dismissSplash() {
+    guard showSplash, !splashDismissing else { return }
+    splashDismissing = true
+
+    let remaining = splashFloor - Date().timeIntervalSince(splashStart)
+    guard remaining > 0 else {
+      withAnimation(.easeOut(duration: 0.4)) { showSplash = false }
+      return
+    }
+    DispatchQueue.main.asyncAfter(deadline: .now() + remaining) {
+      withAnimation(.easeOut(duration: 0.4)) { showSplash = false }
     }
   }
 

--- a/client/ios/PastePoint/App/ContentView.swift
+++ b/client/ios/PastePoint/App/ContentView.swift
@@ -31,7 +31,7 @@ struct ContentView: View {
   @State var suppressNextConnectToast = false
 
   private let splashCeiling: Double = 5.0
-  private let splashFloor: Double = 0.6
+  private let splashFloor: Double = 1.4
 
   @ViewBuilder
   private var connectionBanner: some View {

--- a/client/ios/PastePoint/Views/Splash/SplashView.swift
+++ b/client/ios/PastePoint/Views/Splash/SplashView.swift
@@ -6,15 +6,12 @@
 import SwiftUI
 
 struct SplashView: View {
-  var onFinished: () -> Void
-
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-  @State private var logoScale: CGFloat = 1.0
-  @State private var nodesIn = false
+  @State private var devicesIn = false
   @State private var edgeProgress: CGFloat = 0
   @State private var packetVisible = false
-  @State private var packetIndex = 0
+  @State private var packetPhase: CGFloat = 0
 
   /// Fixed dark-navy matching the storyboard scene background (always dark,
   /// independent of system theme).
@@ -25,22 +22,28 @@ struct SplashView: View {
     blue: 0.171_103_149_7,
   )
 
-  private let edgeColor = AppColors.Primary.p300
-  private let nodeColors = [AppColors.Brand.brand, AppColors.Primary.p300]
+  private let iconColor = AppColors.Primary.p300
+  private var edgeGradient: LinearGradient {
+    LinearGradient(
+      colors: [AppColors.Primary.p300.opacity(0.7), AppColors.Brand.brand.opacity(0.7)],
+      startPoint: .leading,
+      endPoint: .trailing,
+    )
+  }
 
-  private let nodeCount = 5
-  private let canvas: CGFloat = 170 // square the mesh lives in
-  private let radius: CGFloat = 62 // ring radius for the nodes
+  private let deviceFont: CGFloat = 44
+  private let wireWidth: CGFloat = 84
+  private let wireHeight: CGFloat = 48
+  private let deviceGap: CGFloat = 16
 
   var body: some View {
     ZStack {
       Self.background
 
       logo
-      mesh
-        .frame(width: canvas, height: canvas)
-        .offset(y: 150)
-        .opacity(nodesIn ? 1 : 0)
+      link
+        .offset(y: 160)
+        .opacity(devicesIn ? 1 : 0)
         .accessibilityHidden(true)
     }
     .ignoresSafeArea()
@@ -54,76 +57,67 @@ struct SplashView: View {
       .resizable()
       .scaledToFit()
       .frame(width: 250, height: 255)
-      .scaleEffect(logoScale)
       .offset(y: -40)
       .accessibilityHidden(true)
   }
 
-  private var mesh: some View {
-    ZStack {
-      edgePath
-        .trim(from: 0, to: edgeProgress)
-        .stroke(edgeColor.opacity(0.45), style: StrokeStyle(lineWidth: 1.2, lineCap: .round))
+  private var link: some View {
+    HStack(spacing: deviceGap) {
+      deviceIcon("iphone")
+        .scaleEffect(devicesIn ? 1 : 0.1)
+        .animation(.spring(response: 0.4, dampingFraction: 0.6), value: devicesIn)
 
-      ForEach(0..<nodeCount, id: \.self) { index in
-        Circle()
-          .fill(nodeColors[index % nodeColors.count])
-          .frame(width: 10, height: 10)
-          .scaleEffect(nodesIn ? 1 : 0.1)
-          .position(point(index))
-          .animation(.spring(response: 0.4, dampingFraction: 0.6).delay(Double(index) * 0.06), value: nodesIn)
+      wire
+
+      deviceIcon("display")
+        .scaleEffect(devicesIn ? 1 : 0.1)
+        .animation(.spring(response: 0.4, dampingFraction: 0.6).delay(0.08), value: devicesIn)
+    }
+  }
+
+  private var wire: some View {
+    ZStack {
+      Path { path in
+        path.move(to: CGPoint(x: 0, y: wireHeight / 2))
+        path.addLine(to: CGPoint(x: wireWidth, y: wireHeight / 2))
       }
+      .trim(from: 0, to: edgeProgress)
+      .stroke(edgeGradient, style: StrokeStyle(lineWidth: 2, lineCap: .round))
 
       Circle()
         .fill(.white)
-        .frame(width: 7, height: 7)
-        .position(point(packetIndex))
+        .frame(width: 8, height: 8)
+        .position(x: packetPhase * wireWidth, y: wireHeight / 2)
         .opacity(packetVisible ? 1 : 0)
     }
+    .frame(width: wireWidth, height: wireHeight)
   }
 
-  private var edgePath: Path {
-    Path { path in
-      for start in 0..<nodeCount {
-        for end in (start + 1)..<nodeCount {
-          path.move(to: point(start))
-          path.addLine(to: point(end))
-        }
-      }
-    }
-  }
-
-  private func point(_ index: Int) -> CGPoint {
-    let center = canvas / 2
-    let angle = (2 * .pi / Double(nodeCount)) * Double(index) - .pi / 2
-    return CGPoint(x: center + radius * cos(angle), y: center + radius * sin(angle))
+  private func deviceIcon(_ name: String) -> some View {
+    Image(systemName: name)
+      .font(.system(size: deviceFont, weight: .regular))
+      .foregroundStyle(iconColor)
   }
 
   // MARK: - Choreography
 
   private func runAnimation() async {
     if reduceMotion {
-      guard await pause(650) else { return }
-      onFinished()
+      devicesIn = true
+      edgeProgress = 1
       return
     }
 
     guard await pause(220) else { return }
-
-    withAnimation(.easeOut(duration: 0.18)) { nodesIn = true }
-    guard await pause(150) else { return }
+    withAnimation(.easeOut(duration: 0.18)) { devicesIn = true }
+    guard await pause(180) else { return }
     withAnimation(.easeInOut(duration: 0.4)) { edgeProgress = 1 }
 
-    guard await pause(220) else { return }
+    guard await pause(300) else { return }
     packetVisible = true
-    for hop in 1...nodeCount {
-      withAnimation(.easeInOut(duration: 0.15)) { packetIndex = hop % nodeCount }
-      guard await pause(150) else { return }
+    withAnimation(.easeInOut(duration: 0.75).repeatForever(autoreverses: true)) {
+      packetPhase = 1
     }
-
-    withAnimation(.easeIn(duration: 0.38)) { logoScale = 1.12 }
-    guard await pause(120) else { return }
-    onFinished()
   }
 
   /// Sleeps for `ms` milliseconds, returning `false` if the task was cancelled
@@ -135,6 +129,6 @@ struct SplashView: View {
 
 #if DEBUG
 #Preview {
-  SplashView {}
+  SplashView()
 }
 #endif

--- a/client/web/src/app/core/components/splash/splash.component.css
+++ b/client/web/src/app/core/components/splash/splash.component.css
@@ -29,114 +29,98 @@
 .splash__logo {
   width: 200px;
   height: auto;
-  transform: scale(1);
-  animation: splash-logo 0.6s ease-in 1.25s forwards;
 }
 
-.splash__mesh {
-  margin-top: 10px;
+/* ── Device link ─────────────────────────────────────────────────────────── */
+.splash__link {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: 40px;
 }
 
-.splash__edges {
-  stroke: #7dd3fc;
-  stroke-opacity: 0.45;
-  stroke-width: 1.2;
-  stroke-linecap: round;
-  stroke-dasharray: 1;
-  stroke-dashoffset: 1;
-  animation: splash-edge 0.4s ease-in-out 0.45s forwards;
-}
-
-.splash__node {
-  opacity: 0;
+.splash__device {
+  color: #7dd3fc;
+  flex: none;
   transform: scale(0.1);
-  transform-box: fill-box;
-  transform-origin: center;
-  animation: splash-node 0.42s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+  animation: splash-device 0.42s cubic-bezier(0.34, 1.56, 0.64, 1) 0.2s forwards;
+}
+.splash__device--peer {
+  animation-delay: 0.28s;
+}
+
+.splash__wire {
+  position: relative;
+  width: 84px;
+  height: 50px;
+  flex: none;
+}
+
+.splash__edge {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  transform: translateY(-50%) scaleX(0);
+  transform-origin: left center;
+  border-radius: 2px;
+  background: linear-gradient(90deg, rgba(125, 211, 252, 0.7), rgba(60, 84, 240, 0.7));
+  animation: splash-edge 0.4s ease-in-out 0.55s forwards;
 }
 
 .splash__packet {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 8px;
+  height: 8px;
+  margin-top: -4px;
+  border-radius: 50%;
+  background: #fff;
   opacity: 0;
-  transform-box: view-box;
   animation:
-    splash-packet 0.9s ease 0.7s forwards,
-    splash-packet-move 0.75s linear 0.7s forwards;
+    splash-packet-in 0.2s linear 1s forwards,
+    splash-packet-move 0.75s ease-in-out 1s infinite alternate;
 }
 
-/* Ring waypoints (5-node pentagon, center 85, radius 62 — mirrors buildNodes()). */
-@keyframes splash-packet-move {
-  0% {
-    transform: translate(85px, 23px);
-  }
-  20% {
-    transform: translate(143.96px, 65.84px);
-  }
-  40% {
-    transform: translate(121.45px, 135.16px);
-  }
-  60% {
-    transform: translate(48.55px, 135.16px);
-  }
-  80% {
-    transform: translate(26.04px, 65.84px);
-  }
-  100% {
-    transform: translate(85px, 23px);
-  }
-}
-
-@keyframes splash-edge {
+@keyframes splash-device {
   to {
-    stroke-dashoffset: 0;
-  }
-}
-
-@keyframes splash-node {
-  to {
-    opacity: 1;
     transform: scale(1);
   }
 }
-
-@keyframes splash-logo {
+@keyframes splash-edge {
   to {
-    transform: scale(1.08);
+    transform: translateY(-50%) scaleX(1);
+  }
+}
+@keyframes splash-packet-in {
+  to {
+    opacity: 1;
+  }
+}
+@keyframes splash-packet-move {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(76px);
   }
 }
 
-@keyframes splash-packet {
-  0% {
-    opacity: 0;
-  }
-  12% {
-    opacity: 1;
-  }
-  85% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0;
-  }
-}
-
-/* Reduce-motion: show the formed mesh statically, no packet, no pulse. */
 @media (prefers-reduced-motion: reduce) {
   .splash {
     transition: none;
   }
-  .splash__edges {
+  .splash__device {
     animation: none;
-    stroke-dashoffset: 0;
-  }
-  .splash__node {
-    animation: none;
-    opacity: 1;
     transform: none;
+  }
+  .splash__edge {
+    animation: none;
+    transform: translateY(-50%) scaleX(1);
   }
   .splash__packet {
     display: none;
-  }
-  .splash__logo {
-    animation: none;
   }
 }

--- a/client/web/src/app/core/components/splash/splash.component.html
+++ b/client/web/src/app/core/components/splash/splash.component.html
@@ -1,4 +1,4 @@
-<!-- MARK: - Launch Splash (mesh-forming animation) -->
+<!-- MARK: - Launch Splash -->
 <div class="splash" [class.splash--leaving]="leaving" aria-hidden="true">
   <div class="splash__stage">
     <img
@@ -9,33 +9,26 @@
       height="68"
     />
 
-    <svg
-      class="splash__mesh"
-      viewBox="0 0 170 170"
-      width="170"
-      height="170"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <!-- Full-mesh edges (drawn via stroke-dashoffset; pathLength normalizes the multi-subpath) -->
-      <path class="splash__edges" [attr.d]="edgePath" pathLength="1" />
+    <div class="splash__link">
+      <svg class="splash__device" width="30" height="50" viewBox="0 0 30 50" fill="none">
+        <rect x="1" y="1" width="28" height="48" rx="7" stroke="currentColor" stroke-width="2" />
+        <rect x="11" y="42" width="8" height="2.5" rx="1.25" fill="currentColor" />
+      </svg>
 
-      <!-- Peer nodes pop in around the ring -->
-      @for (node of nodes; track node.i) {
-        <circle
-          class="splash__node"
-          [attr.cx]="node.x"
-          [attr.cy]="node.y"
-          r="5"
-          [attr.fill]="nodeColor(node.i)"
-          [style.animation-delay.ms]="nodeDelay(node.i)"
-        />
-      }
+      <span class="splash__wire">
+        <span class="splash__edge"></span>
+        <span class="splash__packet"></span>
+      </span>
 
-      <!-- Packet runs the ring. CSS transform (not SMIL animateMotion): SMIL
-           `begin` is relative to page load, so when the splash mounts after
-           bootstrap the packet's start time is already past and it never moves. -->
-      <circle class="splash__packet" cx="0" cy="0" r="3.5" fill="#ffffff" />
-    </svg>
+      <svg
+        class="splash__device splash__device--peer"
+        width="52"
+        height="38"
+        viewBox="0 0 52 38"
+        fill="none"
+      >
+        <rect x="1" y="1" width="50" height="36" rx="6" stroke="currentColor" stroke-width="2" />
+      </svg>
+    </div>
   </div>
 </div>

--- a/client/web/src/app/core/components/splash/splash.component.ts
+++ b/client/web/src/app/core/components/splash/splash.component.ts
@@ -9,18 +9,14 @@ import {
   PLATFORM_ID,
   inject,
 } from '@angular/core';
-import { CommonModule, isPlatformBrowser } from '@angular/common';
-
-interface MeshNode {
-  x: number;
-  y: number;
-  i: number;
-}
+import { isPlatformBrowser } from '@angular/common';
+import { Subscription } from 'rxjs';
+import { WebSocketConnectionService } from '../../services/communication/websocket-connection.service';
 
 @Component({
   selector: 'app-splash',
   standalone: true,
-  imports: [CommonModule],
+  imports: [],
   templateUrl: './splash.component.html',
   styleUrl: './splash.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -30,65 +26,56 @@ export class SplashComponent implements OnInit, OnDestroy {
 
   private platformId = inject(PLATFORM_ID);
   private cdr = inject(ChangeDetectorRef);
+  private ws = inject(WebSocketConnectionService);
+
   private timers: ReturnType<typeof setTimeout>[] = [];
+  private sub?: Subscription;
+  private startedAt = 0;
+  private dismissing = false;
+
+  private readonly floorMs = 1400;
+  private readonly ceilingMs = 5000;
 
   protected leaving = false;
-
-  // 5-node ring (pentagon) in a 170×170 canvas, radius 62.
-  protected readonly nodes: MeshNode[] = this.buildNodes();
-  protected readonly edgePath: string = this.buildEdgePath();
 
   ngOnInit(): void {
     if (!isPlatformBrowser(this.platformId)) {
       return;
     }
 
-    const reduce = window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches ?? false;
-    const hold = reduce ? 650 : 1700;
+    this.startedAt = Date.now();
 
-    this.timers.push(
-      setTimeout(() => {
-        this.leaving = true;
-        this.cdr.markForCheck();
-        this.timers.push(setTimeout(() => this.finished.emit(), 400));
-      }, hold)
-    );
+    if (this.ws.isConnected()) {
+      this.dismiss();
+    } else {
+      this.sub = this.ws.connected$.subscribe(() => this.dismiss());
+    }
+
+    this.timers.push(setTimeout(() => this.dismiss(), this.ceilingMs));
   }
 
   ngOnDestroy(): void {
     this.timers.forEach((t) => clearTimeout(t));
+    this.sub?.unsubscribe();
   }
 
-  protected nodeColor(i: number): string {
-    return i % 2 === 0 ? '#3c54f0' : '#7dd3fc';
-  }
-
-  protected nodeDelay(i: number): number {
-    return 220 + i * 60;
-  }
-
-  private buildNodes(): MeshNode[] {
-    const count = 5;
-    const center = 85;
-    const radius = 62;
-    return Array.from({ length: count }, (_, i) => {
-      const angle = ((2 * Math.PI) / count) * i - Math.PI / 2;
-      return { x: center + radius * Math.cos(angle), y: center + radius * Math.sin(angle), i };
-    });
-  }
-
-  /** All node-pair segments as one multi-subpath (drawn together via stroke-dashoffset). */
-  private buildEdgePath(): string {
-    const parts: string[] = [];
-    for (let s = 0; s < this.nodes.length; s++) {
-      for (let t = s + 1; t < this.nodes.length; t++) {
-        parts.push(`M${this.fmt(this.nodes[s])}L${this.fmt(this.nodes[t])}`);
-      }
+  private dismiss(): void {
+    if (this.dismissing) {
+      return;
     }
-    return parts.join('');
-  }
+    this.dismissing = true;
 
-  private fmt(node: MeshNode): string {
-    return `${node.x.toFixed(2)} ${node.y.toFixed(2)}`;
+    const run = (): void => {
+      this.leaving = true;
+      this.cdr.markForCheck();
+      this.timers.push(setTimeout(() => this.finished.emit(), 400));
+    };
+
+    const remaining = this.floorMs - (Date.now() - this.startedAt);
+    if (remaining <= 0) {
+      run();
+    } else {
+      this.timers.push(setTimeout(run, remaining));
+    }
   }
 }

--- a/client/web/src/app/core/services/communication/websocket-connection.service.ts
+++ b/client/web/src/app/core/services/communication/websocket-connection.service.ts
@@ -58,6 +58,10 @@ export class WebSocketConnectionService implements OnDestroy {
    *  to this to refresh stale state (e.g. username) without polling. */
   public reconnected$ = new Subject<void>();
 
+  /** Fires on every successful socket open (initial connect and reconnects).
+   *  The launch splash waits on this to dismiss once we're online. */
+  public connected$ = new Subject<void>();
+
   /** Live reconnect status (attempt # and when the next try fires), or `null`
    *  when connected / not retrying. Drives the server-reconnect banner. */
   public reconnectState$ = new BehaviorSubject<{ attempt: number; nextAttemptAt: number } | null>(
@@ -217,6 +221,7 @@ export class WebSocketConnectionService implements OnDestroy {
       socket.onopen = () => {
         if (socket !== this.socket) return;
         this.logger.info('connect', 'WebSocket connected');
+        this.connected$.next();
         if (this.reconnectAttempts > 0) {
           this.reconnected$.next();
         }


### PR DESCRIPTION
### Summary
Updates the launch splash on web and iOS so it stays visible until the app has connected to the signaling WebSocket, with a short minimum display time and a 5-second fallback ceiling. The visual animation also changes from the mesh motif to a device-link animation that better matches PastePoint’s peer-to-peer connection flow.

### What changed

**Web**
- Gate splash dismissal on the first successful WebSocket connection.
- Add a `connected$` signal from `WebSocketConnectionService` for initial connects and reconnects.
- Keep the splash visible for at least `1.4s`, then fade it once connected.
- Add a `5s` ceiling so the app can continue if the socket is slow or unavailable.
- Replace the old mesh SVG animation with a phone-to-display link animation.
- Preserve reduced-motion behavior by showing the formed connection state without packet animation.

**iOS**
- Gate splash dismissal on `wsService.didConnect`.
- Dismiss immediately if the WebSocket is already connected, while still respecting the minimum duration.
- Extend the minimum splash duration from `0.6s` to `1.4s`.
- Add the same `5s` fallback ceiling as web.
- Replace the mesh animation with a native SwiftUI device-link animation.
- Remove the splash’s self-finishing callback so `ContentView` owns connection-aware dismissal.

**Behavior**
- Splash exits after both conditions are satisfied:
  - minimum duration elapsed
  - WebSocket connected
- If connection does not arrive, splash exits after `5s`.