### PR TITLE
iOS: Add photo and video capture to the attachment menu

### DIFF
--- a/client/ios/PastePoint/Core/Services/App/AppServices.swift
+++ b/client/ios/PastePoint/Core/Services/App/AppServices.swift
@@ -194,7 +194,10 @@ final class AppServices: ObservableObject {
 
         let previous = self.lastPathStatus
         self.lastPathStatus = path.status
-        self.logger.debug("Network path updated: \(path.status)")
+
+        if previous != path.status {
+          self.logger.debug("Network path changed: \(previous) → \(path.status)")
+        }
 
         guard path.status == .satisfied, previous != .satisfied else { return }
         guard !self.isInBackground else { return }

--- a/client/ios/PastePoint/Core/Services/FileTransfer/FileStaging.swift
+++ b/client/ios/PastePoint/Core/Services/FileTransfer/FileStaging.swift
@@ -83,4 +83,35 @@ enum FileStaging {
 
     return staged
   }
+
+  /// Camera capture: photo bytes → write to tmp; video temp file → copy to tmp.
+  /// Both are owned temp files.
+  static func stage(camera capture: CameraCapture) async -> [StagedFile] {
+    let stamp = Self.photoNameFormatter.string(from: Date())
+    let suffix = UUID().uuidString.prefix(4)
+
+    do {
+      switch capture {
+      case .photo(let data):
+        let name = "Photo-\(stamp)-\(suffix).jpg"
+        let size = Int64(data.count)
+        let dest = FileManager.default.temporaryDirectory.appendingPathComponent(name)
+
+        try data.write(to: dest)
+        return [StagedFile(id: UUID(), name: name, size: size, url: dest, kind: .ownedTemp)]
+      case .video(let src):
+        let ext = src.pathExtension.isEmpty ? "mov" : src.pathExtension
+        let name = "Video-\(stamp)-\(suffix).\(ext)"
+        let dest = FileManager.default.temporaryDirectory.appendingPathComponent(name)
+
+        try FileManager.default.copyItem(at: src, to: dest)
+
+        let size = Int64((try? dest.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0)
+        return [StagedFile(id: UUID(), name: name, size: size, url: dest, kind: .ownedTemp)]
+      }
+    } catch {
+      logger.error("failed to stage camera capture: \(String(describing: error))")
+      return []
+    }
+  }
 }

--- a/client/ios/PastePoint/Resources/Info.plist
+++ b/client/ios/PastePoint/Resources/Info.plist
@@ -31,9 +31,11 @@
 		<string>_pastepoint._tcp</string>
 	</array>
 	<key>NSCameraUsageDescription</key>
-	<string>PastePoint uses the camera to scan QR codes for joining private sessions.</string>
+	<string>PastePoint uses the camera to scan QR codes and to take photos and videos to share.</string>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>PastePoint needs local network access to connect to the server on your network.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>PastePoint uses the microphone to record audio when you capture a video to share.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>PastePoint saves photos and videos you receive to your photo library.</string>
 	<key>UIAppFonts</key>

--- a/client/ios/PastePoint/Resources/Localization/InfoPlist.xcstrings
+++ b/client/ios/PastePoint/Resources/Localization/InfoPlist.xcstrings
@@ -44,43 +44,43 @@
       }
     },
     "NSCameraUsageDescription" : {
-      "comment" : "Permission prompt shown when requesting camera access (QR code scanning).",
+      "comment" : "Permission prompt shown when requesting camera access (QR scanning and photo/video capture).",
       "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "يستخدم PastePoint الكاميرا لمسح رموز QR للانضمام إلى الجلسات الخاصة."
+            "value" : "يستخدم PastePoint الكاميرا لمسح رموز QR والتقاط الصور ومقاطع الفيديو لمشاركتها."
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "PastePoint uses the camera to scan QR codes for joining private sessions."
+            "value" : "PastePoint uses the camera to scan QR codes and to take photos and videos to share."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "PastePoint usa la cámara para escanear códigos QR y unirse a sesiones privadas."
+            "value" : "PastePoint usa la cámara para escanear códigos QR y para tomar fotos y vídeos que compartir."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "PastePoint utilise la caméra pour scanner les codes QR afin de rejoindre des sessions privées."
+            "value" : "PastePoint utilise la caméra pour scanner les codes QR et pour prendre des photos et vidéos à partager."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "PastePoint использует камеру для сканирования QR-кодов, чтобы присоединяться к приватным сессиям."
+            "value" : "PastePoint использует камеру для сканирования QR-кодов и съёмки фото и видео для отправки."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "PastePoint 使用相机扫描二维码以加入私密会话。"
+            "value" : "PastePoint 使用相机扫描二维码，并拍摄照片和视频以供分享。"
           }
         }
       }
