### PR TITLE
iOS: Add session-scoped user blocking across chat and peer connections

### DIFF
--- a/client/ios/PastePoint/App/ContentView+Handlers.swift
+++ b/client/ios/PastePoint/App/ContentView+Handlers.swift
@@ -144,6 +144,16 @@ extension ContentView {
     messages[idx].fileTransfer?.previewMime = previewMime
   }
 
+  func blockPeer(_ peer: String) {
+    guard !peer.isEmpty else { return }
+
+    services.blockService.block(peer)
+    messages.removeAll { !$0.isMine && $0.from == peer }
+
+    haptic(.success)
+    toast.show(.success(.blockedUserToast(peer)))
+  }
+
   func peerWarning() -> ToastItem {
     // Peers are in the room but no data channel is open yet still (re)connecting.
     if !services.peerDirectory.peers.isEmpty {

--- a/client/ios/PastePoint/App/ContentView.swift
+++ b/client/ios/PastePoint/App/ContentView.swift
@@ -138,6 +138,7 @@ struct ContentView: View {
           messages: messages,
           onAcceptFile: handleAcceptFile,
           onDeclineFile: handleDeclineFile,
+          onBlock: blockPeer,
         )
         .simultaneousGesture(
           TapGesture().onEnded {

--- a/client/ios/PastePoint/App/ContentView.swift
+++ b/client/ios/PastePoint/App/ContentView.swift
@@ -209,10 +209,13 @@ struct ContentView: View {
     .preferredColorScheme(AppColors.Scheme.colorScheme(from: colorSchemeRaw))
     .sheet(isPresented: settingsSheetPresented) {
       NavigationStack {
-        SettingsView {
-          showSettings = false
-          pendingPrivateJoin = true
-        }
+        SettingsView(
+          onSessionJoin: {
+            showSettings = false
+            pendingPrivateJoin = true
+          },
+          onBlock: blockPeer,
+        )
       }
     }
   }
@@ -243,6 +246,7 @@ struct ContentView: View {
             setSettingsVisible(false)
             pendingPrivateJoin = true
           },
+          onBlock: blockPeer,
         )
       }
       .frame(width: 320)

--- a/client/ios/PastePoint/Core/Services/App/AppServices.swift
+++ b/client/ios/PastePoint/Core/Services/App/AppServices.swift
@@ -16,11 +16,16 @@ final class AppServices: ObservableObject {
 
   let wsService: WebSocketConnectionService
   let sessionService: SessionService
+
   let userService: UserService
   let signalingService: SignalingService
+
   let roomService: RoomService
+  let blockService: BlockService
+
   let peerDirectory: PeerDirectory
   let fileTransferService: FileTransferService
+
   let connectionWarningMonitor: ConnectionWarningMonitor
   let updateService: AppUpdateService
 
@@ -37,19 +42,31 @@ final class AppServices: ObservableObject {
   private init() {
     wsService = WebSocketConnectionService()
     sessionService = SessionService()
+
     userService = UserService(wsService: wsService)
     roomService = RoomService(wsService: wsService)
-    peerDirectory = PeerDirectory(roomService: roomService, userService: userService)
-    signalingService = SignalingService(wsService: wsService, userService: userService, peerDirectory: peerDirectory)
+
+    blockService = BlockService(wsService: wsService)
+
+    peerDirectory = PeerDirectory(roomService: roomService, userService: userService, blockService: blockService)
+    signalingService = SignalingService(
+      wsService: wsService,
+      userService: userService,
+      peerDirectory: peerDirectory,
+      blockService: blockService,
+    )
+
     fileTransferService = FileTransferService(
       signalingService: signalingService,
       userService: userService,
       peerDirectory: peerDirectory,
     )
+
     connectionWarningMonitor = ConnectionWarningMonitor(
       peerDirectory: peerDirectory,
       signalingService: signalingService,
     )
+
     updateService = AppUpdateService()
 
 #if DEBUG
@@ -69,19 +86,31 @@ final class AppServices: ObservableObject {
   private init(preview _: Bool) {
     wsService = WebSocketConnectionService()
     sessionService = SessionService()
+
     userService = UserService(wsService: wsService)
     roomService = RoomService(wsService: wsService)
-    peerDirectory = PeerDirectory(roomService: roomService, userService: userService)
-    signalingService = SignalingService(wsService: wsService, userService: userService, peerDirectory: peerDirectory)
+
+    blockService = BlockService(wsService: wsService)
+    peerDirectory = PeerDirectory(roomService: roomService, userService: userService, blockService: blockService)
+
+    signalingService = SignalingService(
+      wsService: wsService,
+      userService: userService,
+      peerDirectory: peerDirectory,
+      blockService: blockService,
+    )
+
     fileTransferService = FileTransferService(
       signalingService: signalingService,
       userService: userService,
       peerDirectory: peerDirectory,
     )
+
     connectionWarningMonitor = ConnectionWarningMonitor(
       peerDirectory: peerDirectory,
       signalingService: signalingService,
     )
+
     updateService = AppUpdateService()
 
     forwardServiceChanges()
@@ -189,21 +218,31 @@ final class AppServices: ObservableObject {
     wsService.objectWillChange
       .sink { [weak self] _ in self?.objectWillChange.send() }
       .store(in: &cancellables)
+
     userService.objectWillChange
       .sink { [weak self] _ in self?.objectWillChange.send() }
       .store(in: &cancellables)
+
     roomService.objectWillChange
       .sink { [weak self] _ in self?.objectWillChange.send() }
       .store(in: &cancellables)
+
+    blockService.objectWillChange
+      .sink { [weak self] _ in self?.objectWillChange.send() }
+      .store(in: &cancellables)
+
     signalingService.objectWillChange
       .sink { [weak self] _ in self?.objectWillChange.send() }
       .store(in: &cancellables)
+
     fileTransferService.objectWillChange
       .sink { [weak self] _ in self?.objectWillChange.send() }
       .store(in: &cancellables)
+
     connectionWarningMonitor.objectWillChange
       .sink { [weak self] _ in self?.objectWillChange.send() }
       .store(in: &cancellables)
+
     updateService.objectWillChange
       .sink { [weak self] _ in self?.objectWillChange.send() }
       .store(in: &cancellables)

--- a/client/ios/PastePoint/Core/Services/Moderation/BlockService.swift
+++ b/client/ios/PastePoint/Core/Services/Moderation/BlockService.swift
@@ -1,0 +1,49 @@
+//
+//  Copyright © 2026 PastePoint. All rights reserved.
+//  SPDX-License-Identifier: GPL-3.0-only
+//
+
+import Combine
+import Foundation
+import Logging
+
+@MainActor
+final class BlockService: ObservableObject {
+  private let logger = Logger(label: "Block")
+
+  @Published private(set) var blockedPeers: Set<String> = []
+
+  private var cancellables = Set<AnyCancellable>()
+
+  init(wsService: WebSocketConnectionService) {
+    wsService.$isConnected
+      .receive(on: DispatchQueue.main)
+      .sink { [weak self] connected in
+        if !connected { self?.clear() }
+      }
+      .store(in: &cancellables)
+  }
+
+  func block(_ peer: String) {
+    guard !peer.isEmpty else { return }
+
+    logger.info("blocking peer \(peer)")
+    blockedPeers.insert(peer)
+  }
+
+  func unblock(_ peer: String) {
+    logger.info("unblocking peer \(peer)")
+    blockedPeers.remove(peer)
+  }
+
+  func isBlocked(_ peer: String) -> Bool {
+    blockedPeers.contains(peer)
+  }
+
+  private func clear() {
+    guard !blockedPeers.isEmpty else { return }
+
+    logger.debug("clearing blocks — identities are reassigned on reconnect")
+    blockedPeers.removeAll()
+  }
+}

--- a/client/ios/PastePoint/Core/Services/Room/PeerDirectory.swift
+++ b/client/ios/PastePoint/Core/Services/Room/PeerDirectory.swift
@@ -11,11 +11,11 @@ final class PeerDirectory: ObservableObject {
   @Published private(set) var peers: [String] = []
   private var cancellables: Set<AnyCancellable> = []
 
-  init(roomService: RoomService, userService: UserService) {
+  init(roomService: RoomService, userService: UserService, blockService: BlockService) {
     roomService.$members
-      .combineLatest(userService.$user)
-      .map { members, user in
-        members.filter { $0 != user && !user.isEmpty }.sorted()
+      .combineLatest(userService.$user, blockService.$blockedPeers)
+      .map { members, user, blocked in
+        members.filter { $0 != user && !user.isEmpty && !blocked.contains($0) }.sorted()
       }
       .removeDuplicates()
       .receive(on: DispatchQueue.main)

--- a/client/ios/PastePoint/Core/Services/WebRTC/SignalingService.swift
+++ b/client/ios/PastePoint/Core/Services/WebRTC/SignalingService.swift
@@ -36,6 +36,7 @@ final class SignalingService: NSObject, ObservableObject {
   private let wsService: WebSocketConnectionService
   private let userService: UserService
   private let peerDirectory: PeerDirectory
+  private let blockService: BlockService
   private var cancellables: Set<AnyCancellable> = []
 
   private static let connectionTimeout: TimeInterval = 8.0 // Seconds
@@ -59,10 +60,16 @@ final class SignalingService: NSObject, ObservableObject {
 
   // MARK: - Init
 
-  init(wsService: WebSocketConnectionService, userService: UserService, peerDirectory: PeerDirectory) {
+  init(
+    wsService: WebSocketConnectionService,
+    userService: UserService,
+    peerDirectory: PeerDirectory,
+    blockService: BlockService,
+  ) {
     self.wsService = wsService
     self.userService = userService
     self.peerDirectory = peerDirectory
+    self.blockService = blockService
     super.init()
 
     wsService.signalMessage
@@ -227,6 +234,11 @@ extension SignalingService {
   private func handle(_ message: SignalMessage) {
     guard !message.from.isEmpty else {
       logger.warning("ignoring message with empty 'from'")
+      return
+    }
+
+    guard !blockService.isBlocked(message.from) else {
+      logger.info("ignoring \(message.payload.typeString) from blocked peer \(message.from)")
       return
     }
 
@@ -789,6 +801,11 @@ extension SignalingService: RTCDataChannelDelegate {
   }
 
   private func route(_ decoded: DataChannelMessage.Decoded, from peer: String) {
+    guard !blockService.isBlocked(peer) else {
+      logger.info("dropping data-channel message from blocked peer \(peer)")
+      return
+    }
+
     switch decoded {
     case .chat(let msg): chatMessages.send(msg)
     case .fileOffer(let payload): fileEvent.send(.offer(payload, from: peer))

--- a/client/ios/PastePoint/Resources/Localization/Localizable.xcstrings
+++ b/client/ios/PastePoint/Resources/Localization/Localizable.xcstrings
@@ -127,6 +127,90 @@
         }
       }
     },
+    "BLOCK_USER" : {
+      "comment" : "Action: block a member from the members list.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حظر"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Block"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bloquear"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bloquer"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Заблокировать"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "屏蔽"
+          }
+        }
+      }
+    },
+    "BLOCKED_USER_TOAST" : {
+      "comment" : "Toast shown after blocking a user. %@ is the blocked username.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تم حظر %@. تمت إزالة رسائله."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blocked %@. Their messages were removed."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Has bloqueado a %@. Se han eliminado sus mensajes."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ a été bloqué. Ses messages ont été supprimés."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пользователь %@ заблокирован. Его сообщения удалены."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已屏蔽 %@。其消息已被移除。"
+          }
+        }
+      }
+    },
     "CAMERA_ACCESS_MESSAGE" : {
       "comment" : "Message shown when camera permission is denied.",
       "extractionState" : "manual",

--- a/client/ios/PastePoint/Views/Chat/ChatContainerView.swift
+++ b/client/ios/PastePoint/Views/Chat/ChatContainerView.swift
@@ -9,6 +9,7 @@ struct ChatContainerView: View {
   let messages: [ChatMessage]
   let onAcceptFile: (_ fromUser: String, _ fileId: String) -> Void
   let onDeclineFile: (_ fromUser: String, _ fileId: String) -> Void
+  let onBlock: (String) -> Void
 
   var body: some View {
     Group {
@@ -19,6 +20,7 @@ struct ChatContainerView: View {
           messages: messages,
           onAcceptFile: onAcceptFile,
           onDeclineFile: onDeclineFile,
+          onBlock: onBlock,
         )
       }
     }

--- a/client/ios/PastePoint/Views/Chat/ChatView.swift
+++ b/client/ios/PastePoint/Views/Chat/ChatView.swift
@@ -11,6 +11,7 @@ struct ChatView: View {
   let messages: [ChatMessage]
   let onAcceptFile: (_ fromUser: String, _ fileId: String) -> Void
   let onDeclineFile: (_ fromUser: String, _ fileId: String) -> Void
+  let onBlock: (String) -> Void
 
   var body: some View {
     GeometryReader { geometry in
@@ -30,6 +31,7 @@ struct ChatView: View {
                 fileTransfer: message.fileTransfer,
                 onAccept: acceptHandler(for: message),
                 onDecline: declineHandler(for: message),
+                onBlock: blockHandler(for: message),
               )
               .transition(.asymmetric(
                 insertion: .move(edge: .bottom).combined(with: .opacity),
@@ -135,6 +137,14 @@ struct ChatView: View {
       onDeclineFile(transfer.fromUser, transfer.fileId)
     }
   }
+
+  private func blockHandler(for message: ChatMessage) -> (() -> Void)? {
+    guard !message.isMine else { return nil }
+
+    return {
+      onBlock(message.from)
+    }
+  }
 }
 
 // MARK: - Preview
@@ -159,6 +169,7 @@ struct ChatView: View {
     ],
     onAcceptFile: { _, _ in },
     onDeclineFile: { _, _ in },
+    onBlock: { _ in },
   )
   .environmentObject(services)
 }

--- a/client/ios/PastePoint/Views/Chat/Components/ChatMessageBubble.swift
+++ b/client/ios/PastePoint/Views/Chat/Components/ChatMessageBubble.swift
@@ -22,6 +22,7 @@ struct ChatMessageBubble: View {
   let fileTransfer: FileTransferData?
   let onAccept: (() -> Void)?
   let onDecline: (() -> Void)?
+  var onBlock: (() -> Void)?
 
   private var bubbleMaxWidth: CGFloat {
     isIPad ? 280 : 260
@@ -60,11 +61,14 @@ struct ChatMessageBubble: View {
           }
         }
 
-        if let transfer = fileTransfer {
-          attachmentBody(transfer: transfer)
-        } else {
-          textBody
+        Group {
+          if let transfer = fileTransfer {
+            attachmentBody(transfer: transfer)
+          } else {
+            textBody
+          }
         }
+        .contextMenu { bubbleMenu }
       }
 
       if alignment == .trailing {
@@ -74,6 +78,23 @@ struct ChatMessageBubble: View {
       }
     }
     .frame(maxWidth: .infinity)
+  }
+
+  @ViewBuilder
+  private var bubbleMenu: some View {
+    if fileTransfer == nil {
+      Button {
+        UIPasteboard.general.string = text
+      } label: {
+        Label(String(localized: .copy), systemImage: "doc.on.doc")
+      }
+    }
+
+    if let onBlock {
+      Button(role: .destructive, action: onBlock) {
+        Label(String(localized: .blockUser), systemImage: "hand.raised")
+      }
+    }
   }
 
   private var avatar: some View {
@@ -86,7 +107,6 @@ struct ChatMessageBubble: View {
 
   private var textBody: some View {
     Text(text)
-      .textSelection(.enabled)
       .font(.callout)
       .foregroundStyle(alignment == .trailing ? .textPrimary : .white)
       .padding(.horizontal, 12)

--- a/client/ios/PastePoint/Views/Settings/Sections/SettingsMembersSection.swift
+++ b/client/ios/PastePoint/Views/Settings/Sections/SettingsMembersSection.swift
@@ -8,6 +8,14 @@ import SwiftUI
 struct SettingsMembersSection: View {
   @EnvironmentObject private var services: AppServices
 
+  let onBlock: (String) -> Void
+
+  private var others: [String] {
+    services.roomService.members.filter {
+      $0 != services.userService.user && !services.blockService.isBlocked($0)
+    }
+  }
+
   var body: some View {
     VStack {
       HStack(alignment: .center, spacing: 0) {
@@ -24,14 +32,13 @@ struct SettingsMembersSection: View {
 
         Spacer()
 
-        Text(.onlineMembersCount(services.roomService.members.filter { $0 != services.userService.user }.count))
+        Text(.onlineMembersCount(others.count))
           .font(.caption2)
           .foregroundColor(.textPrimary)
       }
       .padding(.horizontal)
 
       Group {
-        let others = services.roomService.members.filter { $0 != services.userService.user }
         if others.isEmpty {
           Text(.noMembersOnline)
             .font(.subheadline)
@@ -86,6 +93,14 @@ struct SettingsMembersSection: View {
                 .accessibilityLabel(Text(.sendFileToUser))
               }
               .animation(.easeInOut(duration: 0.2), value: dotColor)
+              .contentShape(Rectangle())
+              .contextMenu {
+                Button(role: .destructive) {
+                  onBlock(member)
+                } label: {
+                  Label(String(localized: .blockUser), systemImage: "hand.raised")
+                }
+              }
 
               if !uploads.isEmpty || !downloads.isEmpty {
                 VStack(alignment: .leading, spacing: 4) {

--- a/client/ios/PastePoint/Views/Settings/SettingsView.swift
+++ b/client/ios/PastePoint/Views/Settings/SettingsView.swift
@@ -14,6 +14,7 @@ struct SettingsView: View {
   private let logger = Logger(label: "SettingsView")
   var onClose: (() -> Void)?
   var onSessionJoin: (() -> Void)?
+  var onBlock: ((String) -> Void)?
 
   @State private var isLeaveSessionSheetPresented: Bool = false
   @State private var isJoinRoomSheetPresented: Bool = false
@@ -90,7 +91,7 @@ struct SettingsView: View {
 
           // MARK: - Members
 
-          SettingsMembersSection()
+          SettingsMembersSection { onBlock?($0) }
         }
       }
 


### PR DESCRIPTION
### Summary

Allow iOS users to block peers during a session and prevent further messages, file events, and peer connections from them.

### What changed

#### Blocking

- Add a `BlockService` to manage blocked peers
- Remove blocked users from the active peer directory
- Close their existing WebRTC connections through mesh synchronization
- Ignore signaling and data-channel messages from blocked peers
- Clear the block list after disconnecting because peer identities are reassigned

#### User interface

- Add a block action to incoming message context menus
- Add a block action to members in Settings
- Remove existing messages from a user immediately after blocking them
- Show a localized confirmation toast
- Add a copy action for text message context menus
- Hide blocked users from the members list and online count