### PR TITLE
Web: Add session-scoped user blocking across chat and peer connections

### DIFF
--- a/client/web/src/app/core/i18n/localizations/ar.json
+++ b/client/web/src/app/core/i18n/localizations/ar.json
@@ -71,6 +71,8 @@
   "MEMBERS": "الأعضاء",
   "ONLINE_MEMBERS_COUNT": "عدد المتصلين",
   "NO_MEMBERS_ONLINE": "لا يوجد أعضاء متصلون",
+  "BLOCK_USER": "حظر",
+  "BLOCKED_USER_TOAST": "تم حظر {{user}}. تمت إزالة رسائله.",
 
   "_END_SESSION_SECTION": "==== END SESSION ====",
   "END_SESSION": "إنهاء الجلسة",

--- a/client/web/src/app/core/i18n/localizations/en.json
+++ b/client/web/src/app/core/i18n/localizations/en.json
@@ -71,6 +71,8 @@
   "MEMBERS": "Members",
   "ONLINE_MEMBERS_COUNT": "Online Now",
   "NO_MEMBERS_ONLINE": "No one is online right now",
+  "BLOCK_USER": "Block",
+  "BLOCKED_USER_TOAST": "Blocked {{user}}. Their messages were removed.",
 
   "_END_SESSION_SECTION": "==== END SESSION ====",
   "END_SESSION": "Leave Session",

--- a/client/web/src/app/core/i18n/localizations/es.json
+++ b/client/web/src/app/core/i18n/localizations/es.json
@@ -71,6 +71,8 @@
   "MEMBERS": "Miembros",
   "ONLINE_MEMBERS_COUNT": "Conectados ahora",
   "NO_MEMBERS_ONLINE": "Nadie está conectado en este momento",
+  "BLOCK_USER": "Bloquear",
+  "BLOCKED_USER_TOAST": "Has bloqueado a {{user}}. Se han eliminado sus mensajes.",
 
   "_END_SESSION_SECTION": "==== END SESSION ====",
   "END_SESSION": "Salir de la sesión",

--- a/client/web/src/app/core/i18n/localizations/fr.json
+++ b/client/web/src/app/core/i18n/localizations/fr.json
@@ -71,6 +71,8 @@
   "MEMBERS": "Membres",
   "ONLINE_MEMBERS_COUNT": "En ligne",
   "NO_MEMBERS_ONLINE": "Personne n'est en ligne pour le moment",
+  "BLOCK_USER": "Bloquer",
+  "BLOCKED_USER_TOAST": "{{user}} a été bloqué. Ses messages ont été supprimés.",
 
   "_END_SESSION_SECTION": "==== END SESSION ====",
   "END_SESSION": "Quitter la session",

--- a/client/web/src/app/core/i18n/localizations/ru.json
+++ b/client/web/src/app/core/i18n/localizations/ru.json
@@ -71,6 +71,8 @@
   "MEMBERS": "Участники",
   "ONLINE_MEMBERS_COUNT": "Сейчас в сети",
   "NO_MEMBERS_ONLINE": "Сейчас никого нет в сети",
+  "BLOCK_USER": "Заблокировать",
+  "BLOCKED_USER_TOAST": "Пользователь {{user}} заблокирован. Его сообщения удалены.",
 
   "_END_SESSION_SECTION": "==== END SESSION ====",
   "END_SESSION": "Покинуть сессию",

--- a/client/web/src/app/core/i18n/localizations/zh-CN.json
+++ b/client/web/src/app/core/i18n/localizations/zh-CN.json
@@ -71,6 +71,8 @@
   "MEMBERS": "成员",
   "ONLINE_MEMBERS_COUNT": "当前在线",
   "NO_MEMBERS_ONLINE": "目前没有人在线",
+  "BLOCK_USER": "屏蔽",
+  "BLOCKED_USER_TOAST": "已屏蔽 {{user}}。其消息已被移除。",
 
   "_END_SESSION_SECTION": "==== END SESSION ====",
   "END_SESSION": "退出会话",

