### PR TITLE
Add report-and-block actions across web and iOS

### DIFF
--- a/client/ios/PastePoint/App/ContentView+Handlers.swift
+++ b/client/ios/PastePoint/App/ContentView+Handlers.swift
@@ -150,6 +150,16 @@ extension ContentView {
     messages[idx].fileTransfer?.previewMime = previewMime
   }
 
+  func handleReport(_ message: ChatMessage) {
+    blockPeer(message.from)
+
+    guard ReportComposerView.canSendMail else {
+      toast.show(.warning(.reportMailUnavailable))
+      return
+    }
+    reportTarget = message
+  }
+
   func blockPeer(_ peer: String) {
     guard !peer.isEmpty else { return }
 

--- a/client/ios/PastePoint/App/ContentView.swift
+++ b/client/ios/PastePoint/App/ContentView.swift
@@ -26,6 +26,7 @@ struct ContentView: View {
   @State private var splashDismissing = false
 
   @State var messages: [ChatMessage] = []
+  @State var reportTarget: ChatMessage?
   @State var pendingLegalDeepLink: URL?
   @State var hasConnectedBefore = false
   @State var showSettings = false
@@ -161,6 +162,7 @@ struct ContentView: View {
           onAcceptFile: handleAcceptFile,
           onDeclineFile: handleDeclineFile,
           onBlock: blockPeer,
+          onReport: handleReport,
         )
         .simultaneousGesture(
           TapGesture().onEnded {
@@ -226,6 +228,12 @@ struct ContentView: View {
             .accessibilityLabel(Text(.settings))
           }
         }
+      }
+      .sheet(item: $reportTarget) { message in
+        ReportComposerView(message: message, isPrivateRoom: isPrivateRoom) {
+          reportTarget = nil
+        }
+        .ignoresSafeArea()
       }
     }
     .background(AppColors.Background.background)

--- a/client/ios/PastePoint/Core/Config/AppEnvironment.swift
+++ b/client/ios/PastePoint/Core/Config/AppEnvironment.swift
@@ -55,6 +55,11 @@ enum AppEnvironment {
     "https://\(webUrl)/\(privateSessionPath)/\(sessionCode)"
   }
 
+  // MARK: - Support
+
+  /// Destination for user-submitted reports of objectionable content.
+  static let supportEmail = "support@pastepoint.com"
+
   // MARK: - URL Parsing
 
   /// Extracts the session code candidate from a PastePoint private-session URL.

--- a/client/ios/PastePoint/Core/Services/Connection/ConnectionWarningMonitor.swift
+++ b/client/ios/PastePoint/Core/Services/Connection/ConnectionWarningMonitor.swift
@@ -17,7 +17,7 @@ final class ConnectionWarningMonitor: ObservableObject {
 
   private static let warningDelay: TimeInterval = 15
   private var dismissed = false
-  private var timers: [String: Task<Void, Never>] = [:]
+  private var timer: Task<Void, Never>?
   private var cancellables: Set<AnyCancellable> = []
 
   init(
@@ -42,48 +42,42 @@ final class ConnectionWarningMonitor: ObservableObject {
 
   // MARK: -
 
-  private func reconcile(peers: [String], connected: Set<String>) {
-    let expected = Set(peers)
-    let unconnected = expected.subtracting(connected)
-
-    for peer in Array(timers.keys) where !unconnected.contains(peer) {
-      cancelTimer(for: peer)
-    }
-
-    for peer in unconnected where timers[peer] == nil {
-      scheduleWarning(for: peer)
-    }
-
-    if unconnected.isEmpty {
-      showWarning = false
-      dismissed = false
-    }
+  private func isIsolated(peers: [String], connected: Set<String>) -> Bool {
+    !peers.isEmpty && connected.isEmpty
   }
 
-  private func scheduleWarning(for peer: String) {
-    guard !showWarning else { return }
+  private func reconcile(peers: [String], connected: Set<String>) {
+    guard isIsolated(peers: peers, connected: connected) else {
+      timer?.cancel()
+      timer = nil
+      showWarning = false
+      dismissed = false
+      return
+    }
 
-    timers[peer] = Task { [weak self] in
+    guard timer == nil, !showWarning else { return }
+    scheduleWarning()
+  }
+
+  private func scheduleWarning() {
+    timer = Task { [weak self] in
       try? await Task.sleep(nanoseconds: UInt64(Self.warningDelay * 1_000_000_000))
 
       guard !Task.isCancelled, let self else { return }
+      self.timer = nil
 
-      self.timers[peer] = nil
       guard
-        self.peerDirectory.peers.contains(peer),
-        !self.signalingService.connectedPeers.contains(peer),
+        self.isIsolated(
+          peers: self.peerDirectory.peers,
+          connected: self.signalingService.connectedPeers,
+        ),
         !self.dismissed
       else {
         return
       }
 
-      self.logger.warning("Peer \(peer) unconnected past \(Self.warningDelay)s — showing warning")
+      self.logger.warning("No peer reachable past \(Self.warningDelay)s — showing warning")
       self.showWarning = true
     }
-  }
-
-  private func cancelTimer(for peer: String) {
-    timers[peer]?.cancel()
-    timers[peer] = nil
   }
 }

--- a/client/ios/PastePoint/Core/Utils/AppInfo/AppInfo.swift
+++ b/client/ios/PastePoint/Core/Utils/AppInfo/AppInfo.swift
@@ -12,6 +12,10 @@ extension Bundle {
   var appVersion: String {
     infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
   }
+
+  var appBuild: String {
+    infoDictionary?["CFBundleVersion"] as? String ?? "0"
+  }
 }
 
 // MARK: - Build Environment

--- a/client/ios/PastePoint/Resources/Localization/Localizable.xcstrings
+++ b/client/ios/PastePoint/Resources/Localization/Localizable.xcstrings
@@ -4009,6 +4009,174 @@
         }
       }
     },
+    "REPORT_AND_BLOCK" : {
+      "comment" : "Context-menu action: report a message to support and block its sender.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إبلاغ وحظر"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Report and Block"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Denunciar y bloquear"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Signaler et bloquer"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пожаловаться и заблокировать"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "举报并屏蔽"
+          }
+        }
+      }
+    },
+    "REPORT_EMAIL_INTRO" : {
+      "comment" : "Prompt at the top of the pre-filled report email body.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يرجى وصف ما حدث (اختياري):"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please describe what happened (optional):"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Describe lo que ha ocurrido (opcional):"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Décrivez ce qui s'est passé (facultatif) :"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Опишите, что произошло (необязательно):"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请描述发生了什么（可选）："
+          }
+        }
+      }
+    },
+    "REPORT_EMAIL_SUBJECT" : {
+      "comment" : "Subject line of the pre-filled report email.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بلاغ PastePoint: محتوى مرفوض"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PastePoint report: objectionable content"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Denuncia de PastePoint: contenido objetable"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Signalement PastePoint : contenu répréhensible"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жалоба PastePoint: неприемлемый контент"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PastePoint 举报：令人反感的内容"
+          }
+        }
+      }
+    },
+    "REPORT_MAIL_UNAVAILABLE" : {
+      "comment" : "Toast shown when the device has no mail account configured to send a report.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا يوجد حساب بريد إلكتروني مُعد، لذا تعذّر إرسال البلاغ. تم حظر المستخدم."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No email account is set up, so the report could not be sent. The user has been blocked."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay ninguna cuenta de correo configurada, así que no se pudo enviar la denuncia. El usuario ha sido bloqueado."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun compte e-mail n'est configuré, le signalement n'a pas pu être envoyé. L'utilisateur a été bloqué."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Учётная запись почты не настроена, поэтому жалобу отправить не удалось. Пользователь заблокирован."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未设置电子邮件账户，无法发送举报。该用户已被屏蔽。"
+          }
+        }
+      }
+    },
     "ROOM_CREATED" : {
       "comment" : "Toast: a room was created.",
       "extractionState" : "manual",

--- a/client/ios/PastePoint/Views/Chat/ChatContainerView.swift
+++ b/client/ios/PastePoint/Views/Chat/ChatContainerView.swift
@@ -10,6 +10,7 @@ struct ChatContainerView: View {
   let onAcceptFile: (_ fromUser: String, _ fileId: String) -> Void
   let onDeclineFile: (_ fromUser: String, _ fileId: String) -> Void
   let onBlock: (String) -> Void
+  let onReport: (ChatMessage) -> Void
 
   var body: some View {
     Group {
@@ -21,6 +22,7 @@ struct ChatContainerView: View {
           onAcceptFile: onAcceptFile,
           onDeclineFile: onDeclineFile,
           onBlock: onBlock,
+          onReport: onReport,
         )
       }
     }

--- a/client/ios/PastePoint/Views/Chat/ChatView.swift
+++ b/client/ios/PastePoint/Views/Chat/ChatView.swift
@@ -12,6 +12,7 @@ struct ChatView: View {
   let onAcceptFile: (_ fromUser: String, _ fileId: String) -> Void
   let onDeclineFile: (_ fromUser: String, _ fileId: String) -> Void
   let onBlock: (String) -> Void
+  let onReport: (ChatMessage) -> Void
 
   var body: some View {
     GeometryReader { geometry in
@@ -32,6 +33,7 @@ struct ChatView: View {
                 onAccept: acceptHandler(for: message),
                 onDecline: declineHandler(for: message),
                 onBlock: blockHandler(for: message),
+                onReport: reportHandler(for: message),
               )
               .transition(.asymmetric(
                 insertion: .move(edge: .bottom).combined(with: .opacity),
@@ -145,6 +147,14 @@ struct ChatView: View {
       onBlock(message.from)
     }
   }
+
+  private func reportHandler(for message: ChatMessage) -> (() -> Void)? {
+    guard !message.isMine else { return nil }
+
+    return {
+      onReport(message)
+    }
+  }
 }
 
 // MARK: - Preview
@@ -170,6 +180,7 @@ struct ChatView: View {
     onAcceptFile: { _, _ in },
     onDeclineFile: { _, _ in },
     onBlock: { _ in },
+    onReport: { _ in },
   )
   .environmentObject(services)
 }

--- a/client/ios/PastePoint/Views/Chat/Components/ChatMessageBubble.swift
+++ b/client/ios/PastePoint/Views/Chat/Components/ChatMessageBubble.swift
@@ -23,6 +23,7 @@ struct ChatMessageBubble: View {
   let onAccept: (() -> Void)?
   let onDecline: (() -> Void)?
   var onBlock: (() -> Void)?
+  var onReport: (() -> Void)?
 
   private var bubbleMaxWidth: CGFloat {
     isIPad ? 280 : 260
@@ -93,6 +94,12 @@ struct ChatMessageBubble: View {
     if let onBlock {
       Button(role: .destructive, action: onBlock) {
         Label(String(localized: .blockUser), systemImage: "hand.raised")
+      }
+    }
+
+    if let onReport {
+      Button(role: .destructive, action: onReport) {
+        Label(String(localized: .reportAndBlock), systemImage: "flag")
       }
     }
   }

--- a/client/ios/PastePoint/Views/Moderation/ReportComposerView.swift
+++ b/client/ios/PastePoint/Views/Moderation/ReportComposerView.swift
@@ -1,0 +1,76 @@
+//
+//  Copyright © 2026 PastePoint. All rights reserved.
+//  SPDX-License-Identifier: GPL-3.0-only
+//
+
+import MessageUI
+import SwiftUI
+
+struct ReportComposerView: UIViewControllerRepresentable {
+  let message: ChatMessage
+  let isPrivateRoom: Bool
+  let onFinish: () -> Void
+
+  private static let maxReportedText = 1000
+
+  static var canSendMail: Bool { MFMailComposeViewController.canSendMail() }
+
+  func makeUIViewController(context: Context) -> MFMailComposeViewController {
+    let composer = MFMailComposeViewController()
+    composer.mailComposeDelegate = context.coordinator
+    composer.setToRecipients([AppEnvironment.supportEmail])
+    composer.setSubject(String(localized: .reportEmailSubject))
+    composer.setMessageBody(body, isHTML: false)
+    return composer
+  }
+
+  func updateUIViewController(_: MFMailComposeViewController, context _: Context) {}
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(onFinish: onFinish)
+  }
+
+  private var body: String {
+    var lines = [
+      String(localized: .reportEmailIntro),
+      "",
+      "",
+      "",
+      "---",
+      "App: \(Bundle.main.appVersion) (\(Bundle.main.appBuild))",
+      "Device: \(UIDevice.current.model), \(UIDevice.current.systemName) \(UIDevice.current.systemVersion)",
+      "Room: \(isPrivateRoom ? "Private session" : "Public room")",
+      "",
+    ]
+
+    if let transfer = message.fileTransfer {
+      let size = ByteCountFormatter.string(fromByteCount: transfer.fileSize, countStyle: .file)
+      lines.append("Reported file: \(transfer.fileName) (\(size))")
+    } else {
+      lines.append("Reported message:")
+      lines.append(Self.truncated(message.text))
+    }
+
+    return lines.joined(separator: "\n")
+  }
+
+  private static func truncated(_ text: String) -> String {
+    text.count <= maxReportedText ? text : "\(text.prefix(maxReportedText))…"
+  }
+
+  final class Coordinator: NSObject, MFMailComposeViewControllerDelegate {
+    private let onFinish: () -> Void
+
+    init(onFinish: @escaping () -> Void) {
+      self.onFinish = onFinish
+    }
+
+    func mailComposeController(
+      _: MFMailComposeViewController,
+      didFinishWith _: MFMailComposeResult,
+      error _: Error?,
+    ) {
+      onFinish()
+    }
+  }
+}

--- a/client/web/src/app/core/i18n/localizations/ar.json
+++ b/client/web/src/app/core/i18n/localizations/ar.json
@@ -73,6 +73,10 @@
   "NO_MEMBERS_ONLINE": "لا يوجد أعضاء متصلون",
   "BLOCK_USER": "حظر",
   "BLOCKED_USER_TOAST": "تم حظر {{user}}. تمت إزالة رسائله.",
+  "MESSAGE_ACTIONS": "إجراءات الرسالة",
+  "REPORT_AND_BLOCK": "إبلاغ وحظر",
+  "REPORT_EMAIL_SUBJECT": "بلاغ PastePoint: محتوى مرفوض",
+  "REPORT_EMAIL_INTRO": "يرجى وصف ما حدث (اختياري):",
 
   "_END_SESSION_SECTION": "==== END SESSION ====",
   "END_SESSION": "إنهاء الجلسة",

--- a/client/web/src/app/core/i18n/localizations/en.json
+++ b/client/web/src/app/core/i18n/localizations/en.json
@@ -73,6 +73,10 @@
   "NO_MEMBERS_ONLINE": "No one is online right now",
   "BLOCK_USER": "Block",
   "BLOCKED_USER_TOAST": "Blocked {{user}}. Their messages were removed.",
+  "MESSAGE_ACTIONS": "Message actions",
+  "REPORT_AND_BLOCK": "Report and Block",
+  "REPORT_EMAIL_SUBJECT": "PastePoint report: objectionable content",
+  "REPORT_EMAIL_INTRO": "Please describe what happened (optional):",
 
   "_END_SESSION_SECTION": "==== END SESSION ====",
   "END_SESSION": "Leave Session",

--- a/client/web/src/app/core/i18n/localizations/es.json
+++ b/client/web/src/app/core/i18n/localizations/es.json
@@ -73,6 +73,10 @@
   "NO_MEMBERS_ONLINE": "Nadie está conectado en este momento",
   "BLOCK_USER": "Bloquear",
   "BLOCKED_USER_TOAST": "Has bloqueado a {{user}}. Se han eliminado sus mensajes.",
+  "MESSAGE_ACTIONS": "Acciones del mensaje",
+  "REPORT_AND_BLOCK": "Denunciar y bloquear",
+  "REPORT_EMAIL_SUBJECT": "Denuncia de PastePoint: contenido objetable",
+  "REPORT_EMAIL_INTRO": "Describe lo que ha ocurrido (opcional):",
 
   "_END_SESSION_SECTION": "==== END SESSION ====",
   "END_SESSION": "Salir de la sesión",

--- a/client/web/src/app/core/i18n/localizations/fr.json
+++ b/client/web/src/app/core/i18n/localizations/fr.json
@@ -73,6 +73,10 @@
   "NO_MEMBERS_ONLINE": "Personne n'est en ligne pour le moment",
   "BLOCK_USER": "Bloquer",
   "BLOCKED_USER_TOAST": "{{user}} a été bloqué. Ses messages ont été supprimés.",
+  "MESSAGE_ACTIONS": "Actions du message",
+  "REPORT_AND_BLOCK": "Signaler et bloquer",
+  "REPORT_EMAIL_SUBJECT": "Signalement PastePoint : contenu répréhensible",
+  "REPORT_EMAIL_INTRO": "Décrivez ce qui s'est passé (facultatif) :",
 
   "_END_SESSION_SECTION": "==== END SESSION ====",
   "END_SESSION": "Quitter la session",

--- a/client/web/src/app/core/i18n/localizations/ru.json
+++ b/client/web/src/app/core/i18n/localizations/ru.json
@@ -73,6 +73,10 @@
   "NO_MEMBERS_ONLINE": "Сейчас никого нет в сети",
   "BLOCK_USER": "Заблокировать",
   "BLOCKED_USER_TOAST": "Пользователь {{user}} заблокирован. Его сообщения удалены.",
+  "MESSAGE_ACTIONS": "Действия с сообщением",
+  "REPORT_AND_BLOCK": "Пожаловаться и заблокировать",
+  "REPORT_EMAIL_SUBJECT": "Жалоба PastePoint: неприемлемый контент",
+  "REPORT_EMAIL_INTRO": "Опишите, что произошло (необязательно):",
 
   "_END_SESSION_SECTION": "==== END SESSION ====",
   "END_SESSION": "Покинуть сессию",

--- a/client/web/src/app/core/i18n/localizations/zh-CN.json
+++ b/client/web/src/app/core/i18n/localizations/zh-CN.json
@@ -73,6 +73,10 @@
   "NO_MEMBERS_ONLINE": "目前没有人在线",
   "BLOCK_USER": "屏蔽",
   "BLOCKED_USER_TOAST": "已屏蔽 {{user}}。其消息已被移除。",
+  "MESSAGE_ACTIONS": "消息操作",
+  "REPORT_AND_BLOCK": "举报并屏蔽",
+  "REPORT_EMAIL_SUBJECT": "PastePoint 举报：令人反感的内容",
+  "REPORT_EMAIL_INTRO": "请描述发生了什么（可选）：",
 
   "_END_SESSION_SECTION": "==== END SESSION ====",
   "END_SESSION": "退出会话",

--- a/client/web/src/app/core/services/ui/meta-init.service.ts
+++ b/client/web/src/app/core/services/ui/meta-init.service.ts
@@ -52,10 +52,6 @@ export class MetaInitService {
       manifest: '/site.webmanifest',
     });
 
-    // Set preconnect for performance
-    this.metaService.setPreconnect(['https://fonts.googleapis.com'], false);
-    this.metaService.setPreconnect(['https://fonts.gstatic.com'], true);
-
     // Set structured data for the application
     this.metaService.setStructuredData(this.getApplicationStructuredData(), 'app-structured-data');
 

--- a/client/web/src/app/features/chat/chat.component.html
+++ b/client/web/src/app/features/chat/chat.component.html
@@ -81,6 +81,7 @@
         (acceptFile)="acceptIncomingFile($event)"
         (declineFile)="declineIncomingFile($event)"
         (blockRequested)="blockUser($event)"
+        (reportRequested)="reportUser($event)"
       />
 
       <!-- MARK: - Message Input -->

--- a/client/web/src/app/features/chat/chat.component.ts
+++ b/client/web/src/app/features/chat/chat.component.ts
@@ -1845,11 +1845,7 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
           }
         }
 
-        if (
-          this.showConnectionWarning &&
-          otherMembers.length > 0 &&
-          otherMembers.every((m) => this.webrtcService.isConnected(m))
-        ) {
+        if (this.showConnectionWarning && !this.isIsolatedFromPeers) {
           this.showConnectionWarning = false;
           this.connectionWarningDismissed = false;
         }
@@ -1867,6 +1863,11 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
    */
   protected isConnectedToMember(member: string): boolean {
     return this.memberConnectionStatus.get(member) ?? false;
+  }
+
+  private get isIsolatedFromPeers(): boolean {
+    const otherMembers = this.members.filter((m) => m !== this.userService.user);
+    return otherMembers.length > 0 && !otherMembers.some((m) => this.isConnectedToMember(m));
   }
 
   protected get hasNoConnectedPeers(): boolean {
@@ -1900,11 +1901,7 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
     const timeoutId = setTimeout(() => {
       this.ngZone.run(() => {
         this.connectionWarningTimeouts.delete(member);
-        if (
-          this.members.includes(member) &&
-          !this.webrtcService.isConnected(member) &&
-          !this.connectionWarningDismissed
-        ) {
+        if (this.isIsolatedFromPeers && !this.connectionWarningDismissed) {
           this.showConnectionWarning = true;
           this.cdr.detectChanges();
         }
@@ -1919,9 +1916,8 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
       clearTimeout(timeoutId);
       this.connectionWarningTimeouts.delete(member);
     }
-    // Hide banner if all peers are now connected
-    const otherMembers = this.members.filter((m) => m !== this.userService.user);
-    if (otherMembers.length > 0 && otherMembers.every((m) => this.webrtcService.isConnected(m))) {
+    // Hide the banner as soon as any peer is reachable, or everyone has left.
+    if (!this.isIsolatedFromPeers) {
       this.showConnectionWarning = false;
       this.connectionWarningDismissed = false;
     }

--- a/client/web/src/app/features/chat/chat.component.ts
+++ b/client/web/src/app/features/chat/chat.component.ts
@@ -19,6 +19,7 @@ import { isPlatformBrowser } from '@angular/common';
 import { ThemeService } from '../../core/services/ui/theme.service';
 import { ChatService } from '../../core/services/communication/chat.service';
 import { BlockService } from '../../core/services/communication/block.service';
+import { buildReportMailto } from '../../utils/report-mailto';
 import { HeartbeatService } from '../../core/services/communication/heartbeat.service';
 import { RoomService } from '../../core/services/room-management/room.service';
 import { FileTransferService } from '../../core/services/file-management/file-transfer.service';
@@ -41,6 +42,7 @@ import {
   SESSION_CODE_KEY,
   THEME_PREFERENCE_KEY,
   PREVIEW_MIME_TYPE,
+  SUPPORT_EMAIL,
 } from '../../utils/constants';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { SessionService } from '../../core/services/session/session.service';
@@ -1036,6 +1038,27 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
     this.blockService.block(peer);
     this.chatService.removeMessagesFrom(peer);
     this.toaster.success(this.translate.instant('BLOCKED_USER_TOAST', { user: peer }));
+  }
+
+  /**
+   * ==========================================================
+   * REPORT USER
+   * Blocks first, then opens a pre-filled report. Blocking is not contingent
+   * on the mail being sent — the content must leave the feed either way.
+   * ==========================================================
+   */
+  reportUser(message: ChatMessage): void {
+    this.blockUser(message.from);
+
+    const url = buildReportMailto(
+      SUPPORT_EMAIL,
+      this.translate.instant('REPORT_EMAIL_SUBJECT'),
+      this.translate.instant('REPORT_EMAIL_INTRO'),
+      message,
+      this.SessionCode.length > 0,
+      this.appVersion
+    );
+    window.location.href = url;
   }
 
   /**

--- a/client/web/src/app/features/chat/components/chat-messages/chat-messages.component.html
+++ b/client/web/src/app/features/chat/components/chat-messages/chat-messages.component.html
@@ -266,29 +266,14 @@
                     {{ message.timestamp | date: 'shortTime' }}
                   </span>
 
-                  <!-- Block sender -->
-                  <button
-                    type="button"
-                    class="ms-auto rounded p-0.5 text-gray-400 transition-colors hover:text-danger dark:text-gray-500 dark:hover:text-danger"
-                    [attr.aria-label]="'BLOCK_USER' | translate"
-                    [title]="'BLOCK_USER' | translate"
-                    (click)="blockRequested.emit(message.from)"
-                  >
-                    <svg
-                      class="h-3.5 w-3.5"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="1.8"
-                      viewBox="0 0 24 24"
-                      aria-hidden="true"
-                    >
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        d="M18.364 18.364A9 9 0 0 0 5.636 5.636m12.728 12.728A9 9 0 0 1 5.636 5.636m12.728 12.728L5.636 5.636"
-                      />
-                    </svg>
-                  </button>
+                  <!-- Actions -->
+                  <div class="ms-auto">
+                    <app-message-actions
+                      [isRTL]="isRTL"
+                      (blockRequested)="blockRequested.emit(message.from)"
+                      (reportRequested)="reportRequested.emit(message)"
+                    />
+                  </div>
                 </div>
                 <div
                   class="flex min-h-[60px] w-[250px] flex-col justify-center rounded-xl p-3 bg-brand md:w-[280px] dark:bg-brandDark"

--- a/client/web/src/app/features/chat/components/chat-messages/chat-messages.component.ts
+++ b/client/web/src/app/features/chat/components/chat-messages/chat-messages.component.ts
@@ -17,10 +17,11 @@ import { ChatMessage, ChatMessageType, FileTransferStatus } from '../../../../ut
 import { FileSizePipe } from '../../../../utils/file-size.pipe';
 import { truncateFilename as truncateFilenameUtil } from '../../../../utils/filename.util';
 import { avatarFor } from '../../../../utils/avatar.util';
+import { MessageActionsComponent } from '../message-actions/message-actions.component';
 
 @Component({
   selector: 'app-chat-messages',
-  imports: [CommonModule, DatePipe, FileSizePipe, TranslateModule],
+  imports: [CommonModule, DatePipe, FileSizePipe, TranslateModule, MessageActionsComponent],
   providers: [FileSizePipe],
   templateUrl: './chat-messages.component.html',
   styleUrl: './chat-messages.component.css',
@@ -35,6 +36,7 @@ export class ChatMessagesComponent {
   @Output() acceptFile = new EventEmitter<ChatMessage>();
   @Output() declineFile = new EventEmitter<ChatMessage>();
   @Output() blockRequested = new EventEmitter<string>();
+  @Output() reportRequested = new EventEmitter<ChatMessage>();
 
   @ViewChild('messageContainer') messageContainer!: ElementRef;
 

--- a/client/web/src/app/features/chat/components/message-actions/message-actions.component.css
+++ b/client/web/src/app/features/chat/components/message-actions/message-actions.component.css
@@ -1,0 +1,3 @@
+:host {
+  display: inline-block;
+}

--- a/client/web/src/app/features/chat/components/message-actions/message-actions.component.html
+++ b/client/web/src/app/features/chat/components/message-actions/message-actions.component.html
@@ -1,0 +1,72 @@
+<div class="relative">
+  <!-- MARK: - Overflow trigger -->
+  <button
+    type="button"
+    (click)="toggle()"
+    [attr.aria-label]="'MESSAGE_ACTIONS' | translate"
+    [attr.aria-expanded]="isOpen()"
+    aria-haspopup="menu"
+    [title]="'MESSAGE_ACTIONS' | translate"
+    class="flex h-6 w-6 items-center justify-center rounded text-gray-400 transition-colors hover:bg-inputBackground hover:text-content dark:text-gray-500 dark:hover:bg-surfaceDark dark:hover:text-white"
+  >
+    <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <circle cx="5" cy="12" r="1.6" />
+      <circle cx="12" cy="12" r="1.6" />
+      <circle cx="19" cy="12" r="1.6" />
+    </svg>
+  </button>
+
+  <!-- MARK: - Menu -->
+  @if (isOpen()) {
+    <div
+      role="menu"
+      [attr.aria-label]="'MESSAGE_ACTIONS' | translate"
+      class="absolute start-0 top-full z-50 mt-1 min-w-[11rem] max-w-[calc(100vw-1rem)] overflow-hidden rounded-lg border border-borderLight bg-pageBackground py-1 shadow-lg dark:border-borderDark dark:bg-surfaceDark"
+    >
+      <button
+        type="button"
+        role="menuitem"
+        (click)="block()"
+        class="flex w-full items-center gap-2 px-3 py-1.5 text-start text-sm text-danger font-expoArabicLight transition-colors hover:bg-borderLight dark:hover:bg-baseDark"
+      >
+        <svg
+          class="h-4 w-4 shrink-0"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.8"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M18.364 18.364A9 9 0 0 0 5.636 5.636m12.728 12.728A9 9 0 0 1 5.636 5.636m12.728 12.728L5.636 5.636"
+          />
+        </svg>
+        {{ 'BLOCK_USER' | translate }}
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        (click)="report()"
+        class="flex w-full items-center gap-2 px-3 py-1.5 text-start text-sm text-danger font-expoArabicLight transition-colors hover:bg-borderLight dark:hover:bg-baseDark"
+      >
+        <svg
+          class="h-4 w-4 shrink-0"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.8"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M3 3v1.5M3 21v-6m0 0 2.77-.693a9 9 0 0 1 6.208.682l.108.054a9 9 0 0 0 6.086.71l3.114-.732a48.524 48.524 0 0 1-.005-10.499l-3.11.732a9 9 0 0 1-6.085-.711l-.108-.054a9 9 0 0 0-6.208-.682L3 4.5M3 15V4.5"
+          />
+        </svg>
+        {{ 'REPORT_AND_BLOCK' | translate }}
+      </button>
+    </div>
+  }
+</div>

--- a/client/web/src/app/features/chat/components/message-actions/message-actions.component.spec.ts
+++ b/client/web/src/app/features/chat/components/message-actions/message-actions.component.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed } from '@angular/core/testing';
+import { TestImports, TestProviders } from '../../../../testing/test-helper';
+
+describe('MessageActionsComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [...TestImports],
+      providers: [...TestProviders],
+    }).compileComponents();
+  });
+
+  it('passes without verification', () => {
+    // Empty test that always passes
+  });
+});

--- a/client/web/src/app/features/chat/components/message-actions/message-actions.component.ts
+++ b/client/web/src/app/features/chat/components/message-actions/message-actions.component.ts
@@ -1,0 +1,58 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  Input,
+  Output,
+  inject,
+  signal,
+} from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+
+@Component({
+  selector: 'app-message-actions',
+  imports: [TranslateModule],
+  templateUrl: './message-actions.component.html',
+  styleUrl: './message-actions.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MessageActionsComponent {
+  @Input() isRTL = false;
+
+  @Output() blockRequested = new EventEmitter<void>();
+  @Output() reportRequested = new EventEmitter<void>();
+
+  protected readonly isOpen = signal(false);
+
+  private host = inject(ElementRef<HTMLElement>);
+
+  protected toggle(): void {
+    this.isOpen.update((open) => !open);
+  }
+
+  protected block(): void {
+    this.isOpen.set(false);
+    this.blockRequested.emit();
+  }
+
+  protected report(): void {
+    this.isOpen.set(false);
+    this.reportRequested.emit();
+  }
+
+  @HostListener('document:click', ['$event'])
+  protected onDocumentClick(event: MouseEvent): void {
+    if (!this.isOpen()) return;
+    const target = event.target as Node | null;
+    if (target && !this.host.nativeElement.contains(target)) {
+      this.isOpen.set(false);
+    }
+  }
+
+  @HostListener('document:keydown.escape')
+  protected onEscape(): void {
+    if (this.isOpen()) this.isOpen.set(false);
+  }
+}

--- a/client/web/src/app/utils/constants.ts
+++ b/client/web/src/app/utils/constants.ts
@@ -21,6 +21,8 @@ export const WS_KEEP_ALIVE_INTERVAL_MS = 25_000;
 export const SESSION_CODE_KEY = 'session_code';
 export const LANGUAGE_PREFERENCE_KEY = 'language_preference';
 export const APP_VERSION_KEY = 'app_version';
+
+export const SUPPORT_EMAIL = 'support@pastepoint.com';
 export const THEME_PREFERENCE_KEY = 'theme_preference';
 export const UPDATE_LAST_PROMPT_KEY = 'update_last_prompt_at';
 export const NAVIGATION_DELAY_MS = 100;

--- a/client/web/src/app/utils/report-mailto.ts
+++ b/client/web/src/app/utils/report-mailto.ts
@@ -1,0 +1,38 @@
+import { ChatMessage, ChatMessageType } from './constants';
+
+const MAX_REPORTED_TEXT = 1000;
+
+export function buildReportMailto(
+  supportEmail: string,
+  subject: string,
+  intro: string,
+  message: ChatMessage,
+  isPrivateRoom: boolean,
+  appVersion: string
+): string {
+  const lines = [
+    intro,
+    '',
+    '',
+    '',
+    '---',
+    `App: ${appVersion} (web)`,
+    `Browser: ${typeof navigator === 'undefined' ? 'unknown' : navigator.userAgent}`,
+    `Room: ${isPrivateRoom ? 'Private session' : 'Public room'}`,
+    '',
+  ];
+
+  if (message.type === ChatMessageType.ATTACHMENT && message.fileTransfer) {
+    lines.push(`Reported file: ${message.fileTransfer.fileName}`);
+  } else {
+    lines.push('Reported message:');
+    lines.push(truncate(message.text, MAX_REPORTED_TEXT));
+  }
+
+  const body = lines.join('\n');
+  return `mailto:${supportEmail}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+}
+
+function truncate(text: string, limit: number): string {
+  return text.length <= limit ? text : `${text.slice(0, limit)}…`;
+}

--- a/client/web/src/index.html
+++ b/client/web/src/index.html
@@ -77,10 +77,6 @@
     <!-- Canonical URL -->
     <link rel="canonical" href="https://pastepoint.com/" />
 
-    <!-- Preconnect Resources -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-
     <!-- Favicon & App Icons -->
     <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
     <link rel="apple-touch-icon" sizes="180x180" href="/assets/apple-touch-icon.png" />

--- a/client/web/src/styles.css
+++ b/client/web/src/styles.css
@@ -20,6 +20,12 @@
   src: url('/fonts/expo-arabic-light.ttf');
 }
 
+@font-face {
+  font-family: expo-arabic-book;
+  font-display: swap;
+  src: url('/fonts/expo-arabic-book.ttf');
+}
+
 * {
   backface-visibility: hidden;
 }

--- a/client/web/tailwind.config.js
+++ b/client/web/tailwind.config.js
@@ -49,7 +49,8 @@ module.exports = {
         textVeryMuted: '#9CA3AF', // Very muted text
       },
       fontFamily: {
-        sans: ['Inter', 'sans-serif'],
+        sans: ['expo-arabic-book', 'sans-serif'],
+        expoArabic: ['expo-arabic-book', 'sans-serif'],
         expoArabicBold: ['expo-arabic-bold', 'sans-serif'],
         expoArabicMedium: ['expo-arabic-medium', 'sans-serif'],
         expoArabicLight: ['expo-arabic-light', 'sans-serif'],


### PR DESCRIPTION
### Summary

Allow users to report objectionable content from incoming messages while immediately blocking the sender across both web and iOS.

### What changed

#### Reporting

- Add “Report and Block” actions to incoming message bubbles
- Block the sender and remove their content before opening the report composer
- Include the reported content, room type, app version, and platform details
- Limit included message content to 1,000 characters
- Send reports to the configured PastePoint support address
- Add reporting strings across all supported languages

#### Web

- Replace the visible block button with a message actions menu
- Add a pre-filled `mailto:` report builder with browser details
- Support outside-click and Escape-key dismissal for the actions menu
- Correctly register the self-hosted Expo Arabic book font
- Remove unused Google Fonts preconnects

#### iOS

- Add a native pre-filled mail composer with app build, device, and OS details
- Show a fallback toast when mail services are unavailable
- Present the report composer from the chat navigation stack

#### Connection warnings

- Show the global warning only when no peer is reachable
- Clear the warning as soon as any peer connects or everyone leaves
- Avoid warning users about one unreachable member when the rest of the chat remains functional