### PR TITLE
iOS: Prevent UI stalls during connection cleanup and attachment rendering

### DIFF
--- a/client/ios/PastePoint/Core/Services/WebRTC/SignalingService.swift
+++ b/client/ios/PastePoint/Core/Services/WebRTC/SignalingService.swift
@@ -499,10 +499,17 @@ extension SignalingService {
       outboundSequences[peer] = nil
       inboundSequences[peer] = nil
     }
-    dataChannels[peer]?.close()
-    dataChannels[peer] = nil
-    peerConnections[peer]?.close()
-    peerConnections[peer] = nil
+
+    let dataChannel = dataChannels.removeValue(forKey: peer)
+    let peerConnection = peerConnections.removeValue(forKey: peer)
+    if dataChannel != nil || peerConnection != nil {
+      let closing = UnsafeSendable(value: (dataChannel, peerConnection))
+      Task.detached {
+        closing.value.0?.close()
+        closing.value.1?.close()
+      }
+    }
+
     candidateQueues[peer] = nil
     collectedCandidates[peer] = nil
     connectionLocks.remove(peer)

--- a/client/ios/PastePoint/Resources/Localization/Localizable.xcstrings
+++ b/client/ios/PastePoint/Resources/Localization/Localizable.xcstrings
@@ -2605,6 +2605,48 @@
         }
       }
     },
