### PR TITLE
Improve connection reliability and session handling across platforms

### DIFF
--- a/client/ios/PastePoint/Core/Services/Connection/ConnectionWarningMonitor.swift
+++ b/client/ios/PastePoint/Core/Services/Connection/ConnectionWarningMonitor.swift
@@ -15,7 +15,7 @@ final class ConnectionWarningMonitor: ObservableObject {
   private let signalingService: SignalingService
   private let logger = Logger(label: "ConnectionWarningMonitor")
 
-  private static let warningDelay: TimeInterval = 15
+  private static let warningDelay: TimeInterval = 25
   private var dismissed = false
   private var timer: Task<Void, Never>?
   private var cancellables: Set<AnyCancellable> = []

--- a/client/ios/PastePoint/Core/Services/WebRTC/SignalingService.swift
+++ b/client/ios/PastePoint/Core/Services/WebRTC/SignalingService.swift
@@ -603,8 +603,8 @@ extension SignalingService {
       return false
     }
 
-    guard channel.bufferedAmount < WebRTCConfig.maxBufferedAmount else {
-      logger.warning("channel to \(peer) back-pressured (\(channel.bufferedAmount) bytes)")
+    guard !isBinary || channel.bufferedAmount < WebRTCConfig.maxBufferedAmount else {
+      logger.debug("channel to \(peer) back-pressured (\(channel.bufferedAmount) bytes)")
       return false
     }
 

--- a/client/ios/PastePoint/Core/Services/WebRTC/SignalingService.swift
+++ b/client/ios/PastePoint/Core/Services/WebRTC/SignalingService.swift
@@ -57,6 +57,7 @@ final class SignalingService: NSObject, ObservableObject {
   private var reconnectTasks: [String: Task<Void, Never>] = [:]
   private var connectionTimeouts: [String: Task<Void, Never>] = [:]
   private var connectionRequestTimeouts: [String: Task<Void, Never>] = [:]
+  private var pendingOpens: Set<String> = []
 
   // MARK: - Init
 
@@ -107,6 +108,11 @@ final class SignalingService: NSObject, ObservableObject {
 
     guard peerConnections[peer] == nil else {
       logger.warning("already have a connection to \(peer)")
+      return
+    }
+
+    if !force, connectionRequestTimeouts[peer] != nil {
+      logger.debug("connection request already outstanding for \(peer)")
       return
     }
 
@@ -200,7 +206,10 @@ final class SignalingService: NSObject, ObservableObject {
 #endif
 
     let target = Set(peers)
-    let tracked = Set(peerConnections.keys).union(connectionLocks)
+    let tracked = Set(peerConnections.keys)
+      .union(connectionLocks)
+      .union(connectionRequestTimeouts.keys)
+      .union(pendingOpens)
 
     let toOpen = target.subtracting(tracked)
     let toClose = tracked.subtracting(target)
@@ -212,8 +221,10 @@ final class SignalingService: NSObject, ObservableObject {
 
     for peer in toOpen {
       logger.info("opening connection to \(peer) (joined room)")
+      pendingOpens.insert(peer)
       Task {
         await initiateConnection(to: peer)
+        pendingOpens.remove(peer)
       }
     }
   }
@@ -222,6 +233,7 @@ final class SignalingService: NSObject, ObservableObject {
     for peer in Set(peerConnections.keys).union(connectionLocks) {
       closePeerConnection(peer)
     }
+    pendingOpens.removeAll()
 
     syncMesh(peers: peerDirectory.peers)
   }

--- a/client/ios/PastePoint/Views/Settings/Sheets/SettingsScanQRCodeView.swift
+++ b/client/ios/PastePoint/Views/Settings/Sheets/SettingsScanQRCodeView.swift
@@ -30,6 +30,10 @@ private struct QRCodeScannerRepresentable: UIViewControllerRepresentable {
 
   func updateUIViewController(_: DataScannerViewController, context _: Context) {}
 
+  static func dismantleUIViewController(_ scanner: DataScannerViewController, coordinator _: Coordinator) {
+    scanner.stopScanning()
+  }
+
   func makeCoordinator() -> Coordinator {
     Coordinator(
       onCodeScanned: onCodeScanned,

--- a/client/web/src/app/core/services/file-management/file-upload.service.ts
+++ b/client/web/src/app/core/services/file-management/file-upload.service.ts
@@ -704,7 +704,7 @@ export class FileUploadService extends FileTransferBaseService {
         fileTransfer.phase = 'finalizing';
 
         const userMap = await this.getFileTransfers(fileTransfer.targetUser);
-        if (userMap) {
+        if (userMap?.has(fileTransfer.fileId)) {
           userMap.set(fileTransfer.fileId, fileTransfer);
           await this.setFileTransfers(fileTransfer.targetUser, userMap);
         }

--- a/client/web/src/app/features/chat/chat.component.ts
+++ b/client/web/src/app/features/chat/chat.component.ts
@@ -1799,7 +1799,7 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
     // Callers initiate immediately, callees wait to give callers time to send offers
     otherMembers.forEach((member, index) => {
       // Determine if we should be the caller for this member
-      const shouldInitiate = this.userService.user.localeCompare(member) < 0;
+      const shouldInitiate = this.userService.user < member;
 
       // Callers start at 1000ms, callees wait an additional 500ms
       const baseDelay = 1000;

--- a/client/web/src/app/features/chat/chat.component.ts
+++ b/client/web/src/app/features/chat/chat.component.ts
@@ -20,6 +20,7 @@ import { ThemeService } from '../../core/services/ui/theme.service';
 import { ChatService } from '../../core/services/communication/chat.service';
 import { BlockService } from '../../core/services/communication/block.service';
 import { buildReportMailto } from '../../utils/report-mailto';
+import { environment } from '../../../environments/environment';
 import { HeartbeatService } from '../../core/services/communication/heartbeat.service';
 import { RoomService } from '../../core/services/room-management/room.service';
 import { FileTransferService } from '../../core/services/file-management/file-transfer.service';
@@ -1676,7 +1677,7 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
     if (!this.SessionCode || !isPlatformBrowser(this.platformId)) {
       return '';
     }
-    return `${window.location.origin}/private/${this.SessionCode}`;
+    return `https://${environment.webUrl}/private/${this.SessionCode}`;
   }
 
   /**

--- a/client/web/src/app/features/chat/components/popups/join-session-popup/join-session-popup.component.ts
+++ b/client/web/src/app/features/chat/components/popups/join-session-popup/join-session-popup.component.ts
@@ -16,6 +16,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { DeviceDetectorService } from 'ngx-device-detector';
+import { environment } from '../../../../../../environments/environment';
 
 type JsQrFn = typeof import('jsqr').default;
 
@@ -187,7 +188,7 @@ export class JoinSessionPopupComponent implements OnChanges, OnDestroy {
   private extractSessionCode(payload: string): string | null {
     try {
       const url = new URL(payload);
-      if (url.origin !== window.location.origin) {
+      if (url.host !== environment.webUrl) {
         return null;
       }
       const parts = url.pathname.split('/').filter(Boolean);

--- a/client/web/src/app/features/chat/components/popups/qr-code-popup/qr-code-popup.component.ts
+++ b/client/web/src/app/features/chat/components/popups/qr-code-popup/qr-code-popup.component.ts
@@ -15,6 +15,7 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { HotToastService } from '@ngxpert/hot-toast';
 import { NGXLogger } from 'ngx-logger';
 import * as QRCode from 'qrcode';
+import { environment } from '../../../../../../environments/environment';
 
 @Component({
   selector: 'app-qr-code-popup',
@@ -50,7 +51,7 @@ export class QrCodePopupComponent implements OnChanges {
 
     try {
       const parsedUrl = new URL(this.sessionUrl);
-      if (parsedUrl.origin !== window.location.origin) {
+      if (parsedUrl.host !== environment.webUrl) {
         this.logger.warn('generateQRCode', 'Rejected QR code for external URL');
         this.toaster.error(this.translate.instant('QR_CODE_INVALID_URL'));
         return;

--- a/client/web/src/app/utils/constants.ts
+++ b/client/web/src/app/utils/constants.ts
@@ -33,7 +33,7 @@ export const UPDATE_OPTIONAL_THROTTLE_MS = 12 * 60 * 60 * 1000; // 12h
 // Inactivity timeout constants
 export const IDLE_TIMEOUT = 12 * 60 * 60 * 1000; // 12 hours
 export const BACKGROUND_EXPIRY_THRESHOLD = 5 * 60 * 1000; // 5 minutes
-export const CONNECTION_WARNING_DELAY_MS = 15_000; // 15 seconds before showing connection warning
+export const CONNECTION_WARNING_DELAY_MS = 25_000; // 25 seconds before showing connection warning
 
 // WebRTC constants
 export const MAX_RECONNECT_ATTEMPTS = 5;

--- a/client/web/src/environments/environment.docker-dev.ts
+++ b/client/web/src/environments/environment.docker-dev.ts
@@ -3,6 +3,7 @@ import { NgxLoggerLevel } from 'ngx-logger';
 export const environment = {
   production: false,
   apiUrl: '127.0.0.1',
+  webUrl: '127.0.0.1',
   logLevel: NgxLoggerLevel.DEBUG,
   enableSourceMaps: true,
   disableFileDetails: false,

--- a/client/web/src/environments/environment.prod.ts
+++ b/client/web/src/environments/environment.prod.ts
@@ -3,6 +3,7 @@ import { NgxLoggerLevel } from 'ngx-logger';
 export const environment = {
   production: true,
   apiUrl: 'pastepoint.com',
+  webUrl: 'pastepoint.com',
   logLevel: NgxLoggerLevel.ERROR,
   enableSourceMaps: false,
   disableFileDetails: true,

--- a/client/web/src/environments/environment.ts
+++ b/client/web/src/environments/environment.ts
@@ -3,6 +3,7 @@ import { NgxLoggerLevel } from 'ngx-logger';
 export const environment = {
   production: false,
   apiUrl: '127.0.0.1:9000',
+  webUrl: '127.0.0.1',
   logLevel: NgxLoggerLevel.DEBUG,
   enableSourceMaps: true,
   disableFileDetails: false,

--- a/scripts/configure-network.sh
+++ b/scripts/configure-network.sh
@@ -89,9 +89,13 @@ escaped_ip="$(escape_sed_replacement "$local_ip")"
 # Use regex to match any current IP so the script is idempotent across runs
 sed_in_place "s|apiUrl: '[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*:9000'|apiUrl: '$escaped_ip:9000'|g" \
     "$PROJECT_ROOT/client/web/src/environments/environment.ts"
+sed_in_place "s|webUrl: '[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*'|webUrl: '$escaped_ip'|g" \
+    "$PROJECT_ROOT/client/web/src/environments/environment.ts"
 echo "Updated environment.ts"
 
 sed_in_place "s|apiUrl: '[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*'|apiUrl: '$escaped_ip'|g" \
+    "$PROJECT_ROOT/client/web/src/environments/environment.docker-dev.ts"
+sed_in_place "s|webUrl: '[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*'|webUrl: '$escaped_ip'|g" \
     "$PROJECT_ROOT/client/web/src/environments/environment.docker-dev.ts"
 echo "Updated environment.docker-dev.ts"
 

--- a/server/src/consts.rs
+++ b/server/src/consts.rs
@@ -20,8 +20,8 @@ pub(crate) const MAX_WS_MESSAGES_PER_SEC: usize = 30;
 
 // Timing intervals
 pub const KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(3600);
-pub const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
-pub const HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(90);
+pub const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+pub const HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(15);
 pub const SESSION_EXPIRATION_TIME: Duration = Duration::from_secs(60);
 pub const CLEANUP_INTERVAL: Duration = Duration::from_secs(3600);
 


### PR DESCRIPTION
### Summary

Improve stale-session cleanup, WebRTC connection behavior, file-transfer cancellation, invite links, and QR scanner lifecycle across the server, web, and iOS clients.

### What changed

#### Server

- Shorten the WebSocket heartbeat interval from 30 to 5 seconds
- Reduce the heartbeat timeout from 90 to 15 seconds
- Remove disconnected clients and phantom room members within roughly 20 seconds

#### Web

- Use deterministic byte comparison when selecting the WebRTC caller
- Prevent cancelled uploads from reappearing as completed transfers
- Build invite and QR links from the configured web host
- Validate scanned and generated QR links against that configured host
- Update the network configuration script to keep the web host synchronized
- Increase the connection warning delay from 15 to 25 seconds

#### iOS

- Prevent duplicate connection requests during rapid mesh synchronization
- Allow control messages through while binary file chunks are back-pressured
- Ensure upload cancellation reaches the receiving peer immediately
- Increase the connection warning delay from 15 to 25 seconds
- Stop the QR scanner before its view controller is dismantled