@@ -123,6 +123,48 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "PastePoint 需要访问本地网络以连接到您网络中的服务器。"
+          }
+        }
+      }
+    },
+    "NSMicrophoneUsageDescription" : {
+      "comment" : "Permission prompt shown when recording audio for a captured video.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يستخدم PastePoint الميكروفون لتسجيل الصوت عند التقاط مقطع فيديو لمشاركته."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PastePoint uses the microphone to record audio when you capture a video to share."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PastePoint usa el micrófono para grabar audio cuando capturas un vídeo para compartir."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PastePoint utilise le microphone pour enregistrer le son lorsque vous filmez une vidéo à partager."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PastePoint использует микрофон для записи звука при съёмке видео для отправки."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PastePoint 使用麦克风在您拍摄视频以供分享时录制声音。"
           }
         }
       }

--- a/client/ios/PastePoint/Resources/Localization/Localizable.xcstrings
+++ b/client/ios/PastePoint/Resources/Localization/Localizable.xcstrings
@@ -5371,6 +5371,48 @@
         }
       }
     },
+    "TAKE_PHOTO_OR_VIDEO" : {
+      "comment" : "Attach menu option that opens the camera to capture a photo or video.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "التقاط صورة أو فيديو"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Take Photo or Video"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tomar foto o vídeo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prendre une photo ou une vidéo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Снять фото или видео"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拍摄照片或视频"
+          }
+        }
+      }
+    },
     "TAP_TO_REVEAL" : {
       "comment" : "Overlay on a blurred incoming image preview; tapping shows the image.",
       "extractionState" : "manual",

--- a/client/ios/PastePoint/Views/Attachment/AttachmentMenuView.swift
+++ b/client/ios/PastePoint/Views/Attachment/AttachmentMenuView.swift
@@ -3,9 +3,11 @@
 //  SPDX-License-Identifier: GPL-3.0-only
 //
 
+import AVFoundation
 import Logging
 import PhotosUI
 import SwiftUI
+import UIKit
 
 /// Shared attach menu: a native `Menu` of source options (Files / Photo Library),
 /// each routing through `FileStaging`. Callers supply the trigger label and an
@@ -19,6 +21,7 @@ struct AttachmentMenu<Content: View>: View {
   @State private var showFileImporter = false
   @State private var showPhotoPicker = false
   @State private var photosPickerSelection: [PhotosPickerItem] = []
+  @State private var showCamera = false
 
   init(
     onStaged: @escaping ([StagedFile]) async -> Void,
@@ -35,7 +38,24 @@ struct AttachmentMenu<Content: View>: View {
       } label: {
         Label(.chooseFiles, systemImage: "folder")
       }
-      // TODO: "Take Photo or Video" — camera capture (UIImagePickerController + NSCameraUsageDescription).
+      if UIImagePickerController.isSourceTypeAvailable(.camera) {
+        Button {
+          Task {
+            let status = CameraPermission.status == .notDetermined ? await CameraPermission.request() : CameraPermission.status
+
+            switch status {
+            case .authorized:
+              showCamera = true
+            case .denied, .restricted:
+              CameraPermission.openSettings()
+            default:
+              break
+            }
+          }
+        } label: {
+          Label(.takePhotoOrVideo, systemImage: "camera")
+        }
+      }
       Button {
         showPhotoPicker = true
       } label: {
@@ -63,6 +83,14 @@ struct AttachmentMenu<Content: View>: View {
       maxSelectionCount: 10, // TODO: unlimited later
       matching: .any(of: [.images, .videos]),
     )
+    .fullScreenCover(isPresented: $showCamera) {
+      CameraCapturePicker { capture in
+        showCamera = false
+        guard let capture else { return }
+        Task { await onStaged(await FileStaging.stage(camera: capture)) }
+      }
+      .ignoresSafeArea()
+    }
     .onChange(of: photosPickerSelection) { _, items in
       guard !items.isEmpty else { return }
       let toProcess = items

--- a/client/ios/PastePoint/Views/Attachment/CameraCapturePicker.swift
+++ b/client/ios/PastePoint/Views/Attachment/CameraCapturePicker.swift
@@ -1,0 +1,60 @@
+//
+//  Copyright © 2026 PastePoint. All rights reserved.
+//  SPDX-License-Identifier: GPL-3.0-only
+//
+
+import SwiftUI
+import UIKit
+import UniformTypeIdentifiers
+
+enum CameraCapture {
+  case photo(Data)
+  case video(URL)
+}
+
+struct CameraCapturePicker: UIViewControllerRepresentable {
+  let onCapture: (CameraCapture?) -> Void
+
+  func makeUIViewController(context: Context) -> UIImagePickerController {
+    let picker = UIImagePickerController()
+    picker.sourceType = .camera
+    picker.mediaTypes = UIImagePickerController.availableMediaTypes(for: .camera) ?? [UTType.image.identifier]
+    picker.videoQuality = .typeHigh
+    picker.delegate = context.coordinator
+    return picker
+  }
+
+  func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(onCapture: onCapture)
+  }
+
+  final class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+    let onCapture: (CameraCapture?) -> Void
+
+    init(onCapture: @escaping (CameraCapture?) -> Void) {
+      self.onCapture = onCapture
+    }
+
+    func imagePickerController(
+      _ picker: UIImagePickerController,
+      didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any],
+    ) {
+      if let url = info[.mediaURL] as? URL {
+        onCapture(.video(url))
+      } else if
+        let image = info[.originalImage] as? UIImage,
+        let data = image.jpegData(compressionQuality: 0.9)
+      {
+        onCapture(.photo(data))
+      } else {
+        onCapture(nil)
+      }
+    }
+
+    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+      onCapture(nil)
+    }
+  }
+}

--- a/client/web/src/app/core/components/layout/page-footer/page-footer.component.html
+++ b/client/web/src/app/core/components/layout/page-footer/page-footer.component.html
@@ -1,6 +1,6 @@
 <!-- MARK: - Footer -->
 <div
-  class="flex w-full flex-col items-center gap-3 border-t px-4 py-3 bg-surface dark:bg-baseDark dark:border-surfaceDark"
+  class="flex w-full flex-col items-center gap-3 border-t px-4 py-3 bg-pageBackground dark:bg-baseDark dark:border-surfaceDark"
 >
   <!-- Social links -->
   <div class="flex items-center gap-5">

--- a/client/web/src/app/features/chat/components/blurred-preview/blurred-preview.component.html
+++ b/client/web/src/app/features/chat/components/blurred-preview/blurred-preview.component.html
@@ -1,18 +1,18 @@
 <!-- MARK: - Hidden Preview -->
 <div class="relative mx-auto w-fit overflow-hidden rounded-lg">
   <img
-    [src]="source"
+    [src]="src"
     [alt]="alt"
     [title]="alt"
     class="max-w-full h-auto max-h-[220px] rounded-lg object-contain transition duration-200"
-    [class.blur-lg]="!revealed()"
-    [class.scale-110]="!revealed()"
+    [class.blur-lg]="!revealed"
+    [class.scale-110]="!revealed"
     loading="lazy"
     width="320"
     height="192"
   />
 
-  @if (!revealed()) {
+  @if (!revealed) {
     <button
       type="button"
       (click)="reveal()"

--- a/client/web/src/app/features/chat/components/blurred-preview/blurred-preview.component.ts
+++ b/client/web/src/app/features/chat/components/blurred-preview/blurred-preview.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 
 @Component({
@@ -9,18 +9,14 @@ import { TranslateModule } from '@ngx-translate/core';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BlurredPreviewComponent {
-  @Input()
-  set src(value: string | undefined) {
-    this.source = value;
-    this.revealed.set(false);
-  }
-
+  @Input() src?: string;
   @Input() alt = '';
+  @Input() revealed = false;
 
-  protected source?: string;
-  protected readonly revealed = signal(false);
+  @Output() revealedChange = new EventEmitter<boolean>();
 
   protected reveal(): void {
-    this.revealed.set(true);
+    this.revealed = true;
+    this.revealedChange.emit(true);
   }
 }

--- a/client/web/src/app/features/chat/components/chat-messages/chat-messages.component.html
+++ b/client/web/src/app/features/chat/components/chat-messages/chat-messages.component.html
@@ -330,6 +330,8 @@
                                   class="mb-3"
                                   [src]="message.previewUrl"
                                   [alt]="message.fileTransfer?.fileName || 'Attachment'"
+                                  [revealed]="isPreviewRevealed(message)"
+                                  (revealedChange)="revealPreview(message)"
                                 />
                               }
                             } @else {
@@ -368,6 +370,8 @@
                                   class="mb-2"
                                   [src]="message.previewUrl"
                                   [alt]="message.fileTransfer?.fileName || 'Attachment'"
+                                  [revealed]="isPreviewRevealed(message)"
+                                  (revealedChange)="revealPreview(message)"
                                 />
                               }
                             } @else {

--- a/client/web/src/app/features/chat/components/chat-messages/chat-messages.component.ts
+++ b/client/web/src/app/features/chat/components/chat-messages/chat-messages.component.ts
@@ -50,8 +50,21 @@ export class ChatMessagesComponent {
 
   protected readonly ChatMessageType = ChatMessageType;
   protected readonly FileTransferStatus = FileTransferStatus;
+  private readonly revealedPreviews = new Set<string>();
 
   private sanitizer = inject(DomSanitizer);
+
+  protected isPreviewRevealed(msg: ChatMessage): boolean {
+    const id = msg.fileTransfer?.fileId;
+    return id ? this.revealedPreviews.has(id) : false;
+  }
+
+  protected revealPreview(msg: ChatMessage): void {
+    const id = msg.fileTransfer?.fileId;
+    if (id) {
+      this.revealedPreviews.add(id);
+    }
+  }
 
   trackMessage(index: number, message: ChatMessage): string {
     if (message.type === ChatMessageType.ATTACHMENT && message.fileTransfer?.fileId) {


### PR DESCRIPTION
### Summary

Allow iOS users to capture photos and videos directly from the attachment menu and send them through the existing staged-file workflow.

### What changed

#### Camera capture

- Add a localized “Take Photo or Video” attachment option
- Hide the option on devices without an available camera
- Request camera permission when capture is selected
- Open system Settings when camera access is denied
- Present the native camera interface as a full-screen cover
- Support high-quality photos and videos with recorded audio

#### File staging

- Encode captured photos as JPEG files
- Copy captured videos into app-owned temporary storage
- Give captures timestamped filenames
- Route camera media through the existing staged-file verification and transfer flow
- Clean up captured files using the existing temporary-file ownership model

#### Permissions

- Expand the camera usage description to cover QR scanning and media capture
- Add a microphone usage description for video audio
- Localize permission descriptions and the new menu action across all supported languages

#### Additional fixes

- Keep web attachment previews revealed when transfer state changes
- Match the web page footer background to legal and error pages in light mode
- Log iOS network path updates only when the status actually changes