### PR TITLE
Add ephemeral TURN credentials across server, web, and iOS

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -25,3 +25,8 @@ SERVER_NAME=127.0.0.1
 # local .env.development (which is gitignored).
 SENTRY_DSN=
 SENTRY_ENABLED=false
+
+# TURN relay (GET /turn-credentials)
+# Empty = endpoint 204s and clients stay STUN-only (fine for LAN dev).
+# Set it only in your gitignored .env.development.
+TURN_SECRET=

--- a/.env.production.example
+++ b/.env.production.example
@@ -25,3 +25,8 @@ SERVER_NAME=pastepoint.com
 # disabled even if SENTRY_ENABLED=true.
 SENTRY_DSN=
 SENTRY_ENABLED=true
+
+# TURN relay (GET /turn-credentials)
+# Empty = endpoint 204s and clients stay STUN-only.
+# Set this only in your gitignored .env.production.
+TURN_SECRET=

--- a/client/ios/PastePoint/Core/Config/AppEnvironment.swift
+++ b/client/ios/PastePoint/Core/Config/AppEnvironment.swift
@@ -32,6 +32,9 @@ enum AppEnvironment {
   /// Used for the launch-time client version/update-policy check.
   static var versionUrl: String { "https://\(apiUrl)/version" }
 
+  /// Used for fetching short-lived TURN relay credentials.
+  static var turnCredentialsUrl: String { "https://\(apiUrl)/turn-credentials" }
+
   /// Used for connecting to the signaling WebSocket.
   static func webSocketUrl(sessionCode: String?) -> String {
     "wss://\(apiUrl)/ws\(sessionCode.map { "/\($0)" } ?? "")"

--- a/client/ios/PastePoint/Core/Services/WebRTC/PeerConnectionFactory.swift
+++ b/client/ios/PastePoint/Core/Services/WebRTC/PeerConnectionFactory.swift
@@ -19,10 +19,13 @@ final class PeerConnectionFactory: @unchecked Sendable {
     factory = RTCPeerConnectionFactory(encoderFactory: nil, decoderFactory: nil)
   }
 
-  func makePeerConnection(delegate: RTCPeerConnectionDelegate) -> RTCPeerConnection? {
+  func makePeerConnection(
+    iceServers: [RTCIceServer],
+    delegate: RTCPeerConnectionDelegate,
+  ) -> RTCPeerConnection? {
     let constraints = RTCMediaConstraints(mandatoryConstraints: nil, optionalConstraints: nil)
     return factory.peerConnection(
-      with: WebRTCConfig.peerConnectionConfig,
+      with: WebRTCConfig.makeConfiguration(iceServers: iceServers),
       constraints: constraints,
       delegate: delegate,
     )

--- a/client/ios/PastePoint/Core/Services/WebRTC/SignalingService.swift
+++ b/client/ios/PastePoint/Core/Services/WebRTC/SignalingService.swift
@@ -59,6 +59,8 @@ final class SignalingService: NSObject, ObservableObject {
   private var connectionRequestTimeouts: [String: Task<Void, Never>] = [:]
   private var pendingOpens: Set<String> = []
 
+  private let turnCredentials = TurnCredentialsService()
+
   // MARK: - Init
 
   init(
@@ -77,6 +79,14 @@ final class SignalingService: NSObject, ObservableObject {
       .receive(on: DispatchQueue.main)
       .sink { [weak self] message in
         self?.handle(message)
+      }
+      .store(in: &cancellables)
+
+    // Warm the TURN credential cache on connect so the first peer connection
+    wsService.didConnect
+      .receive(on: DispatchQueue.main)
+      .sink { [weak self] in
+        Task { _ = await self?.turnCredentials.iceServers() }
       }
       .store(in: &cancellables)
 
@@ -136,7 +146,7 @@ final class SignalingService: NSObject, ObservableObject {
     connectingPeers.insert(peer)
     startConnectionTimeout(for: peer)
 
-    guard let pc = PeerConnectionFactory.shared.makePeerConnection(delegate: self) else {
+    guard let pc = PeerConnectionFactory.shared.makePeerConnection(iceServers: await turnCredentials.iceServers(), delegate: self) else {
       logger.error("factory returned nil for \(peer)")
       connectionLocks.remove(peer)
       return
@@ -304,7 +314,7 @@ extension SignalingService {
     }
     let remoteSdp = RTCSessionDescription(type: .offer, sdp: sdpString)
 
-    guard let pc = PeerConnectionFactory.shared.makePeerConnection(delegate: self) else {
+    guard let pc = PeerConnectionFactory.shared.makePeerConnection(iceServers: await turnCredentials.iceServers(), delegate: self) else {
       logger.error("factory returned nil for \(message.from)")
       connectionLocks.remove(message.from)
       return

--- a/client/ios/PastePoint/Core/Services/WebRTC/TurnCredentialsService.swift
+++ b/client/ios/PastePoint/Core/Services/WebRTC/TurnCredentialsService.swift
@@ -1,0 +1,82 @@
+//
+//  Copyright © 2026 PastePoint. All rights reserved.
+//  SPDX-License-Identifier: GPL-3.0-only
+//
+
+import Foundation
+import Logging
+import WebRTC
+
+/// Fetches short-lived TURN credentials from `GET /turn-credentials` and caches
+/// the resulting ICE server list (STUN + relay) until shortly before the
+/// credential expires. Concurrent callers share one in-flight fetch; failures
+/// and a 204 (no relay configured) fall back to STUN-only.
+@MainActor
+final class TurnCredentialsService {
+  private struct Response: Decodable {
+    let username: String
+    let credential: String
+    let ttl: Int
+    let urls: [String]
+  }
+
+  private let logger = Logger(label: "TurnCredentials")
+
+  private var cached: [RTCIceServer]?
+  private var expiresAt: Date = .distantPast
+
+  /// STUN + a relay when available; cached until just before expiry.
+  func iceServers() async -> [RTCIceServer] {
+    if let cached, Date() < expiresAt { return cached }
+    return await load()
+  }
+
+  private func load() async -> [RTCIceServer] {
+    guard let url = URL(string: AppEnvironment.turnCredentialsUrl) else {
+      return WebRTCConfig.stunServers
+    }
+
+    do {
+      let (data, response) = try await session().data(from: url)
+      guard
+        let http = response as? HTTPURLResponse,
+        (200...299).contains(http.statusCode),
+        http.statusCode != 204,
+        !data.isEmpty
+      else {
+        logger.info("No TURN relay configured on server — STUN-only")
+        return WebRTCConfig.stunServers
+      }
+
+      let creds = try JSONDecoder().decode(Response.self, from: data)
+      guard !creds.urls.isEmpty, !creds.username.isEmpty, !creds.credential.isEmpty else {
+        logger.info("No TURN relay configured on server — STUN-only")
+        return WebRTCConfig.stunServers
+      }
+
+      let relay = RTCIceServer(
+        urlStrings: creds.urls,
+        username: creds.username,
+        credential: creds.credential,
+      )
+      let servers = WebRTCConfig.stunServers + [relay]
+      cached = servers
+
+      // Refresh a minute before the credential actually expires.
+      expiresAt = Date().addingTimeInterval(TimeInterval(max(creds.ttl - 60, 60)))
+      logger.info("TURN credentials fetched — relay available (ttl \(creds.ttl)s, urls: \(creds.urls.joined(separator: ", ")))")
+      return servers
+    } catch {
+      logger.debug("TURN fetch failed, STUN-only: \(error.localizedDescription)")
+      return WebRTCConfig.stunServers
+    }
+  }
+
+  private func session() -> URLSession {
+#if DEBUG
+    URLSession(configuration: .default, delegate: InsecureSession(), delegateQueue: nil)
+#else
+    URLSession.shared
+#endif
+  }
+}

--- a/client/ios/PastePoint/Core/Services/WebRTC/WebRTCConfig.swift
+++ b/client/ios/PastePoint/Core/Services/WebRTC/WebRTCConfig.swift
@@ -10,8 +10,8 @@ enum WebRTCConfig {
   static let maxBufferedAmount: UInt64 = 16 * 1024 * 1024 // 16MB
   static let bufferedAmountLowThreshold: UInt64 = 8 * 1024 * 1024 // 8MB
 
-  static let iceServers: [RTCIceServer] = [
-    // Public STUN servers
+  /// Public STUN servers only.
+  static let stunServers: [RTCIceServer] = [
     RTCIceServer(urlStrings: [
       "stun:stun.l.google.com:19302",
       "stun:stun.cloudflare.com:3478",
@@ -19,14 +19,17 @@ enum WebRTCConfig {
     ]),
   ]
 
-  static let peerConnectionConfig: RTCConfiguration = {
+  /// Builds a peer-connection config with the given ICE servers (STUN, plus a
+  /// relay when credentials are available).
+  static func makeConfiguration(iceServers: [RTCIceServer]) -> RTCConfiguration {
     let config = RTCConfiguration()
     config.iceServers = iceServers
     config.sdpSemantics = .unifiedPlan
     config.bundlePolicy = .maxBundle
     config.rtcpMuxPolicy = .require
+    config.iceCandidatePoolSize = 10
     return config
-  }()
+  }
 
   static let dataChannelConfig: RTCDataChannelConfiguration = {
     let config = RTCDataChannelConfiguration()

--- a/client/web/src/app/core/services/communication/turn-credentials.service.ts
+++ b/client/web/src/app/core/services/communication/turn-credentials.service.ts
@@ -1,0 +1,67 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, PLATFORM_ID, inject } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { NGXLogger } from 'ngx-logger';
+import { firstValueFrom } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import { ICE_SERVERS } from '../../../utils/constants';
+
+interface TurnCredentialsResponse {
+  username: string;
+  credential: string;
+  ttl: number;
+  urls: string[];
+}
+
+/**
+ * Fetches short-lived TURN credentials from `GET /turn-credentials` and exposes
+ * the ICE server list (STUN + relay). Refreshed on each WebSocket connect so a
+ * long-idle tab never relays with an expired credential; failures fall back to
+ * STUN-only (direct/STUN connections still work).
+ */
+@Injectable({ providedIn: 'root' })
+export class TurnCredentialsService {
+  private http = inject(HttpClient);
+  private logger = inject(NGXLogger);
+  private platformId = inject(PLATFORM_ID);
+
+  private servers: RTCIceServer[] = [...ICE_SERVERS];
+  private fetching = false;
+
+  constructor() {
+    // Warm the cache at construction
+    void this.refresh();
+  }
+
+  get iceServers(): RTCIceServer[] {
+    return this.servers;
+  }
+
+  async refresh(): Promise<void> {
+    if (!isPlatformBrowser(this.platformId) || this.fetching) return;
+    this.fetching = true;
+
+    try {
+      const url = `https://${environment.apiUrl}/turn-credentials`;
+      const res = await firstValueFrom(this.http.get<TurnCredentialsResponse>(url));
+      if (res?.urls?.length && res.username && res.credential) {
+        this.servers = [
+          ...ICE_SERVERS,
+          { urls: res.urls, username: res.username, credential: res.credential },
+        ];
+        this.logger.info(
+          'TurnCredentialsService',
+          `TURN credentials fetched — relay available (ttl ${res.ttl}s, urls: ${res.urls.join(', ')})`
+        );
+      } else {
+        // 204 / disabled — stay STUN-only.
+        this.servers = [...ICE_SERVERS];
+        this.logger.info('TurnCredentialsService', 'No TURN relay configured on server — STUN-only');
+      }
+    } catch (error) {
+      this.logger.debug('TurnCredentialsService', 'TURN fetch failed, STUN-only', error);
+    } finally {
+      this.fetching = false;
+    }
+  }
+}

--- a/client/web/src/app/core/services/communication/turn-credentials.service.ts
+++ b/client/web/src/app/core/services/communication/turn-credentials.service.ts
@@ -56,7 +56,10 @@ export class TurnCredentialsService {
       } else {
         // 204 / disabled — stay STUN-only.
         this.servers = [...ICE_SERVERS];
-        this.logger.info('TurnCredentialsService', 'No TURN relay configured on server — STUN-only');
+        this.logger.info(
+          'TurnCredentialsService',
+          'No TURN relay configured on server — STUN-only'
+        );
       }
     } catch (error) {
       this.logger.debug('TurnCredentialsService', 'TURN fetch failed, STUN-only', error);

--- a/client/web/src/app/core/services/communication/webrtc-signaling.service.ts
+++ b/client/web/src/app/core/services/communication/webrtc-signaling.service.ts
@@ -20,6 +20,7 @@ import {
 import { TranslateService } from '@ngx-translate/core';
 import { NGXLogger } from 'ngx-logger';
 import { WebRTCCommunicationService } from './webrtc-communication.service';
+import { TurnCredentialsService } from './turn-credentials.service';
 import { HotToastService } from '@ngxpert/hot-toast';
 import { Subject } from 'rxjs';
 
@@ -34,6 +35,7 @@ export class WebRTCSignalingService {
   private translate = inject<TranslateService>(TranslateService);
   private logger = inject(NGXLogger);
   private communicationService = inject(WebRTCCommunicationService);
+  private turnCredentials = inject(TurnCredentialsService);
 
   // =============== Properties ===============
   public peerDisconnected$ = new Subject<string>();
@@ -60,6 +62,9 @@ export class WebRTCSignalingService {
 
   constructor() {
     this.initializeSignalMessageHandler();
+
+    // Refresh TURN credentials on every connect so peers created afterwards
+    this.wsService.connected$.subscribe(() => void this.turnCredentials.refresh());
 
     this.userService.user$.subscribe((user) => {
       if (user && this.pendingSignals.length > 0) {
@@ -552,7 +557,10 @@ export class WebRTCSignalingService {
       this.peerConnections.delete(targetUser);
     }
 
-    const peerConnection = new RTCPeerConnection(RTC_CONFIGURATION);
+    const peerConnection = new RTCPeerConnection({
+      ...RTC_CONFIGURATION,
+      iceServers: this.turnCredentials.iceServers,
+    });
 
     let iceGatheringTimeout: ReturnType<typeof setTimeout> | null = null;
     let iceGatheringComplete = false;

--- a/client/web/src/app/utils/constants.ts
+++ b/client/web/src/app/utils/constants.ts
@@ -60,8 +60,8 @@ export const RTC_SIGNALING_STATES = {
   STABLE: 'stable',
 } as const;
 
+// Public STUN servers only.
 export const ICE_SERVERS: RTCIceServer[] = [
-  // Public STUN servers
   { urls: 'stun:stun.l.google.com:19302' },
   { urls: 'stun:stun.cloudflare.com:3478' },
   { urls: 'stun:global.stun.twilio.com:3478' },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - RUN_ENV=${SERVER_ENV:?SERVER_ENV is required (set it in your .env file)}
       - SENTRY_ENABLED=${SENTRY_ENABLED:-false}
       - SENTRY_DSN=${SENTRY_DSN:-}
+      - TURN_SECRET=${TURN_SECRET:-}
     volumes:
       - ${CERT_PATH}:/etc/ssl/pastepoint:ro
     depends_on:

--- a/nginx/locations.conf
+++ b/nginx/locations.conf
@@ -77,6 +77,18 @@ location = /version {
     include /etc/nginx/includes/common_proxy_ws.conf;
 }
 
+# TURN credentials location
+location = /turn-credentials {
+    limit_req   zone=turn_cred_limit burst=10 nodelay;
+    limit_req_status    429;
+    limit_conn  conn_limit  5;
+    include /etc/nginx/security/security_headers.conf;
+
+    # Proxy to Backend server
+    proxy_pass https://backend_ws; # If your backend is listening on HTTP (not HTTPS), use http:// instead
+    include /etc/nginx/includes/common_proxy_ws.conf;
+}
+
 # WebSocket location
 location /ws {
     limit_req   zone=api_req_limit burst=80;

--- a/nginx/security/security_settings.conf
+++ b/nginx/security/security_settings.conf
@@ -4,8 +4,9 @@ limit_req_zone  $binary_remote_addr  zone=general_req_limit:10m  rate=2000r/m;
 limit_req_zone  $binary_remote_addr  zone=api_req_limit:10m      rate=500r/m;
 limit_req_zone  $binary_remote_addr  zone=seo_req_limit:10m      rate=100r/m;
 limit_req_zone  $binary_remote_addr  zone=strict_req_limit:10m   rate=50r/m;
+limit_req_zone  $binary_remote_addr  zone=turn_cred_limit:10m    rate=20r/m;
 
-# Connection‑concurrency control 
+# Connection‑concurrency control
 limit_conn_zone $binary_remote_addr  zone=conn_limit:10m;
 
 # Drop the identifying part of the client address before it reaches disk

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rand 0.10.1",
- "sha1",
+ "sha1 0.11.0",
  "smallvec",
  "tokio",
  "tokio-util",
@@ -841,6 +841,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -883,6 +884,12 @@ checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
 ]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "either"
@@ -1298,6 +1305,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "hostname"
@@ -2752,12 +2768,15 @@ dependencies = [
  "actix-web",
  "actix-ws",
  "awc",
+ "base64",
  "bytes",
  "config",
  "derive_more",
+ "dotenvy",
  "env_logger",
  "fake",
  "futures-util",
+ "hmac",
  "log",
  "openssl",
  "rand 0.10.1",
@@ -2765,9 +2784,21 @@ dependencies = [
  "sentry-actix",
  "serde",
  "serde_json",
+ "sha1 0.10.7",
  "tokio",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -28,8 +28,12 @@ serde = { version = "1.0.228", features = ["derive"] }
 env_logger = "0.11.10"
 log = "0.4.29"
 rand = "0.10.1"
+hmac = "0.12.1"
+sha1 = "0.10.6"
+base64 = "0.22.1"
 bytes = "1.11.1"
 config = "0.15.22"
+dotenvy = "0.15.7"
 url = "2.5.8"
 sentry = { version = "0.48", features = ["log", "logs"] }
 sentry-actix = "0.48"

--- a/server/config/development.toml
+++ b/server/config/development.toml
@@ -27,3 +27,9 @@ enabled = false
 environment = "development"
 sample_rate = 1.0
 traces_sample_rate = 0.1
+
+# TURN relay for GET /turn-credentials. urls are the fixed public relay (same in
+# every env); the shared secret comes from the TURN_SECRET env var, never here.
+[turn]
+urls = ["turn:turn.pastepoint.com:3478", "turns:turn.pastepoint.com:5349"]
+ttl_seconds = 1800

--- a/server/config/docker-dev.toml
+++ b/server/config/docker-dev.toml
@@ -27,3 +27,9 @@ enabled = false
 environment = "docker-dev"
 sample_rate = 1.0
 traces_sample_rate = 0.1
+
+# TURN relay for GET /turn-credentials. urls are the fixed public relay (same in
+# every env); the shared secret comes from the TURN_SECRET env var, never here.
+[turn]
+urls = ["turn:turn.pastepoint.com:3478", "turns:turn.pastepoint.com:5349"]
+ttl_seconds = 1800

--- a/server/config/production.toml
+++ b/server/config/production.toml
@@ -27,3 +27,9 @@ enabled = true
 environment = "production"
 sample_rate = 1.0
 traces_sample_rate = 0.1
+
+# TURN relay for GET /turn-credentials. urls are the fixed public relay (same in
+# every env); the shared secret comes from the TURN_SECRET env var, never here.
+[turn]
+urls = ["turn:turn.pastepoint.com:3478", "turns:turn.pastepoint.com:5349"]
+ttl_seconds = 1800

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -89,6 +89,51 @@ impl ClientVersionConfig {
     }
 }
 
+fn default_turn_ttl() -> u64 {
+    1800
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct TurnConfig {
+    #[serde(default)]
+    pub secret: String,
+    #[serde(default)]
+    pub urls: Vec<String>,
+    #[serde(default = "default_turn_ttl")]
+    pub ttl_seconds: u64,
+}
+
+impl Default for TurnConfig {
+    fn default() -> Self {
+        Self {
+            secret: String::new(),
+            urls: Vec::new(),
+            ttl_seconds: default_turn_ttl(),
+        }
+    }
+}
+
+impl TurnConfig {
+    pub fn load() -> Self {
+        let environment = env::var("RUN_ENV").unwrap_or_else(|_| "development".to_string());
+
+        let mut cfg: Self = Config::builder()
+            .add_source(File::with_name(&format!("config/{environment}")).required(false))
+            .build()
+            .and_then(|s| s.get::<Self>("turn"))
+            .unwrap_or_default();
+
+        if let Ok(secret) = env::var("TURN_SECRET") {
+            cfg.secret = secret;
+        }
+        cfg
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        !self.secret.is_empty() && !self.urls.is_empty()
+    }
+}
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct ServerConfig {
     pub bind_address: String,

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -9,7 +9,7 @@ mod session;
 mod session_store;
 
 pub use chat_server::{ChatServerHandle, WsChatServer};
-pub use config::{ClientVersionConfig, SentryConfig, ServerConfig};
+pub use config::{ClientVersionConfig, SentryConfig, ServerConfig, TurnConfig};
 pub use consts::{
     CLEANUP_INTERVAL, CONTENT_TYPE_TEXT_PLAIN, CORS_MAX_AGE, HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT,
     KEEP_ALIVE_INTERVAL, MAX_FRAME_SIZE, MAX_SIGNAL_SIZE, MIN_USER_AGENT_LENGTH, SAFE_CHARSET,
@@ -18,5 +18,7 @@ pub use consts::{
     WS_PREFIX_SYSTEM_ROOMS, WS_PREFIX_USER_COMMAND, WS_PREFIX_USER_DISCONNECTED,
 };
 pub use error::ServerError;
-pub use routes::{chat_ws, create_session, health, index, private_chat_ws, version};
+pub use routes::{
+    chat_ws, create_session, health, index, private_chat_ws, turn_credentials, version,
+};
 pub use session_store::SessionStore;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -9,8 +9,8 @@ use actix_web::{
 use openssl::ssl::{SslAcceptor, SslFiletype, SslMethod};
 use server::{
     CORS_MAX_AGE, ClientVersionConfig, KEEP_ALIVE_INTERVAL, SentryConfig, ServerConfig,
-    SessionStore, chat_ws, create_session, health, index, private_chat_ws,
-    version as version_route,
+    SessionStore, TurnConfig, chat_ws, create_session, health, index, private_chat_ws,
+    turn_credentials, version as version_route,
 };
 use std::borrow::Cow;
 use std::io::Result;
@@ -79,6 +79,9 @@ fn init_sentry(cfg: &SentryConfig) -> Option<sentry::ClientInitGuard> {
 
 #[actix_web::main]
 async fn main() -> Result<()> {
+    #[cfg(debug_assertions)]
+    let _ = dotenvy::from_filename(".env.development");
+
     let sentry_cfg = SentryConfig::load();
     let _sentry_guard = init_sentry(&sentry_cfg);
 
@@ -146,12 +149,14 @@ async fn main() -> Result<()> {
 
     let server_config = Data::new(config.clone());
     let client_version = Data::new(ClientVersionConfig::load());
+    let turn_config = Data::new(TurnConfig::load());
     let sentry_enabled = _sentry_guard.is_some();
 
     HttpServer::new(move || {
         let server_config = server_config.clone();
         let server_config_for_app = server_config.clone();
         let client_version = client_version.clone();
+        let turn_config = turn_config.clone();
         let cors = Cors::default()
             .allowed_origin_fn(move |origin, _req_head| server_config.check_origin(origin))
             .allowed_methods(vec!["GET", "OPTIONS"])
@@ -169,9 +174,11 @@ async fn main() -> Result<()> {
             .app_data(session_manager.clone())
             .app_data(server_config_for_app)
             .app_data(client_version)
+            .app_data(turn_config)
             .service(index)
             .service(health)
             .service(version_route)
+            .service(turn_credentials)
             .service(create_session)
             .service(chat_ws)
             .service(private_chat_ws)

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -2,11 +2,18 @@
 
 use crate::{
     CONTENT_TYPE_TEXT_PLAIN, ClientVersionConfig, MIN_USER_AGENT_LENGTH, SESSION_CODE_LENGTH,
-    ServerConfig, ServerError, SessionStore, consts::MAX_SESSIONS, session_store::SessionData,
+    ServerConfig, ServerError, SessionStore, TurnConfig, consts::MAX_SESSIONS,
+    session_store::SessionData,
 };
 use actix_web::{Error, HttpRequest, HttpResponse, Responder, get, http::header, web};
+use base64::{Engine, engine::general_purpose::STANDARD};
+use hmac::{Hmac, Mac};
 use serde_json::json;
+use sha1::Sha1;
+use std::time::{SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
+
+type HmacSha1 = Hmac<Sha1>;
 
 // -----------------------------------------------------
 // Simple index route
@@ -36,6 +43,36 @@ pub async fn version(config: web::Data<ClientVersionConfig>) -> impl Responder {
     HttpResponse::Ok()
         .insert_header((header::CACHE_CONTROL, "public, max-age=300"))
         .json(config.get_ref())
+}
+
+// -----------------------------------------------------
+// TURN ephemeral credentials route
+// -----------------------------------------------------
+#[get("/turn-credentials")]
+pub async fn turn_credentials(turn: web::Data<TurnConfig>) -> Result<HttpResponse, ServerError> {
+    if !turn.is_enabled() {
+        return Ok(HttpResponse::NoContent().finish());
+    }
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|_| ServerError::InternalServerError)?
+        .as_secs();
+    let username = format!("{}:pastepoint", now + turn.ttl_seconds);
+
+    let mut mac = HmacSha1::new_from_slice(turn.secret.as_bytes())
+        .map_err(|_| ServerError::InternalServerError)?;
+    mac.update(username.as_bytes());
+    let credential = STANDARD.encode(mac.finalize().into_bytes());
+
+    Ok(HttpResponse::Ok()
+        .insert_header((header::CACHE_CONTROL, "no-store"))
+        .json(json!({
+            "username": username,
+            "credential": credential,
+            "ttl": turn.ttl_seconds,
+            "urls": turn.urls,
+        })))
 }
 
 // -----------------------------------------------------


### PR DESCRIPTION
### Summary

Add a production-ready TURN credential flow so peers can establish relayed WebRTC connections when direct connectivity fails, without shipping permanent relay credentials in either client.

### What changed

#### Server

- Add `GET /turn-credentials`
- Generate short-lived coturn REST credentials using HMAC-SHA1
- Configure relay URLs and credential lifetime through `[turn]`
- Read the shared secret exclusively from `TURN_SECRET`
- Return `204 No Content` when TURN is not configured
- Mark credential responses as `no-store`
- Load `.env.development` for standalone debug runs

#### Nginx and Docker

- Proxy `/turn-credentials` to the signaling server
- Add a dedicated rate limit of 20 requests per minute
- Limit concurrent credential requests per client
- Pass `TURN_SECRET` into the server container
- Document the variable in development and production environment examples

#### Web

- Add a service for fetching and caching short-lived TURN credentials
- Prewarm credentials and refresh them after WebSocket connections
- Append the configured relay to the existing STUN servers
- Build new peer connections with the current dynamic ICE server list
- Fall back to STUN-only connections when TURN is unavailable

#### iOS

- Add a cached `TurnCredentialsService`
- Prewarm credentials after connecting to the signaling server
- Refresh credentials shortly before expiration
- Await the current ICE server list before creating offers or answers
- Build peer connection configurations dynamically
- Fall back to STUN-only behavior when fetching credentials fails
- Enable ICE candidate pooling for faster connection setup