### PR TITLE
iOS: Link settings footer social icons to their profiles

### DIFF
--- a/client/ios/PastePoint/Views/Settings/Sections/SettingsFooterView.swift
+++ b/client/ios/PastePoint/Views/Settings/Sections/SettingsFooterView.swift
@@ -6,32 +6,52 @@
 import SwiftUI
 
 struct SettingsFooterView: View {
-  @Binding var privacyURLToShow: IdentifiableURL?
+  @Binding var safariURL: IdentifiableURL?
 
-  private func socialIcon(_ name: String) -> some View {
-    Image(name)
-      .renderingMode(.template)
-      .resizable()
-      .scaledToFit()
-      .frame(width: 16, height: 16)
-      .foregroundStyle(.textSecondary)
+  private struct SocialLink {
+    let icon: String
+    let name: String
+    let url: URL
+  }
+
+  private var socialLinks: [SocialLink] {
+    [
+      ("linkedin", "LinkedIn", "https://www.linkedin.com/in/sulaiman-alromaih-845700202/"),
+      ("github", "GitHub", "https://github.com/SloMR/pastepoint"),
+      ("x", "X", "https://x.com/PastePoint"),
+      ("instagram", "Instagram", "https://www.instagram.com/paste_point/"),
+    ].compactMap { icon, name, urlString in
+      URL(string: urlString).map { SocialLink(icon: icon, name: name, url: $0) }
+    }
+  }
+
+  private func socialLink(_ link: SocialLink) -> some View {
+    Button {
+      safariURL = IdentifiableURL(url: link.url)
+    } label: {
+      Image(link.icon)
+        .renderingMode(.template)
+        .resizable()
+        .scaledToFit()
+        .frame(width: 16, height: 16)
+        .foregroundStyle(.textSecondary)
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel(Text(verbatim: link.name))
   }
 
   var body: some View {
     VStack(spacing: 10) {
       // Social links
       HStack(alignment: .center, spacing: 20) {
-        socialIcon("linkedin")
-        socialIcon("github")
-        socialIcon("x")
-        socialIcon("instagram")
+        ForEach(socialLinks, id: \.icon) { socialLink($0) }
       }
 
       // privacy · version
       HStack(spacing: 6) {
         Button {
           if let url = URL(string: AppEnvironment.legalUrl) {
-            privacyURLToShow = IdentifiableURL(url: url)
+            safariURL = IdentifiableURL(url: url)
           }
         } label: {
           Text(.privacyAndTerms)
@@ -54,7 +74,7 @@ struct SettingsFooterView: View {
         .foregroundColor(.textSecondary)
         .multilineTextAlignment(.center)
     }
-    .sheet(item: $privacyURLToShow) { identifiableURL in
+    .sheet(item: $safariURL) { identifiableURL in
       SafariView(url: identifiableURL.url)
     }
   }

--- a/client/ios/PastePoint/Views/Settings/SettingsView.swift
+++ b/client/ios/PastePoint/Views/Settings/SettingsView.swift
@@ -17,7 +17,7 @@ struct SettingsView: View {
 
   @State private var isLeaveSessionSheetPresented: Bool = false
   @State private var isJoinRoomSheetPresented: Bool = false
-  @State private var privacyURLToShow: IdentifiableURL?
+  @State private var safariURL: IdentifiableURL?
 
   private var avatar: some View {
     Image(ChatAvatar.selfImageName)
@@ -124,7 +124,7 @@ struct SettingsView: View {
       Divider()
         .padding()
 
-      SettingsFooterView(privacyURLToShow: $privacyURLToShow)
+      SettingsFooterView(safariURL: $safariURL)
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(AppColors.Background.surface)


### PR DESCRIPTION
#### Summary

- Make the LinkedIn, GitHub, X and Instagram footer icons open their profile URLs in the shared in-app `SafariView`, matching the Privacy & Terms link; previously they were inert `Image`s

- Rename the `privacyURLToShow` binding to `safariURL` in `SettingsFooterView` and `SettingsView` now that it drives the SafariView sheet for both the legal link and the socials