--- a/client/web/src/app/core/services/communication/block.service.ts
+++ b/client/web/src/app/core/services/communication/block.service.ts
@@ -1,0 +1,50 @@
+import { Injectable, inject } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { NGXLogger } from 'ngx-logger';
+import { WebSocketConnectionService } from './websocket-connection.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class BlockService {
+  private wsService = inject(WebSocketConnectionService);
+  private logger = inject(NGXLogger);
+
+  public blockedPeers$ = new BehaviorSubject<Set<string>>(new Set());
+  private blockedPeers = new Set<string>();
+
+  constructor() {
+    this.wsService.connected$.subscribe(() => this.clear());
+  }
+
+  public block(peer: string): void {
+    if (!peer) {
+      return;
+    }
+
+    this.logger.info('block', `Blocking peer ${peer}`);
+    this.blockedPeers.add(peer);
+    this.blockedPeers$.next(new Set(this.blockedPeers));
+  }
+
+  public unblock(peer: string): void {
+    this.logger.info('unblock', `Unblocking peer ${peer}`);
+
+    this.blockedPeers.delete(peer);
+    this.blockedPeers$.next(new Set(this.blockedPeers));
+  }
+
+  public isBlocked(peer: string): boolean {
+    return this.blockedPeers.has(peer);
+  }
+
+  private clear(): void {
+    if (this.blockedPeers.size === 0) {
+      return;
+    }
+
+    this.logger.debug('clear', 'Clearing blocks — identities are reassigned on reconnect');
+    this.blockedPeers.clear();
+    this.blockedPeers$.next(new Set());
+  }
+}

