### PR TITLE
iOS: Request Local Network permission on first launch

### DIFF
--- a/client/ios/PastePoint/App/PastePointApp.swift
+++ b/client/ios/PastePoint/App/PastePointApp.swift
@@ -10,6 +10,7 @@ import UIKit
 struct PastePointApp: App {
   @Environment(\.scenePhase) private var phase
   @AppStorage(AppColors.Scheme.storageKey) private var colorSchemeRaw: String = AppColors.Scheme.default
+  @State private var didRequestLocalNetwork = false
 
   @StateObject private var services = AppServices.shared
   @StateObject private var toast = ToastCenter()
@@ -39,6 +40,10 @@ struct PastePointApp: App {
       switch newPhase {
 
       case .active:
+        if !didRequestLocalNetwork {
+          didRequestLocalNetwork = true
+          LocalNetworkPermission.requestAccess()
+        }
         Task { await services.handleForeground() }
         Task { await services.updateService.check() }
 

--- a/client/ios/PastePoint/Core/Permissions/LocalNetworkPermission.swift
+++ b/client/ios/PastePoint/Core/Permissions/LocalNetworkPermission.swift
@@ -11,6 +11,19 @@ import os
 enum LocalNetworkPermission {
   private static let logger = Logger(label: "LocalNetworkPermission")
 
+  @MainActor
+  static func requestAccess() {
+    logger.info("Requesting local network permission")
+    let browser = NWBrowser(for: .bonjour(type: "_http._tcp", domain: nil), using: NWParameters())
+    browser.stateUpdateHandler = { _ in }
+    browser.start(queue: .main)
+
+    Task { @MainActor in
+      try? await Task.sleep(for: .seconds(2))
+      browser.cancel()
+    }
+  }
+
   static func isDenied() async -> Bool {
     logger.info("Checking local network permission")
 

--- a/client/ios/PastePoint/Core/Permissions/LocalNetworkPermission.swift
+++ b/client/ios/PastePoint/Core/Permissions/LocalNetworkPermission.swift
@@ -14,7 +14,7 @@ enum LocalNetworkPermission {
   @MainActor
   static func requestAccess() {
     logger.info("Requesting local network permission")
-    let browser = NWBrowser(for: .bonjour(type: "_http._tcp", domain: nil), using: NWParameters())
+    let browser = NWBrowser(for: .bonjour(type: "_pastepoint._tcp", domain: nil), using: NWParameters())
     browser.stateUpdateHandler = { _ in }
     browser.start(queue: .main)
 

--- a/client/ios/PastePoint/Resources/Info.plist
+++ b/client/ios/PastePoint/Resources/Info.plist
@@ -28,7 +28,7 @@
 	<true/>
 	<key>NSBonjourServices</key>
 	<array>
-		<string>_http._tcp</string>
+		<string>_pastepoint._tcp</string>
 	</array>
 	<key>NSCameraUsageDescription</key>
 	<string>PastePoint uses the camera to scan QR codes for joining private sessions.</string>


### PR DESCRIPTION
### Summary

Prompt users for Local Network access when the iOS app first becomes active, ensuring permission is resolved before network-dependent features are used.

### What changed

- Trigger the Local Network permission request during the app’s initial active phase
- Use an `NWBrowser` Bonjour probe to display the system permission prompt
- Cancel the temporary browser after the permission request is initiated
- Register a dedicated `_pastepoint._tcp` Bonjour service type
- Prevent duplicate permission requests during the same app session