### PR TITLE
Web: Allow attaching files to chat via clipboard paste

### DIFF
--- a/client/web/src/app/features/chat/chat.component.html
+++ b/client/web/src/app/features/chat/chat.component.html
@@ -47,6 +47,7 @@
       (dragenter)="onChatDragEnter($event)"
       (dragleave)="onChatDragLeave($event)"
       (drop)="onChatDrop($event)"
+      (paste)="onChatPaste($event)"
     >
       <!-- MARK: - Drag & Drop Overlay (whole chat view) -->
       @if (isDraggingFiles) {

--- a/client/web/src/app/features/chat/chat.component.ts
+++ b/client/web/src/app/features/chat/chat.component.ts
@@ -2018,6 +2018,14 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
     this.handleFilesDropped(files);
   }
 
+  protected onChatPaste(event: ClipboardEvent): void {
+    const files = Array.from(event.clipboardData?.files ?? []);
+    if (files.length === 0) return;
+
+    event.preventDefault();
+    this.handleFilesDropped(files);
+  }
+
   /**
    * ==========================================================
    * HANDLE FILES DROPPED


### PR DESCRIPTION
#### Summary

- Add a paste event listener to the chat component that extracts files from the clipboard and routes them through the existing file-drop handler.