### PR TITLE
Bump iOS, web, and server release versions

### DIFF
--- a/client/ios/PastePoint.xcodeproj/project.pbxproj
+++ b/client/ios/PastePoint.xcodeproj/project.pbxproj
@@ -456,7 +456,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.11.0;
+				MARKETING_VERSION = 0.12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pastepoint.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -495,7 +495,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.11.0;
+				MARKETING_VERSION = 0.12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pastepoint.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/client/web/package-lock.json
+++ b/client/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "dependencies": {
         "@angular/cdk": "^21.2.9",
         "@angular/common": "^21.2.17",

--- a/client/web/package.json
+++ b/client/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "actix-cors",
  "actix-governor",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2024"
 authors = ["Sulaiman AlRomaih"]
 license = "GPL-3"

--- a/server/config/development.toml
+++ b/server/config/development.toml
@@ -16,8 +16,8 @@ latest = "0.12.0"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]
-minimum = "0.22.0"
-latest = "0.22.0"
+minimum = "0.23.0"
+latest = "0.23.0"
 url = "https://127.0.0.1"
 
 [sentry]

--- a/server/config/development.toml
+++ b/server/config/development.toml
@@ -11,8 +11,8 @@ cors_allowed_origins = "https://127.0.0.1"
 # Client update policy (GET /version). minimum = force floor, latest = soft nudge.
 # Raise these only AFTER the build is live on the store/web, or you soft-brick users.
 [client_version.ios]
-minimum = "0.11.0"
-latest = "0.11.0"
+minimum = "0.12.0"
+latest = "0.12.0"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]

--- a/server/config/docker-dev.toml
+++ b/server/config/docker-dev.toml
@@ -16,8 +16,8 @@ latest = "0.12.0"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]
-minimum = "0.22.0"
-latest = "0.22.0"
+minimum = "0.23.0"
+latest = "0.23.0"
 url = "https://127.0.0.1"
 
 [sentry]

--- a/server/config/docker-dev.toml
+++ b/server/config/docker-dev.toml
@@ -11,8 +11,8 @@ cors_allowed_origins = "https://127.0.0.1"
 # Client update policy (GET /version). minimum = force floor, latest = soft nudge.
 # Raise these only AFTER the build is live on the store/web, or you soft-brick users.
 [client_version.ios]
-minimum = "0.11.0"
-latest = "0.11.0"
+minimum = "0.12.0"
+latest = "0.12.0"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]

--- a/server/config/production.toml
+++ b/server/config/production.toml
@@ -16,8 +16,8 @@ latest = "0.12.0"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]
-minimum = "0.22.0"
-latest = "0.22.0"
+minimum = "0.23.0"
+latest = "0.23.0"
 url = "https://pastepoint.com"
 
 [sentry]

--- a/server/config/production.toml
+++ b/server/config/production.toml
@@ -11,8 +11,8 @@ cors_allowed_origins = "https://pastepoint.com"
 # Client update policy (GET /version). minimum = force floor, latest = soft nudge.
 # Raise these only AFTER the build is live on the store/web, or you soft-brick users.
 [client_version.ios]
-minimum = "0.11.0"
-latest = "0.11.0"
+minimum = "0.12.0"
+latest = "0.12.0"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]


### PR DESCRIPTION
### Summary

Prepare the next coordinated PastePoint release by updating application versions and server-driven client compatibility requirements.

### What changed

- Bump iOS from `0.11.0` to `0.12.0`
- Bump web from `0.22.0` to `0.23.0`
- Bump the server from `0.11.1` to `0.12.0`
- Update package and dependency lockfiles
- Set the iOS minimum and latest policy to `0.12.0`
- Set the web minimum and latest policy to `0.23.0`
- Apply the client-version policy across development, Docker, and production configurations