+    "LEAVING" : {
+      "comment" : "Button label while a private session is being left.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "جارٍ المغادرة…"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leaving…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saliendo…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Déconnexion…"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выход…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "退出中…"
+          }
+        }
+      }
+    },
     "LEFT_PRIVATE_SESSION" : {
       "comment" : "Toast: the user left a private session.",
       "extractionState" : "manual",

--- a/client/ios/PastePoint/Views/Chat/Components/ChatMessageBubble.swift
+++ b/client/ios/PastePoint/Views/Chat/Components/ChatMessageBubble.swift
@@ -105,16 +105,63 @@ struct ChatMessageBubble: View {
       .fixedSize(horizontal: false, vertical: true)
   }
 
-  private func attachmentBody(transfer: FileTransferData) -> some View {
-    VStack(alignment: .leading, spacing: 8) {
+  private var previewSlot: some View {
+    Group {
       if let previewImage {
         Image(uiImage: previewImage)
           .resizable()
           .scaledToFit()
-          .frame(maxWidth: bubbleMaxWidth - 24, maxHeight: 220)
-          .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-          .allowsHitTesting(false)
+      } else {
+        Image(systemName: "doc")
+          .resizable()
+          .scaledToFit()
+          .opacity(0.5)
+          .padding(50)
       }
+    }
+    .frame(maxWidth: bubbleMaxWidth - 24, maxHeight: 220)
+    .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    .allowsHitTesting(false)
+  }
+
+  @ViewBuilder
+  private func attachmentStatus(_ transfer: FileTransferData) -> some View {
+    if transfer.status == .pending, onAccept != nil, onDecline != nil {
+      HStack(spacing: 8) {
+        Button(.accept) {
+          onAccept?()
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.small)
+        Button(.decline, role: .destructive) {
+          onDecline?()
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+      }
+    } else if alignment == .leading {
+      if transfer.status == .completed {
+        Label(
+          transfer.fileURL == nil ? .savedToPhotos : .savedToFiles,
+          systemImage: "checkmark.circle",
+        )
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+      } else {
+        Text(statusLabel(transfer.status))
+          .font(.caption2)
+          .foregroundStyle(.secondary)
+      }
+    } else if alignment == .trailing {
+      Text(outgoingStatusLabel(transfer))
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+    }
+  }
+
+  private func attachmentBody(transfer: FileTransferData) -> some View {
+    VStack(alignment: .leading, spacing: 8) {
+      previewSlot
 
       HStack(spacing: 8) {
         Image(systemName: "doc")
@@ -131,37 +178,7 @@ struct ChatMessageBubble: View {
         }
       }
 
-      if transfer.status == .pending, onAccept != nil, onDecline != nil {
-        HStack(spacing: 8) {
-          Button(.accept) {
-            onAccept?()
-          }
-          .buttonStyle(.borderedProminent)
-          .controlSize(.small)
-          Button(.decline, role: .destructive) {
-            onDecline?()
-          }
-          .buttonStyle(.bordered)
-          .controlSize(.small)
-        }
-      } else if alignment == .leading {
-        if transfer.status == .completed {
-          Label(
-            transfer.fileURL == nil ? .savedToPhotos : .savedToFiles,
-            systemImage: "checkmark.circle",
-          )
-          .font(.caption2)
-          .foregroundStyle(.secondary)
-        } else {
-          Text(statusLabel(transfer.status))
-            .font(.caption2)
-            .foregroundStyle(.secondary)
-        }
-      } else if alignment == .trailing {
-        Text(outgoingStatusLabel(transfer))
-          .font(.caption2)
-          .foregroundStyle(.secondary)
-      }
+      attachmentStatus(transfer)
     }
     .task(id: transfer.previewDataUrl) {
       let dataUrl = transfer.previewDataUrl

--- a/client/ios/PastePoint/Views/Chat/Components/ChatMessageBubble.swift
+++ b/client/ios/PastePoint/Views/Chat/Components/ChatMessageBubble.swift
@@ -164,7 +164,9 @@ struct ChatMessageBubble: View {
       }
     }
     .task(id: transfer.previewDataUrl) {
-      previewImage = Self.decodePreview(transfer.previewDataUrl)
+      let dataUrl = transfer.previewDataUrl
+      let data = await Task.detached { Self.decodePreviewData(dataUrl) }.value
+      previewImage = data.flatMap { UIImage(data: $0) }
     }
     .foregroundStyle(alignment == .trailing ? .textPrimary : .white)
     .padding(.horizontal, 12)
@@ -185,7 +187,7 @@ struct ChatMessageBubble: View {
     ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
   }
 
-  private static func decodePreview(_ dataUrl: String?) -> UIImage? {
+  private nonisolated static func decodePreviewData(_ dataUrl: String?) -> Data? {
     guard
       let dataUrl,
       let comma = dataUrl.firstIndex(of: ","),
@@ -194,7 +196,7 @@ struct ChatMessageBubble: View {
       return nil
     }
 
-    return UIImage(data: data)
+    return data
   }
 
   private func statusLabel(_ status: FileTransferStatus) -> LocalizedStringResource {

--- a/client/ios/PastePoint/Views/Settings/Sheets/SettingsLeaveSessionView.swift
+++ b/client/ios/PastePoint/Views/Settings/Sheets/SettingsLeaveSessionView.swift
@@ -14,6 +14,8 @@ struct SettingsLeaveSessionView: View {
 
   var onSessionLeft: (() -> Void)?
 
+  @State private var isLeaving = false
+
   var body: some View {
     VStack(spacing: 20) {
       Text(.endSessionHeader)
@@ -24,21 +26,20 @@ struct SettingsLeaveSessionView: View {
 
       HStack(spacing: 12) {
         Button {
-          logger.info("User confirmed leaving private session")
-          services.wsService.disconnect(manual: true)
-          Task {
-            if await services.connectIfPermitted(sessionCode: nil) {
-              await services.roomService.listRooms()
-              await services.userService.getUsername()
-            }
-            logger.info("Left private session")
-            dismiss()
-            onSessionLeft?()
-          }
+          Task { await leaveSession() }
         } label: {
-          Text(.endTheSession)
+          HStack(spacing: 8) {
+            if isLeaving {
+              ProgressView()
+                .progressViewStyle(.circular)
+                .tint(.white)
+                .scaleEffect(0.85)
+            }
+            Text(isLeaving ? .leaving : .endTheSession)
+          }
         }
         .buttonStyle(.pill(tint: .red))
+        .disabled(isLeaving)
 
         Button {
           logger.info("Dismiss Leave Session view")
@@ -47,10 +48,25 @@ struct SettingsLeaveSessionView: View {
           Text(.cancel)
         }
         .buttonStyle(.pill(.outlined, tint: .red))
+        .disabled(isLeaving)
       }
     }
     .padding(24)
     .sheetContainer(title: .endSession)
+  }
+
+  private func leaveSession() async {
+    logger.info("User confirmed leaving private session")
+    isLeaving = true
+    services.wsService.disconnect(manual: true)
+    if await services.connectIfPermitted(sessionCode: nil) {
+      await services.roomService.listRooms()
+      await services.userService.getUsername()
+    }
+    isLeaving = false
+    logger.info("Left private session")
+    dismiss()
+    onSessionLeft?()
   }
 }
 

--- a/client/ios/PastePoint/Views/Settings/Sheets/SettingsQRCodeView.swift
+++ b/client/ios/PastePoint/Views/Settings/Sheets/SettingsQRCodeView.swift
@@ -11,19 +11,24 @@ struct QRCodeView: View {
   let text: String
   let size: CGFloat
 
-  private let context = CIContext()
+  @State private var qrImage: UIImage?
 
   var body: some View {
-    if let image = generateQRCode(from: text) {
-      Image(uiImage: image)
-        .interpolation(.none)
-        .resizable()
-        .scaledToFit()
-        .frame(width: size, height: size)
+    Group {
+      if let qrImage {
+        Image(uiImage: qrImage)
+          .interpolation(.none)
+          .resizable()
+          .scaledToFit()
+          .frame(width: size, height: size)
+      } else {
+        Color.clear.frame(width: size, height: size)
+      }
     }
+    .task(id: text) { qrImage = Self.generateQRCode(from: text) }
   }
 
-  private func generateQRCode(from text: String) -> UIImage? {
+  private static func generateQRCode(from text: String) -> UIImage? {
     let filter = CIFilter.qrCodeGenerator()
 
     filter.message = Data(text.utf8)
@@ -31,7 +36,7 @@ struct QRCodeView: View {
 
     guard
       let outputImage = filter.outputImage,
-      let cgImage = context.createCGImage(outputImage, from: outputImage.extent)
+      let cgImage = CIContext().createCGImage(outputImage, from: outputImage.extent)
     else { return nil }
 
     return UIImage(cgImage: cgImage)


### PR DESCRIPTION
### Summary

Improve iOS responsiveness by moving expensive connection and attachment work off the main actor, while adding clearer loading and fallback states.

### What changed

#### Performance and stability

- Close WebRTC peer connections and data channels in a detached task
- Decode attachment preview data off the main actor
- Generate session QR codes once per session code instead of during every render

#### UI improvements

- Show a default file icon when an attachment preview is unavailable
- Display a localized “Leaving…” spinner while leaving a private session
- Disable leave and cancel actions while the session transition is in progress