--- a/client/web/src/app/core/services/communication/chat.service.ts
+++ b/client/web/src/app/core/services/communication/chat.service.ts
@@ -149,6 +149,17 @@ export class ChatService implements IChatService {
   }
 
   /**
+   * Removes every message from a peer, keeping your own.
+   * App Review requires a block to clear their content from the feed instantly.
+   */
+  public removeMessagesFrom(peer: string): void {
+    this.ngZone.run(() => {
+      this.messages = this.messages.filter((message) => message.isMine || message.from !== peer);
+      this.messages$.next(this.messages);
+    });
+  }
+
+  /**
    * ==========================================================
    * PRIVATE METHODS
    * Handlers for incoming messages

--- a/client/web/src/app/core/services/communication/webrtc-communication.service.ts
+++ b/client/web/src/app/core/services/communication/webrtc-communication.service.ts
@@ -12,6 +12,7 @@ import {
 import { NGXLogger } from 'ngx-logger';
 import { HotToastService } from '@ngxpert/hot-toast';
 import { decodeChunk } from '../../../utils/chunk-protocol';
+import { BlockService } from './block.service';
 
 @Injectable({
   providedIn: 'root',
@@ -21,6 +22,7 @@ export class WebRTCCommunicationService {
   private logger = inject(NGXLogger);
   private toaster = inject(HotToastService);
   private platformId = inject(PLATFORM_ID);
+  private blockService = inject(BlockService);
 
   // =============== Properties ===============
 
@@ -348,6 +350,14 @@ export class WebRTCCommunicationService {
    * @param targetUser The user who sent the data
    */
   private handleDataChannelMessage(data: unknown, targetUser: string): void {
+    if (this.blockService.isBlocked(targetUser)) {
+      this.logger.info(
+        'handleDataChannelMessage',
+        `Dropping data-channel message from blocked peer ${targetUser}`
+      );
+      return;
+    }
+
     this.zone.run(() => {
       if (typeof data === 'string') {
         let message: DataChannelMessage;

--- a/client/web/src/app/core/services/communication/webrtc-signaling.service.ts
+++ b/client/web/src/app/core/services/communication/webrtc-signaling.service.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/angular';
 import { startNewTrace } from '@sentry/core';
 import { WebSocketConnectionService } from './websocket-connection.service';
 import { UserService } from '../user-management/user.service';
+import { BlockService } from './block.service';
 import {
   MAX_RECONNECT_ATTEMPTS,
   RECONNECT_DELAY,
@@ -28,6 +29,7 @@ import { Subject } from 'rxjs';
 export class WebRTCSignalingService {
   private wsService = inject(WebSocketConnectionService);
   private userService = inject(UserService);
+  private blockService = inject(BlockService);
   private toaster = inject(HotToastService);
   private translate = inject<TranslateService>(TranslateService);
   private logger = inject(NGXLogger);
@@ -840,6 +842,14 @@ export class WebRTCSignalingService {
    * @param message The signal message to handle
    */
   private handleSignalMessage(message: SignalMessage): void {
+    if (this.blockService.isBlocked(message.from)) {
+      this.logger.info(
+        'handleSignalMessage',
+        `Ignoring ${message.type} from blocked peer ${message.from}`
+      );
+      return;
+    }
+
     if (message.from === message.to) {
       this.logger.warn(
         'handleSignalMessage',

--- a/client/web/src/app/features/chat/chat.component.html
+++ b/client/web/src/app/features/chat/chat.component.html
@@ -25,6 +25,7 @@
     (joinPrivateSessionRequested)="openJoinSessionPopup()"
     (endSessionRequested)="openEndSessionPopup()"
     (filePickerRequested)="openFilePickerForMember($event)"
+    (blockRequested)="blockUser($event)"
     (cancelUploadRequested)="cancelUpload($event)"
     (cancelDownloadRequested)="cancelDownload($event)"
   />

--- a/client/web/src/app/features/chat/chat.component.html
+++ b/client/web/src/app/features/chat/chat.component.html
@@ -80,6 +80,7 @@
         [currentUser]="userService.user"
         (acceptFile)="acceptIncomingFile($event)"
         (declineFile)="declineIncomingFile($event)"
+        (blockRequested)="blockUser($event)"
       />
 
       <!-- MARK: - Message Input -->

--- a/client/web/src/app/features/chat/chat.component.ts
+++ b/client/web/src/app/features/chat/chat.component.ts
@@ -1025,6 +1025,21 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
 
   /**
    * ==========================================================
+   * BLOCK USER
+   * Blocks the peer and clears their messages. Dropping them from `members`
+   * takes the connection down through the departed-member path above.
+   * ==========================================================
+   */
+  blockUser(peer: string): void {
+    if (!peer) return;
+
+    this.blockService.block(peer);
+    this.chatService.removeMessagesFrom(peer);
+    this.toaster.success(this.translate.instant('BLOCKED_USER_TOAST', { user: peer }));
+  }
+
+  /**
+   * ==========================================================
    * SEND MESSAGE
    * Sends the chat message to other members via WebRTC, then clears
    * the input field and scrolls chat down.

--- a/client/web/src/app/features/chat/chat.component.ts
+++ b/client/web/src/app/features/chat/chat.component.ts
@@ -18,6 +18,7 @@ import { isPlatformBrowser } from '@angular/common';
 
 import { ThemeService } from '../../core/services/ui/theme.service';
 import { ChatService } from '../../core/services/communication/chat.service';
+import { BlockService } from '../../core/services/communication/block.service';
 import { HeartbeatService } from '../../core/services/communication/heartbeat.service';
 import { RoomService } from '../../core/services/room-management/room.service';
 import { FileTransferService } from '../../core/services/file-management/file-transfer.service';
@@ -97,6 +98,7 @@ import { ChatSidebarComponent } from './components/chat-sidebar/chat-sidebar.com
 export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
   userService = inject(UserService);
   private chatService = inject(ChatService);
+  private blockService = inject(BlockService);
   private heartbeatService = inject(HeartbeatService);
   private roomService = inject(RoomService);
   private fileTransferService = inject(FileTransferService);
@@ -568,10 +570,16 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
 
     // Listen for current members in the room
     this.subscriptions.push(
-      combineLatest([this.roomService.members$, this.userService.user$])
+      combineLatest([
+        this.roomService.members$,
+        this.userService.user$,
+        this.blockService.blockedPeers$,
+      ])
         .pipe(
           filter(([, currentUser]) => currentUser.trim().length > 0),
-          map(([allMembers, currentUser]) => allMembers.filter((m) => m !== currentUser)),
+          map(([allMembers, currentUser, blocked]) =>
+            allMembers.filter((m) => m !== currentUser && !blocked.has(m))
+          ),
           distinctUntilChanged(
             (previous, current) =>
               previous.length === current.length &&

--- a/client/web/src/app/features/chat/components/chat-messages/chat-messages.component.html
+++ b/client/web/src/app/features/chat/components/chat-messages/chat-messages.component.html
@@ -265,6 +265,30 @@
                   <span class="text-xs text-gray-400 font-expoArabic dark:text-gray-500">
                     {{ message.timestamp | date: 'shortTime' }}
                   </span>
+
+                  <!-- Block sender -->
+                  <button
+                    type="button"
+                    class="ms-auto rounded p-0.5 text-gray-400 transition-colors hover:text-danger dark:text-gray-500 dark:hover:text-danger"
+                    [attr.aria-label]="'BLOCK_USER' | translate"
+                    [title]="'BLOCK_USER' | translate"
+                    (click)="blockRequested.emit(message.from)"
+                  >
+                    <svg
+                      class="h-3.5 w-3.5"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="1.8"
+                      viewBox="0 0 24 24"
+                      aria-hidden="true"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M18.364 18.364A9 9 0 0 0 5.636 5.636m12.728 12.728A9 9 0 0 1 5.636 5.636m12.728 12.728L5.636 5.636"
+                      />
+                    </svg>
+                  </button>
                 </div>
                 <div
                   class="flex min-h-[60px] w-[250px] flex-col justify-center rounded-xl p-3 bg-brand md:w-[280px] dark:bg-brandDark"

--- a/client/web/src/app/features/chat/components/chat-messages/chat-messages.component.ts
+++ b/client/web/src/app/features/chat/components/chat-messages/chat-messages.component.ts
@@ -34,6 +34,7 @@ export class ChatMessagesComponent {
 
   @Output() acceptFile = new EventEmitter<ChatMessage>();
   @Output() declineFile = new EventEmitter<ChatMessage>();
+  @Output() blockRequested = new EventEmitter<string>();
 
   @ViewChild('messageContainer') messageContainer!: ElementRef;
 

--- a/client/web/src/app/features/chat/components/chat-sidebar/chat-sidebar.component.html
+++ b/client/web/src/app/features/chat/components/chat-sidebar/chat-sidebar.component.html
@@ -277,7 +277,7 @@
                   [attr.title]="memberDotTitle(member)"
                 ></div>
                 <p class="truncate text-sm font-expoArabicLight">{{ member }}</p>
-                <div class="ms-auto">
+                <div class="ms-auto flex items-center gap-1">
                   <button
                     type="button"
                     [disabled]="!isConnectedToMember(member)"
@@ -301,6 +301,30 @@
                       width="16"
                       height="16"
                     />
+                  </button>
+
+                  <!-- Block -->
+                  <button
+                    type="button"
+                    class="rounded-md p-1 text-textMuted hover:text-danger dark:text-textVeryMuted dark:hover:text-danger"
+                    [attr.aria-label]="'BLOCK_USER' | translate"
+                    [title]="'BLOCK_USER' | translate"
+                    (click)="blockRequested.emit(member)"
+                  >
+                    <svg
+                      class="h-4 w-4"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="1.8"
+                      viewBox="0 0 24 24"
+                      aria-hidden="true"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M18.364 18.364A9 9 0 0 0 5.636 5.636m12.728 12.728A9 9 0 0 1 5.636 5.636m12.728 12.728L5.636 5.636"
+                      />
+                    </svg>
                   </button>
                 </div>
               </div>

--- a/client/web/src/app/features/chat/components/chat-sidebar/chat-sidebar.component.ts
+++ b/client/web/src/app/features/chat/components/chat-sidebar/chat-sidebar.component.ts
@@ -48,6 +48,7 @@ export class ChatSidebarComponent {
   @Output() joinPrivateSessionRequested = new EventEmitter<void>();
   @Output() endSessionRequested = new EventEmitter<void>();
   @Output() filePickerRequested = new EventEmitter<string>();
+  @Output() blockRequested = new EventEmitter<string>();
   @Output() cancelUploadRequested = new EventEmitter<FileUpload>();
   @Output() cancelDownloadRequested = new EventEmitter<FileDownload>();
 


### PR DESCRIPTION
### Summary

Allow web users to block peers during a session and prevent further messages, file events, and peer connections from them.

### What changed

#### Blocking

- Add a `BlockService` to manage blocked peers
- Remove blocked users from the active members list
- Close their existing WebRTC connections and clean up active transfers
- Ignore signaling and data-channel messages from blocked peers
- Prevent the mesh from reconnecting to blocked users
- Clear blocks after reconnecting because peer identities are reassigned

#### User interface

- Add a block action to incoming message bubbles
- Add a block action to members in the chat sidebar
- Remove the blocked user’s existing messages immediately
- Show a localized confirmation toast
- Add translations across all supported languages