### PR TITLE
Refine WebSocket reconnection logic for improved user experience

### DIFF
--- a/client/web/package-lock.json
+++ b/client/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.23.0",
+      "version": "0.23.1",
       "dependencies": {
         "@angular/cdk": "^21.2.9",
         "@angular/common": "^21.2.17",

--- a/client/web/package.json
+++ b/client/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/client/web/src/app/core/services/communication/websocket-connection.service.ts
+++ b/client/web/src/app/core/services/communication/websocket-connection.service.ts
@@ -323,10 +323,16 @@ export class WebSocketConnectionService implements OnDestroy {
       'scheduleReconnect',
       `Scheduling reconnect attempt ${this.reconnectAttempts} in ${currentDelay}ms`
     );
-    this.reconnectState$.next({
-      attempt: this.reconnectAttempts,
-      nextAttemptAt: Date.now() + currentDelay,
-    });
+
+    // Don't flag the server as troubled on the first retry — a suspended tab
+    // resuming (e.g. after picking a file) reconnects on attempt 1 without ever
+    // showing the banner. Only a persistent failure surfaces it.
+    if (this.reconnectAttempts > 1) {
+      this.reconnectState$.next({
+        attempt: this.reconnectAttempts,
+        nextAttemptAt: Date.now() + currentDelay,
+      });
+    }
 
     this.reconnectTimer = setTimeout(() => {
       if (this.isConnected()) {

--- a/client/web/src/app/features/chat/chat.component.ts
+++ b/client/web/src/app/features/chat/chat.component.ts
@@ -183,9 +183,7 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
       !this.wsConnectionService.isConnected()
     ) {
       this.logger.info('visibilitychange', 'Page visible, reconnecting if needed');
-      this.connect(this.SessionCode).catch((err: unknown) => {
-        this.logger.warn('visibilitychange', `Reconnect after visibility change failed: ${err}`);
-      });
+      this.reconnectInPlace('visibilitychange');
     }
   };
   private beforeUnloadHandler = () => {
@@ -476,13 +474,33 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
           'Suspension detected; reconnecting in place instead of reloading'
         );
 
-        this.wsConnectionService.disconnect(false);
-        this.connect(this.SessionCode || undefined).catch((err: unknown) => {
-          this.logger.warn('startHeartbeatMonitor', `Reconnect after suspension failed: ${err}`);
-        });
+        this.reconnectInPlace('startHeartbeatMonitor');
       })
     );
     this.heartbeatService.start();
+  }
+
+  /**
+   * Reconnect the WebSocket in place after a suspend/resume
+   * (tab backgrounded while picking a file, then resumed).
+   */
+  private reconnectInPlace(context: string): void {
+    this.wsConnectionService.disconnect(false);
+    this.webrtcService.closeAllConnections();
+
+    this.members
+      .filter((member) => member !== this.userService.user)
+      .forEach((member) => {
+        this.memberConnectionStatus.set(member, false);
+        this.memberConnectionState.set(member, 'connecting');
+      });
+    this.cdr.detectChanges();
+
+    this.connect(this.SessionCode || undefined)
+      .then(() => this.initiateConnectionsWithMembers())
+      .catch((err: unknown) => {
+        this.logger.warn(context, `Reconnect after resume failed: ${err}`);
+      });
   }
 
   /**

--- a/server/config/development.toml
+++ b/server/config/development.toml
@@ -17,7 +17,7 @@ url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]
 minimum = "0.23.0"
-latest = "0.23.0"
+latest = "0.23.1"
 url = "https://127.0.0.1"
 
 [sentry]

--- a/server/config/docker-dev.toml
+++ b/server/config/docker-dev.toml
@@ -17,7 +17,7 @@ url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]
 minimum = "0.23.0"
-latest = "0.23.0"
+latest = "0.23.1"
 url = "https://127.0.0.1"
 
 [sentry]

--- a/server/config/production.toml
+++ b/server/config/production.toml
@@ -17,7 +17,7 @@ url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]
 minimum = "0.23.0"
-latest = "0.23.0"
+latest = "0.23.1"
 url = "https://pastepoint.com"
 
 [sentry]


### PR DESCRIPTION
### Summary

##### Web: Refine reconnect logic for smoother UX
- Avoids marking server as troubled on first retry
- Ensures reconnect only flags persistent failures

##### Web: Improve reconnection handling
- Streamlines WebSocket reconnections after suspension.
- Introduces in-place reconnect logic for better peer status management.

#### Web: Bump version to 0.23.1.
- Ensure server configurations align with the latest web version