### PR TITLE
iOS: Centralize logging and remove redundant session refreshes

### DIFF
--- a/client/ios/PastePoint/App/ContentView+Events.swift
+++ b/client/ios/PastePoint/App/ContentView+Events.swift
@@ -3,7 +3,6 @@
 //  SPDX-License-Identifier: GPL-3.0-only
 //
 
-import Logging
 import SwiftUI
 
 // MARK: - Event Wiring
@@ -28,7 +27,7 @@ private struct ChatEventHandlers: ViewModifier {
     content
       .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { activity in
         guard let url = activity.webpageURL else {
-          owner.logger.error("Ignoring universal-link activity without URL")
+          log.error("Ignoring universal-link activity without URL")
           return
         }
         owner.handleIncomingURL(url)
@@ -43,10 +42,10 @@ private struct ChatEventHandlers: ViewModifier {
   private func messageHandlers(_ content: some View) -> some View {
     content
       .onReceive(owner.services.wsService.message) { msg in
-        owner.logger.info("User message: \(msg)")
+        log.info("User message: \(msg)")
       }
       .onReceive(owner.services.wsService.signalMessage) { sig in
-        owner.logger.debug("Signal: \(sig.payload.typeString) | from: \(sig.from) → to: \(sig.to)")
+        log.debug("Signal: \(sig.payload.typeString) | from: \(sig.from) → to: \(sig.to)")
       }
       .onReceive(owner.services.signalingService.chatMessages) { message in
         owner.messages.append(message)

--- a/client/ios/PastePoint/App/ContentView+Handlers.swift
+++ b/client/ios/PastePoint/App/ContentView+Handlers.swift
@@ -89,10 +89,9 @@ extension ContentView {
         toast.show(.error(.localNetworkOffJoin))
         return
       }
+
       setSettingsVisible(false)
       pendingPrivateJoin = true
-      await services.roomService.listRooms()
-      await services.userService.getUsername()
     }
   }
 

--- a/client/ios/PastePoint/App/ContentView+Handlers.swift
+++ b/client/ios/PastePoint/App/ContentView+Handlers.swift
@@ -3,7 +3,6 @@
 //  SPDX-License-Identifier: GPL-3.0-only
 //
 
-import Logging
 import SwiftUI
 
 // MARK: - Handlers
@@ -66,7 +65,7 @@ extension ContentView {
   /// mirroring the manual join flow in `SettingsJoinPrivateView`.
   func handleIncomingURL(_ url: URL) {
     guard LegalConsent.isAccepted else {
-      logger.info("Deferring incoming URL until the terms are accepted")
+      log.info("Deferring incoming URL until the terms are accepted")
       pendingLegalDeepLink = url
       return
     }
@@ -75,7 +74,7 @@ extension ContentView {
       let code = AppEnvironment.privateSessionCode(from: url.absoluteString),
       SessionService.isValidSessionCode(code)
     else {
-      logger.warning("Ignoring invalid incoming URL")
+      log.warning("Ignoring invalid incoming URL")
       toast.show(.error(.invalidSessionCode))
       return
     }
@@ -83,7 +82,7 @@ extension ContentView {
     // Already in this session
     guard services.wsService.currentSessionCode != code else { return }
 
-    logger.info("Joining private session from universal link")
+    log.info("Joining private session from universal link")
     Task {
       await services.wsService.setupPrivateSession(code)
       guard await services.connectIfPermitted() else {

--- a/client/ios/PastePoint/App/ContentView.swift
+++ b/client/ios/PastePoint/App/ContentView.swift
@@ -3,7 +3,6 @@
 //  SPDX-License-Identifier: GPL-3.0-only
 //
 
-import Logging
 import SwiftUI
 
 // MARK: - Root
@@ -18,8 +17,6 @@ struct ContentView: View {
 
   @EnvironmentObject var toast: ToastCenter
   @EnvironmentObject var services: AppServices
-
-  let logger = Logger(label: "ContentView")
 
   @State private var showSplash = true
   @State private var splashStart = Date()

--- a/client/ios/PastePoint/Core/Permissions/LocalNetworkPermission.swift
+++ b/client/ios/PastePoint/Core/Permissions/LocalNetworkPermission.swift
@@ -4,16 +4,14 @@
 //
 
 import Foundation
-import Logging
 import Network
 import os
 
 enum LocalNetworkPermission {
-  private static let logger = Logger(label: "LocalNetworkPermission")
 
   @MainActor
   static func requestAccess() {
-    logger.info("Requesting local network permission")
+    log.info("Requesting local network permission")
     let browser = NWBrowser(for: .bonjour(type: "_pastepoint._tcp", domain: nil), using: NWParameters())
     browser.stateUpdateHandler = { _ in }
     browser.start(queue: .main)
@@ -25,7 +23,7 @@ enum LocalNetworkPermission {
   }
 
   static func isDenied() async -> Bool {
-    logger.info("Checking local network permission")
+    log.info("Checking local network permission")
 
     let port = NWEndpoint.Port(integerLiteral: UInt16(AppEnvironment.localNetworkProbePort))
     let connection = NWConnection(host: NWEndpoint.Host(AppEnvironment.localNetworkProbeHost), port: port, using: .tcp)
@@ -45,23 +43,23 @@ enum LocalNetworkPermission {
           switch newState {
           case .ready:
             guard claim() else { return }
-            Self.logger.info("Connection ready — permission granted")
+            log.info("Connection ready — permission granted")
             connection.cancel()
             continuation.resume(returning: false)
           case .waiting(let error):
             guard claim() else { return }
             if case .posix(.ECONNREFUSED) = error {
-              Self.logger.info("Connection refused — server down, permission granted")
+              log.info("Connection refused — server down, permission granted")
               connection.cancel()
               continuation.resume(returning: false)
             } else {
-              Self.logger.warning("Connection waiting — \(error.localizedDescription) — assuming denied")
+              log.warning("Connection waiting — \(error.localizedDescription) — assuming denied")
               connection.cancel()
               continuation.resume(returning: true)
             }
           case .failed(let error):
             guard claim() else { return }
-            Self.logger.error("Connection failed — \(error.localizedDescription)")
+            log.error("Connection failed — \(error.localizedDescription)")
             connection.cancel()
             continuation.resume(returning: false)
           default:
@@ -75,7 +73,7 @@ enum LocalNetworkPermission {
       Task {
         try? await Task.sleep(for: .seconds(3))
         guard claim() else { return }
-        Self.logger.info("Timeout — assuming permitted")
+        log.info("Timeout — assuming permitted")
         connection.cancel()
         continuation.resume(returning: false)
       }

--- a/client/ios/PastePoint/Core/Services/App/AppServices.swift
+++ b/client/ios/PastePoint/Core/Services/App/AppServices.swift
@@ -4,7 +4,6 @@
 //
 
 import Combine
-import Logging
 import Network
 import SwiftUI
 import UIKit
@@ -12,7 +11,6 @@ import WebRTC
 
 @MainActor
 final class AppServices: ObservableObject {
-  private let logger = Logger(label: "App")
 
   @Published private(set) var localNetworkDenied = false
 
@@ -143,12 +141,12 @@ final class AppServices: ObservableObject {
     endBackgroundGrace()
 
     guard LegalConsent.isAccepted else {
-      logger.debug("handleForeground — terms not accepted, staying offline")
+      log.debug("handleForeground — terms not accepted, staying offline")
       return
     }
 
     guard !wsService.isConnected, !wsService.isConnecting, !isForegroundHandling else {
-      logger.debug("handleForeground — already connected or connecting, skipping")
+      log.debug("handleForeground — already connected or connecting, skipping")
       return
     }
     isForegroundHandling = true
@@ -172,7 +170,7 @@ final class AppServices: ObservableObject {
     let denied = await LocalNetworkPermission.isDenied()
     localNetworkDenied = denied
     guard !denied else {
-      logger.warning("connectIfPermitted — local network denied, skipping connect")
+      log.warning("connectIfPermitted — local network denied, skipping connect")
       wsService.disconnect(manual: false)
       return false
     }
@@ -182,7 +180,7 @@ final class AppServices: ObservableObject {
   }
 
   func handleBackground() {
-    logger.info("handleBackground — starting disconnect grace window")
+    log.info("handleBackground — starting disconnect grace window")
     isInBackground = true
 
     backgroundGraceTask?.cancel()
@@ -201,7 +199,7 @@ final class AppServices: ObservableObject {
   /// Teardown, run once the grace window elapses
   private func performBackgroundDisconnect() {
     guard backgroundTaskID != .invalid else { return }
-    logger.info("handleBackground — grace elapsed, disconnecting")
+    log.info("handleBackground — grace elapsed, disconnecting")
     fileTransferService.cancelAllTransfers()
     wsService.disconnect(manual: false)
     endBackgroundGrace()
@@ -231,13 +229,13 @@ final class AppServices: ObservableObject {
         self.lastPathStatus = path.status
 
         if previous != path.status {
-          self.logger.debug("Network path changed: \(previous) → \(path.status)")
+          log.debug("Network path changed: \(previous) → \(path.status)")
         }
 
         guard path.status == .satisfied, previous != .satisfied else { return }
         guard !self.isInBackground else { return }
 
-        self.logger.info("Network restored — triggering reconnect")
+        log.info("Network restored — triggering reconnect")
         await self.handleForeground()
       }
     }

--- a/client/ios/PastePoint/Core/Services/App/AppUpdateService.swift
+++ b/client/ios/PastePoint/Core/Services/App/AppUpdateService.swift
@@ -5,7 +5,6 @@
 
 import Combine
 import Foundation
-import Logging
 
 // MARK: - Wire model
 
@@ -35,8 +34,6 @@ enum UpdateRecommendation {
 final class AppUpdateService: ObservableObject {
   @Published private(set) var recommendation: UpdateRecommendation?
 
-  private let logger = Logger(label: "AppUpdate")
-
   private var isChecking: Bool = false
 
   private static let lastOptionalPromptKey = "AppUpdate.lastOptionalPromptAt"
@@ -53,7 +50,7 @@ final class AppUpdateService: ObservableObject {
     defer { isChecking = false }
 
     guard let url = URL(string: AppEnvironment.versionUrl) else {
-      logger.error("Invalid version URL")
+      log.error("Invalid version URL")
       return
     }
 
@@ -62,7 +59,7 @@ final class AppUpdateService: ObservableObject {
       let data = try await fetch(url)
       policy = try JSONDecoder().decode(VersionResponse.self, from: data).ios
     } catch {
-      logger.debug("Version check failed, ignoring: \(error.localizedDescription)")
+      log.debug("Version check failed, ignoring: \(error.localizedDescription)")
       return
     }
 
@@ -95,7 +92,7 @@ private extension AppUpdateService {
 
     guard !policy.url.isEmpty, let url = URL(string: policy.url) else {
       if !policy.minimum.isEmpty || !policy.latest.isEmpty {
-        logger.warning("Version policy has no valid url; ignoring")
+        log.warning("Version policy has no valid url; ignoring")
       }
       return recommendation
     }

--- a/client/ios/PastePoint/Core/Services/Connection/ConnectionWarningMonitor.swift
+++ b/client/ios/PastePoint/Core/Services/Connection/ConnectionWarningMonitor.swift
@@ -5,7 +5,6 @@
 
 import Combine
 import Foundation
-import Logging
 
 @MainActor
 final class ConnectionWarningMonitor: ObservableObject {
@@ -13,7 +12,6 @@ final class ConnectionWarningMonitor: ObservableObject {
 
   private let peerDirectory: PeerDirectory
   private let signalingService: SignalingService
-  private let logger = Logger(label: "ConnectionWarningMonitor")
 
   private static let warningDelay: TimeInterval = 25
   private var dismissed = false
@@ -76,7 +74,7 @@ final class ConnectionWarningMonitor: ObservableObject {
         return
       }
 
-      self.logger.warning("No peer reachable past \(Self.warningDelay)s — showing warning")
+      log.warning("No peer reachable past \(Self.warningDelay)s — showing warning")
       self.showWarning = true
     }
   }

--- a/client/ios/PastePoint/Core/Services/FileTransfer/FileStaging.swift
+++ b/client/ios/PastePoint/Core/Services/FileTransfer/FileStaging.swift
@@ -4,7 +4,6 @@
 //
 
 import Foundation
-import Logging
 import PhotosUI
 import SwiftUI
 
@@ -27,7 +26,6 @@ private struct StagedPhotoFile: Transferable {
 /// Copies picked files/photos into the app tmp dir and returns `StagedFile`s.
 /// Shared by the broadcast input bar and the per-member send button.
 enum FileStaging {
-  private static let logger = Logger(label: "FileStaging")
 
   private static let photoNameFormatter: DateFormatter = {
     let formatter = DateFormatter()
@@ -43,7 +41,7 @@ enum FileStaging {
     var staged: [StagedFile] = []
     for url in urls {
       guard url.startAccessingSecurityScopedResource() else {
-        logger.error("couldn't access security-scoped \(url.lastPathComponent)")
+        log.error("couldn't access security-scoped \(url.lastPathComponent)")
         continue
       }
 
@@ -51,10 +49,10 @@ enum FileStaging {
       do {
         let size = Int64(try url.resourceValues(forKeys: [.fileSizeKey]).fileSize ?? 0)
         staged.append(StagedFile(id: UUID(), name: fileName, size: size, url: url, kind: .securityScoped))
-        logger.info("staged file: \(fileName) (\(size) bytes)")
+        log.info("staged file: \(fileName) (\(size) bytes)")
       } catch {
         url.stopAccessingSecurityScopedResource()
-        logger.error("failed to stat \(fileName): \(String(describing: error))")
+        log.error("failed to stat \(fileName): \(String(describing: error))")
       }
     }
     return staged
@@ -66,7 +64,7 @@ enum FileStaging {
     for item in photoItems {
       do {
         guard let picked = try await item.loadTransferable(type: StagedPhotoFile.self) else {
-          logger.error("photosPicker item returned nil file")
+          log.error("photosPicker item returned nil file")
           continue
         }
 
@@ -75,9 +73,9 @@ enum FileStaging {
         let size = Int64((try? picked.url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0)
 
         staged.append(StagedFile(id: UUID(), name: displayName, size: size, url: picked.url, kind: .ownedTemp))
-        logger.info("staged photo: \(displayName) (\(size) bytes)")
+        log.info("staged photo: \(displayName) (\(size) bytes)")
       } catch {
-        logger.error("failed to stage photo: \(String(describing: error))")
+        log.error("failed to stage photo: \(String(describing: error))")
       }
     }
 
@@ -110,7 +108,7 @@ enum FileStaging {
         return [StagedFile(id: UUID(), name: name, size: size, url: dest, kind: .ownedTemp)]
       }
     } catch {
-      logger.error("failed to stage camera capture: \(String(describing: error))")
+      log.error("failed to stage camera capture: \(String(describing: error))")
       return []
     }
   }

--- a/client/ios/PastePoint/Core/Services/FileTransfer/FileTransferService.swift
+++ b/client/ios/PastePoint/Core/Services/FileTransfer/FileTransferService.swift
@@ -5,11 +5,9 @@
 
 import Combine
 import Foundation
-import Logging
 
 @MainActor
 final class FileTransferService: ObservableObject {
-  private let logger = Logger(label: "FileTransferService")
   private let signalingService: SignalingService
   private let userService: UserService
 
@@ -73,7 +71,7 @@ final class FileTransferService: ObservableObject {
     preview: PreviewGenerator.Preview? = nil,
   ) async -> Bool {
     guard stagedFile.size > 0 else {
-      logger.warning("skipping empty file \(stagedFile.name)")
+      log.warning("skipping empty file \(stagedFile.name)")
       return false
     }
 
@@ -95,12 +93,12 @@ final class FileTransferService: ObservableObject {
     do {
       data = try DataChannelMessage.encodeFileOffer(offer)
     } catch {
-      logger.error("encodeFileOffer failed for \(stagedFile.name): \(error)")
+      log.error("encodeFileOffer failed for \(stagedFile.name): \(error)")
       return false
     }
 
     guard signalingService.send(data, to: targetUser) else {
-      logger.warning("send failed for file-offer \(fileId) to \(targetUser)")
+      log.warning("send failed for file-offer \(fileId) to \(targetUser)")
       return false
     }
 
@@ -118,7 +116,7 @@ final class FileTransferService: ObservableObject {
         phase: .sending,
       ),
     )
-    logger.info("file-offer sent: \(stagedFile.name) (\(fileId)) → \(targetUser)")
+    log.info("file-offer sent: \(stagedFile.name) (\(fileId)) → \(targetUser)")
 
     offerTasks[fileId] = Task { [weak self] in
       await self?.sendEnrichOffer(
@@ -136,7 +134,7 @@ final class FileTransferService: ObservableObject {
 
   func sendStagedFile(_ stagedFile: StagedFile, to peers: [String]) async {
     guard stagedFile.size > 0 else {
-      logger.warning("skipping empty file \(stagedFile.name)")
+      log.warning("skipping empty file \(stagedFile.name)")
       return
     }
 
@@ -219,11 +217,11 @@ final class FileTransferService: ObservableObject {
         let data = try DataChannelMessage.encodeFileCancelUpload(FileCancelPayload(fileId: fileId))
         _ = signalingService.send(data, to: targetUser)
       } catch {
-        logger.error("encodeFileCancelUpload failed: \(error)")
+        log.error("encodeFileCancelUpload failed: \(error)")
       }
     }
 
-    logger.info("upload stopped: \(fileId) → \(targetUser) (notify=\(notifyRecipient))")
+    log.info("upload stopped: \(fileId) → \(targetUser) (notify=\(notifyRecipient))")
     return true
   }
 
@@ -245,17 +243,17 @@ final class FileTransferService: ObservableObject {
       let data = try DataChannelMessage.encodeFileCancelDownload(FileCancelPayload(fileId: fileId))
       _ = signalingService.send(data, to: uploader)
     } catch {
-      logger.error("encodeFileCancelDownload failed: \(error)")
+      log.error("encodeFileCancelDownload failed: \(error)")
     }
 
-    logger.info("download cancelled: \(fileId) ← \(fromUser)")
+    log.info("download cancelled: \(fileId) ← \(fromUser)")
     return true
   }
 
   @discardableResult
   func acceptFileOffer(fromUser: String, fileId: String) async -> Bool {
     guard let idx = incomingFileOffers.firstIndex(where: { $0.id == fileId }) else {
-      logger.warning("no offer for \(fileId)")
+      log.warning("no offer for \(fileId)")
       return false
     }
 
@@ -263,13 +261,13 @@ final class FileTransferService: ObservableObject {
     do {
       data = try DataChannelMessage.encodeFileAccept(FileAcceptPayload(fileId: fileId))
     } catch {
-      logger.error("encodeFileAccept failed: \(error)")
+      log.error("encodeFileAccept failed: \(error)")
       return false
     }
 
     let uploader = fromUser
     guard signalingService.send(data, to: uploader) else {
-      logger.warning("send failed for file-accept \(fileId) to \(uploader)")
+      log.warning("send failed for file-accept \(fileId) to \(uploader)")
       return false
     }
 
@@ -279,14 +277,14 @@ final class FileTransferService: ObservableObject {
     activeDownloads.append(download)
     startStallWatchdog()
 
-    logger.info("file-accept sent: \(fileId) → \(uploader)")
+    log.info("file-accept sent: \(fileId) → \(uploader)")
     return true
   }
 
   @discardableResult
   func declineFileOffer(fromUser: String, fileId: String) async -> Bool {
     guard let idx = incomingFileOffers.firstIndex(where: { $0.id == fileId }) else {
-      logger.warning("no offer for \(fileId)")
+      log.warning("no offer for \(fileId)")
       return false
     }
 
@@ -294,18 +292,18 @@ final class FileTransferService: ObservableObject {
     do {
       data = try DataChannelMessage.encodeFileDecline(FileDeclinePayload(fileId: fileId))
     } catch {
-      logger.error("encodeFileDecline failed: \(error)")
+      log.error("encodeFileDecline failed: \(error)")
       return false
     }
 
     let uploader = fromUser
     guard signalingService.send(data, to: uploader) else {
-      logger.warning("send failed for file-decline \(fileId) to \(uploader)")
+      log.warning("send failed for file-decline \(fileId) to \(uploader)")
       return false
     }
 
     incomingFileOffers.remove(at: idx)
-    logger.info("file-decline sent: \(fileId) → \(uploader)")
+    log.info("file-decline sent: \(fileId) → \(uploader)")
     return true
   }
 
@@ -362,12 +360,12 @@ extension FileTransferService {
         $0.targetUser == peer && $0.id == payload.fileId
       })
     else {
-      logger.warning("file-accept ignored: no upload for \(payload.fileId) → \(peer)")
+      log.warning("file-accept ignored: no upload for \(payload.fileId) → \(peer)")
       return
     }
 
     let upload = activeUploads[idx]
-    logger.info("file-accept received: starting chunk send for \(upload.id) → \(peer)")
+    log.info("file-accept received: starting chunk send for \(upload.id) → \(peer)")
 
     let offerTask = offerTasks[payload.fileId]
     let task = Task.detached { [weak self] in
@@ -388,7 +386,7 @@ extension FileTransferService {
     }
 
     guard let snapshot else {
-      logger.warning("chunk loop: upload \(uploadId) not found")
+      log.warning("chunk loop: upload \(uploadId) not found")
       return
     }
 
@@ -397,7 +395,7 @@ extension FileTransferService {
     do {
       handle = try FileHandle(forReadingFrom: snapshot.fileURL)
     } catch {
-      logger.error("chunk loop: cannot open \(snapshot.fileURL.path): \(error)")
+      log.error("chunk loop: cannot open \(snapshot.fileURL.path): \(error)")
       return
     }
     defer { try? handle.close() }
@@ -412,7 +410,7 @@ extension FileTransferService {
     // 3. Send loop.
     while true {
       if Task.isCancelled {
-        logger.info("chunk loop cancelled for \(uploadId) → \(targetUser)")
+        log.info("chunk loop cancelled for \(uploadId) → \(targetUser)")
         return
       }
 
@@ -427,7 +425,7 @@ extension FileTransferService {
 
         chunkData = data
       } catch {
-        logger.error("chunk loop: read error: \(error)")
+        log.error("chunk loop: read error: \(error)")
         return
       }
 
@@ -441,7 +439,7 @@ extension FileTransferService {
       // Back-pressure: poll-retry. `send` returns false when bufferedAmount is
       // above maxBufferedAmount — we sleep briefly and retry until it accepts.
       guard await sendEncodedChunk(encoded, to: targetUser) else {
-        logger.info("chunk loop cancelled (back-pressure wait) for \(uploadId)")
+        log.info("chunk loop cancelled (back-pressure wait) for \(uploadId)")
         return
       }
 
@@ -464,7 +462,7 @@ extension FileTransferService {
       fileSize: snapshot.fileSize,
       phase: .finalizing,
     )
-    logger.info("chunk loop: finished \(chunkIndex) chunks for \(uploadId) → \(targetUser)")
+    log.info("chunk loop: finished \(chunkIndex) chunks for \(uploadId) → \(targetUser)")
   }
 
   /// Applies progress (and optionally a phase) to the matching active upload.
@@ -510,7 +508,7 @@ extension FileTransferService {
     }
 
     guard let hash else {
-      logger.error("hash failed for \(fileId); aborting send")
+      log.error("hash failed for \(fileId); aborting send")
       stopFileUpload(targetUser: targetUser, fileId: fileId) // removes upload + sends file-cancel-upload
       fileTransferFailed.send((fileId: fileId, reason: .sendHashFailed))
       return
@@ -535,9 +533,9 @@ extension FileTransferService {
 
     do {
       _ = signalingService.send(try DataChannelMessage.encodeFileOffer(enriched), to: targetUser)
-      logger.info("enriched file-offer sent: \(fileId) → \(targetUser)")
+      log.info("enriched file-offer sent: \(fileId) → \(targetUser)")
     } catch {
-      logger.error("encodeFileOffer (enriched) failed for \(fileId): \(error)")
+      log.error("encodeFileOffer (enriched) failed for \(fileId): \(error)")
     }
   }
 }
@@ -566,7 +564,7 @@ extension FileTransferService {
     if let i = incomingFileOffers.firstIndex(where: { $0.id == payload.fileId }) {
       if let hash = payload.fileHash, incomingFileOffers[i].expectedHash == nil {
         incomingFileOffers[i].expectedHash = hash
-        logger.info("merged hash into pending offer \(payload.fileId)")
+        log.info("merged hash into pending offer \(payload.fileId)")
       }
 
       if
@@ -578,7 +576,7 @@ extension FileTransferService {
         incomingFileOffers[i].previewMime = previewMime
 
         attachmentPreviewUpdated.send((fileId: payload.fileId, previewDataUrl: preview, previewMime: previewMime))
-        logger.info("merged preview into pending offer \(payload.fileId)")
+        log.info("merged preview into pending offer \(payload.fileId)")
       }
       return
     }
@@ -586,7 +584,7 @@ extension FileTransferService {
     if let i = activeDownloads.firstIndex(where: { $0.id == payload.fileId && $0.fromUser == peer }) {
       if let hash = payload.fileHash, activeDownloads[i].expectedHash == nil {
         activeDownloads[i].expectedHash = hash
-        logger.info("merged hash into accepted download \(payload.fileId)")
+        log.info("merged hash into accepted download \(payload.fileId)")
       }
 
       if
@@ -598,7 +596,7 @@ extension FileTransferService {
         activeDownloads[i].previewMime = previewMime
 
         attachmentPreviewUpdated.send((fileId: payload.fileId, previewDataUrl: preview, previewMime: previewMime))
-        logger.info("merged preview into accepted download \(payload.fileId)")
+        log.info("merged preview into accepted download \(payload.fileId)")
       }
       return
     }
@@ -637,7 +635,7 @@ extension FileTransferService {
     )
 
     attachmentMessages.send(message)
-    logger.info("received file-offer: \(payload.fileName) (\(payload.fileId)) from \(peer)")
+    log.info("received file-offer: \(payload.fileName) (\(payload.fileId)) from \(peer)")
   }
 
   func handleChunk(_ parsed: ParsedChunk, from peer: String) async {
@@ -651,13 +649,13 @@ extension FileTransferService {
     }
 
     guard parsed.isValid else {
-      logger.warning("invalid chunk \(parsed.chunkIndex) for \(parsed.fileId), failing transfer")
+      log.warning("invalid chunk \(parsed.chunkIndex) for \(parsed.fileId), failing transfer")
       failDownload(fileId: parsed.fileId, from: peer, reason: .integrity)
       return
     }
 
     if activeDownloads[idx].expectedHash == nil {
-      logger.warning("no hash for \(parsed.fileId); rejecting early")
+      log.warning("no hash for \(parsed.fileId); rejecting early")
       failDownload(fileId: parsed.fileId, from: peer, reason: .noHash)
       return
     }
@@ -689,7 +687,7 @@ extension FileTransferService {
     pendingChunkIndices[parsed.fileId]?.remove(chunkIndex)
 
     guard didWrite else {
-      logger.error("failed to persist chunk \(chunkIndex) for \(parsed.fileId)")
+      log.error("failed to persist chunk \(chunkIndex) for \(parsed.fileId)")
       return
     }
 
@@ -720,7 +718,7 @@ extension FileTransferService {
     if total > 0, activeDownloads[i].receivedChunkURLs.count == total {
       let download = activeDownloads[i]
 
-      logger.info("all \(total) chunks received for \(download.fileName) ← \(peer)")
+      log.info("all \(total) chunks received for \(download.fileName) ← \(peer)")
       finalizeDownload(download, from: peer)
     }
   }
@@ -734,7 +732,6 @@ extension FileTransferService {
       try? FileManager.default.createDirectory(at: completedDir, withIntermediateDirectories: true)
       let finalURL = completedDir.appendingPathComponent(download.fileName)
 
-      let logger = self.logger
       // Assemble + (optional) verify off the main actor.
       let result: (ok: Bool, reason: FileTransferFailureReason?) = await Task.detached {
         do {
@@ -763,7 +760,7 @@ extension FileTransferService {
             return (false, .integrity)
           }
 
-          logger.info("file integrity verified \(download.fileName) ✓")
+          log.info("file integrity verified \(download.fileName) ✓")
           return (true, nil)
         } catch {
           return (false, .assembly)
@@ -774,7 +771,7 @@ extension FileTransferService {
       try? FileManager.default.removeItem(at: dir)
 
       guard result.ok else {
-        logger.error("finalize failed for \(download.fileName), reason: \(result.reason ?? .assembly)")
+        log.error("finalize failed for \(download.fileName), reason: \(result.reason ?? .assembly)")
 
         try? FileManager.default.removeItem(at: completedDir)
         failDownload(fileId: download.id, from: peer, reason: result.reason ?? .assembly)
@@ -800,7 +797,7 @@ extension FileTransferService {
         fileTransferFailed.send((fileId: download.id, reason: .saveFailed))
         return
       }
-      logger.info("download complete: \(download.fileName) ← \(peer)")
+      log.info("download complete: \(download.fileName) ← \(peer)")
     }
   }
 
@@ -809,7 +806,7 @@ extension FileTransferService {
       let data = try DataChannelMessage.encodeFileReceived(FileReceivedPayload(fileId: fileId))
       _ = signalingService.send(data, to: peer)
     } catch {
-      logger.error("encodeFileReceived failed: \(error)")
+      log.error("encodeFileReceived failed: \(error)")
     }
   }
 
@@ -819,13 +816,13 @@ extension FileTransferService {
         $0.targetUser == peer && $0.id == payload.fileId
       })
     else {
-      logger.warning("file-received ignored: no upload for \(payload.fileId) ← \(peer)")
+      log.warning("file-received ignored: no upload for \(payload.fileId) ← \(peer)")
       return
     }
 
     let removed = activeUploads.remove(at: idx)
     markGroupOutcome(removed.groupId, success: true)
-    logger.info("file-received ack: \(payload.fileId) ← \(peer)")
+    log.info("file-received ack: \(payload.fileId) ← \(peer)")
 
     // Delete the tmp file only if no other in-flight upload references it.
     // Multiple peer-specific FileUploads share the same source `fileURL` when the
@@ -852,7 +849,7 @@ extension FileTransferService {
     }
 
     fileTransferCancelled.send(fileId)
-    logger.info("upload cancelled by sender: \(fileId) ← \(peer)")
+    log.info("upload cancelled by sender: \(fileId) ← \(peer)")
   }
 
   func cleanupDownload(fileId: String, fromUser: String) {
@@ -873,7 +870,7 @@ extension FileTransferService {
     guard !stillReferenced else { return }
 
     upload.kind.releaseSource(at: upload.fileURL)
-    logger.info("released source (\(upload.kind)): \(upload.fileURL.lastPathComponent)")
+    log.info("released source (\(upload.kind)): \(upload.fileURL.lastPathComponent)")
   }
 
   private func failDownload(fileId: String, from peer: String, reason: FileTransferFailureReason) {
@@ -883,7 +880,7 @@ extension FileTransferService {
       let data = try DataChannelMessage.encodeFileCancelDownload(FileCancelPayload(fileId: fileId))
       _ = signalingService.send(data, to: peer)
     } catch {
-      logger.error("encodeFileCancelDownload (fail) failed: \(error)")
+      log.error("encodeFileCancelDownload (fail) failed: \(error)")
     }
 
     fileTransferFailed.send((
@@ -919,7 +916,7 @@ extension FileTransferService {
       now.timeIntervalSince($0.lastActivityAt) > downloadStallTimeout
     }
     for download in stalled {
-      logger.warning("download \(download.id) stalled (\(downloadStallTimeout)s no chunk) — failing")
+      log.warning("download \(download.id) stalled (\(downloadStallTimeout)s no chunk) — failing")
       failDownload(fileId: download.id, from: download.fromUser, reason: .stalled)
     }
   }

--- a/client/ios/PastePoint/Core/Services/FileTransfer/PreviewGenerator.swift
+++ b/client/ios/PastePoint/Core/Services/FileTransfer/PreviewGenerator.swift
@@ -5,12 +5,10 @@
 
 import Foundation
 import ImageIO
-import Logging
 import PDFKit
 import UniformTypeIdentifiers
 
 enum PreviewGenerator {
-  private nonisolated static let logger = Logger(label: "PreviewGenerator")
 
   private nonisolated static let maxPixelSize = 320
   private nonisolated static let jpegQuality: CGFloat = 0.7
@@ -52,7 +50,7 @@ enum PreviewGenerator {
       let src = CGImageSourceCreateWithURL(url as CFURL, nil),
       let cg = CGImageSourceCreateThumbnailAtIndex(src, 0, options as CFDictionary)
     else {
-      logger.warning("image preview failed")
+      log.warning("image preview failed")
       return nil
     }
 
@@ -66,11 +64,11 @@ enum PreviewGenerator {
       let jpeg = image.jpegData(compressionQuality: jpegQuality),
       let preview = dataUrl(jpeg, mime: "image/jpeg")
     {
-      logger.info("image preview: PNG over cap, used JPEG fallback")
+      log.info("image preview: PNG over cap, used JPEG fallback")
       return preview
     }
 
-    logger.warning("image preview over cap even as JPEG, dropping")
+    log.warning("image preview over cap even as JPEG, dropping")
     return nil
   }
 
@@ -83,7 +81,7 @@ enum PreviewGenerator {
       let doc = PDFDocument(url: url),
       let page = doc.page(at: 0)
     else {
-      logger.warning("pdf preview failed")
+      log.warning("pdf preview failed")
       return nil
     }
 
@@ -95,7 +93,7 @@ enum PreviewGenerator {
     }
 
     guard let preview = dataUrl(data, mime: "image/jpeg") else {
-      logger.warning("pdf preview over cap, dropping")
+      log.warning("pdf preview over cap, dropping")
       return nil
     }
 

--- a/client/ios/PastePoint/Core/Services/FileTransfer/ReceivedFileSaver.swift
+++ b/client/ios/PastePoint/Core/Services/FileTransfer/ReceivedFileSaver.swift
@@ -4,7 +4,6 @@
 //
 
 import Foundation
-import Logging
 import Photos
 import UniformTypeIdentifiers
 
@@ -12,7 +11,6 @@ import UniformTypeIdentifiers
 /// library, everything else into the app's Documents folder. The tmp buffer is
 /// consumed (moved) or deleted afterwards — nothing lingers.
 enum ReceivedFileSaver {
-  private nonisolated static let logger = Logger(label: "ReceivedFileSaver")
 
   enum Outcome: Sendable {
     case photos
@@ -34,7 +32,7 @@ enum ReceivedFileSaver {
   private nonisolated static func saveToPhotos(url: URL, isVideo: Bool) async -> Outcome {
     let status = await PHPhotoLibrary.requestAuthorization(for: .addOnly)
     guard status == .authorized || status == .limited else {
-      logger.error("Photos add permission denied")
+      log.error("Photos add permission denied")
       return .permissionDenied
     }
 
@@ -48,10 +46,10 @@ enum ReceivedFileSaver {
       } completionHandler: { success, error in
         if success {
           try? FileManager.default.removeItem(at: url)
-          Self.logger.info("saved to Photos: \(url.lastPathComponent)")
+          log.info("saved to Photos: \(url.lastPathComponent)")
           continuation.resume(returning: .photos)
         } else {
-          Self.logger.error("Photos save failed: \(String(describing: error))")
+          log.error("Photos save failed: \(String(describing: error))")
           continuation.resume(returning: .failed)
         }
       }
@@ -71,10 +69,10 @@ enum ReceivedFileSaver {
 
       let dest = uniqueURL(in: docs, fileName: fileName)
       try FileManager.default.moveItem(at: url, to: dest)
-      logger.info("saved to Documents: \(dest.lastPathComponent)")
+      log.info("saved to Documents: \(dest.lastPathComponent)")
       return .documents(dest)
     } catch {
-      logger.error("Documents save failed: \(String(describing: error))")
+      log.error("Documents save failed: \(String(describing: error))")
       return .failed
     }
   }

--- a/client/ios/PastePoint/Core/Services/Moderation/BlockService.swift
+++ b/client/ios/PastePoint/Core/Services/Moderation/BlockService.swift
@@ -5,11 +5,9 @@
 
 import Combine
 import Foundation
-import Logging
 
 @MainActor
 final class BlockService: ObservableObject {
-  private let logger = Logger(label: "Block")
 
   @Published private(set) var blockedPeers: Set<String> = []
 
@@ -27,12 +25,12 @@ final class BlockService: ObservableObject {
   func block(_ peer: String) {
     guard !peer.isEmpty else { return }
 
-    logger.info("blocking peer \(peer)")
+    log.info("blocking peer \(peer)")
     blockedPeers.insert(peer)
   }
 
   func unblock(_ peer: String) {
-    logger.info("unblocking peer \(peer)")
+    log.info("unblocking peer \(peer)")
     blockedPeers.remove(peer)
   }
 
@@ -43,7 +41,7 @@ final class BlockService: ObservableObject {
   private func clear() {
     guard !blockedPeers.isEmpty else { return }
 
-    logger.debug("clearing blocks — identities are reassigned on reconnect")
+    log.debug("clearing blocks — identities are reassigned on reconnect")
     blockedPeers.removeAll()
   }
 }

--- a/client/ios/PastePoint/Core/Services/Room/RoomService.swift
+++ b/client/ios/PastePoint/Core/Services/Room/RoomService.swift
@@ -5,11 +5,9 @@
 
 import Combine
 import Foundation
-import Logging
 
 @MainActor
 final class RoomService: ObservableObject {
-  private let logger = Logger(label: "Room")
 
   @Published var rooms: [String] = []
   @Published var members: [String] = []
@@ -51,14 +49,14 @@ final class RoomService: ObservableObject {
 
   func joinOrCreateRoom(_ room: String) async {
     guard !room.isEmpty else {
-      logger.warning("room name is empty — skipped")
+      log.warning("room name is empty — skipped")
       return
     }
     guard room != currentRoom else {
-      logger.debug("already in room '\(room)' — skipped")
+      log.debug("already in room '\(room)' — skipped")
       return
     }
-    logger.info("Joining room: \(room)")
+    log.info("Joining room: \(room)")
     await wsService.send("[UserCommand] /join \(room)")
     currentRoom = room
 
@@ -75,36 +73,36 @@ final class RoomService: ObservableObject {
   private func handleSystemMessage(_ message: String) {
     if message.contains("[SystemRooms]") {
       guard let range = message.range(of: "\\[SystemRooms]\\s*(.*)$", options: .regularExpression) else {
-        logger.warning("failed to parse [SystemRooms] message: \(message)")
+        log.warning("failed to parse [SystemRooms] message: \(message)")
         return
       }
       let rest = String(message[range])
       let prefix = "[SystemRooms] "
       let list = rest.hasPrefix(prefix) ? String(rest.dropFirst(prefix.count)) : rest
       rooms = list.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
-      logger.debug("Rooms updated: \(rooms)")
+      log.debug("Rooms updated: \(rooms)")
     } else if message.contains("[SystemMembers]") {
       guard let range = message.range(of: "\\[SystemMembers]\\s*(.*)$", options: .regularExpression) else {
-        logger.warning("failed to parse [SystemMembers] message: \(message)")
+        log.warning("failed to parse [SystemMembers] message: \(message)")
         return
       }
       let rest = String(message[range])
       let prefix = "[SystemMembers] "
       let list = rest.hasPrefix(prefix) ? String(rest.dropFirst(prefix.count)) : rest
       members = list.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
-      logger.debug("Members updated: \(members)")
+      log.debug("Members updated: \(members)")
     } else if message.contains("[SystemJoin]") {
       guard let range = message.range(of: "\\[SystemJoin]\\s*(\\S+)\\s*$", options: .regularExpression) else {
-        logger.warning("failed to parse [SystemJoin] message: \(message)")
+        log.warning("failed to parse [SystemJoin] message: \(message)")
         return
       }
       let parts = String(message[range]).split(separator: " ")
       guard let last = parts.last else {
-        logger.warning("[SystemJoin] had no room name in: \(message)")
+        log.warning("[SystemJoin] had no room name in: \(message)")
         return
       }
       currentRoom = String(last)
-      logger.info("Joined room: \(currentRoom)")
+      log.info("Joined room: \(currentRoom)")
       Task { await self.listRooms() }
     }
   }

--- a/client/ios/PastePoint/Core/Services/Session/SessionService.swift
+++ b/client/ios/PastePoint/Core/Services/Session/SessionService.swift
@@ -5,7 +5,6 @@
 
 import Combine
 import Foundation
-import Logging
 
 struct CreateSessionResponse: Decodable {
   let code: String
@@ -13,7 +12,6 @@ struct CreateSessionResponse: Decodable {
 
 @MainActor
 final class SessionService: ObservableObject {
-  private let logger = Logger(label: "Session")
 
   func getNewSessionCode() async throws -> String {
 #if DEBUG
@@ -44,7 +42,7 @@ final class SessionService: ObservableObject {
 
     let decoded = try JSONDecoder().decode(CreateSessionResponse.self, from: data)
     // TODO: Remove this log before release.
-    logger.debug("Private session code received successfully with: \(decoded.code)")
+    log.debug("Private session code received successfully with: \(decoded.code)")
     return decoded.code
   }
 

--- a/client/ios/PastePoint/Core/Services/User/UserService.swift
+++ b/client/ios/PastePoint/Core/Services/User/UserService.swift
@@ -5,11 +5,9 @@
 
 import Combine
 import Foundation
-import Logging
 
 @MainActor
 final class UserService: ObservableObject {
-  private let logger = Logger(label: "User")
 
   @Published var user: String = ""
 
@@ -61,18 +59,18 @@ final class UserService: ObservableObject {
   private func handleSystemMessage(_ message: String) {
     guard message.contains("[SystemName]") else { return }
     guard let regex = Self.nameRegex else {
-      logger.error("nameRegex failed to initialize")
+      log.error("nameRegex failed to initialize")
       return
     }
     guard let match = regex.firstMatch(in: message, range: NSRange(message.startIndex..., in: message)) else {
-      logger.warning("no [SystemName] match in: \(message)")
+      log.warning("no [SystemName] match in: \(message)")
       return
     }
     guard let range = Range(match.range(at: 1), in: message) else {
-      logger.warning("capture group out of range in: \(message)")
+      log.warning("capture group out of range in: \(message)")
       return
     }
     user = String(message[range]).trimmingCharacters(in: .whitespaces)
-    logger.debug("Username updated: \(user)")
+    log.debug("Username updated: \(user)")
   }
 }

--- a/client/ios/PastePoint/Core/Services/WebRTC/SignalingService.swift
+++ b/client/ios/PastePoint/Core/Services/WebRTC/SignalingService.swift
@@ -5,7 +5,6 @@
 
 import Combine
 import Foundation
-import Logging
 import WebRTC
 
 private struct UnsafeSendable<T>: @unchecked Sendable {
@@ -32,7 +31,6 @@ final class SignalingService: NSObject, ObservableObject {
   let fileEvent = PassthroughSubject<FileChannelEvent, Never>()
   let chunkReceived = PassthroughSubject<(ParsedChunk, from: String), Never>()
 
-  private let logger = Logger(label: "SignalingService")
   private let wsService: WebSocketConnectionService
   private let userService: UserService
   private let peerDirectory: PeerDirectory
@@ -112,23 +110,23 @@ final class SignalingService: NSObject, ObservableObject {
 
   func initiateConnection(to peer: String, force: Bool = false) async {
     guard !connectionLocks.contains(peer) else {
-      logger.debug("already locked for \(peer)")
+      log.debug("already locked for \(peer)")
       return
     }
 
     guard peerConnections[peer] == nil else {
-      logger.warning("already have a connection to \(peer)")
+      log.warning("already have a connection to \(peer)")
       return
     }
 
     if !force, connectionRequestTimeouts[peer] != nil {
-      logger.debug("connection request already outstanding for \(peer)")
+      log.debug("connection request already outstanding for \(peer)")
       return
     }
 
     await userService.waitForUsername()
     if !force, !shouldInitiateConnection(to: peer) {
-      logger.info("not the designated caller for \(peer), sending connection request")
+      log.info("not the designated caller for \(peer), sending connection request")
       let request = SignalMessage(
         payload: .connectionRequest,
         from: userService.user,
@@ -147,14 +145,14 @@ final class SignalingService: NSObject, ObservableObject {
     startConnectionTimeout(for: peer)
 
     guard let pc = PeerConnectionFactory.shared.makePeerConnection(iceServers: await turnCredentials.iceServers(), delegate: self) else {
-      logger.error("factory returned nil for \(peer)")
+      log.error("factory returned nil for \(peer)")
       connectionLocks.remove(peer)
       return
     }
     peerConnections[peer] = pc
 
     guard let channel = pc.dataChannel(forLabel: "data", configuration: WebRTCConfig.dataChannelConfig) else {
-      logger.error("failed to create data channel for \(peer)")
+      log.error("failed to create data channel for \(peer)")
       peerConnections[peer] = nil
       connectionLocks.remove(peer)
       return
@@ -167,7 +165,7 @@ final class SignalingService: NSObject, ObservableObject {
       let offer = try await pc.offer(for: constraints)
       try await pc.setLocalDescription(offer)
     } catch {
-      logger.error("SDP offer failed: \(error.localizedDescription)")
+      log.error("SDP offer failed: \(error.localizedDescription)")
       peerConnections[peer] = nil
       dataChannels[peer] = nil
       connectionLocks.remove(peer)
@@ -181,23 +179,23 @@ final class SignalingService: NSObject, ObservableObject {
       sequence: nextSequence(for: peer),
     )
     await wsService.sendSignal(offerMessage)
-    logger.info("offer sent to \(peer)")
+    log.info("offer sent to \(peer)")
   }
 
   func send(_ text: String, to peer: String) {
     guard let channel = dataChannels[peer] else {
-      logger.warning("no data channel for \(peer)")
+      log.warning("no data channel for \(peer)")
       return
     }
 
     guard channel.readyState == .open else {
-      logger.warning("channel to \(peer) not open (state: \(channel.readyState.rawValue))")
+      log.warning("channel to \(peer) not open (state: \(channel.readyState.rawValue))")
       return
     }
 
     let buffer = RTCDataBuffer(data: Data(text.utf8), isBinary: false)
     channel.sendData(buffer)
-    logger.info("sent \(text) to \(peer)")
+    log.info("sent \(text) to \(peer)")
   }
 
   func isReadyToSend(to peer: String) -> Bool {
@@ -225,12 +223,12 @@ final class SignalingService: NSObject, ObservableObject {
     let toClose = tracked.subtracting(target)
 
     for peer in toClose {
-      logger.info("closing connection to \(peer) (left room)")
+      log.info("closing connection to \(peer) (left room)")
       closePeerConnection(peer)
     }
 
     for peer in toOpen {
-      logger.info("opening connection to \(peer) (joined room)")
+      log.info("opening connection to \(peer) (joined room)")
       pendingOpens.insert(peer)
       Task {
         await initiateConnection(to: peer)
@@ -255,16 +253,16 @@ extension SignalingService {
 
   private func handle(_ message: SignalMessage) {
     guard !message.from.isEmpty else {
-      logger.warning("ignoring message with empty 'from'")
+      log.warning("ignoring message with empty 'from'")
       return
     }
 
     guard !blockService.isBlocked(message.from) else {
-      logger.info("ignoring \(message.payload.typeString) from blocked peer \(message.from)")
+      log.info("ignoring \(message.payload.typeString) from blocked peer \(message.from)")
       return
     }
 
-    logger.info("received \(message.payload.typeString) from \(message.from)")
+    log.info("received \(message.payload.typeString) from \(message.from)")
     switch message.payload {
     case .offer:
       Task {
@@ -289,17 +287,17 @@ extension SignalingService {
     await userService.waitForUsername()
 
     if isDuplicate(message.from, sequence: message.sequence) {
-      logger.debug("ignoring duplicate sequence from \(message.from)")
+      log.debug("ignoring duplicate sequence from \(message.from)")
       return
     }
 
     if connectionLocks.contains(message.from) {
-      logger.warning("collision with \(message.from), resolving by role")
+      log.warning("collision with \(message.from), resolving by role")
       if shouldInitiateConnection(to: message.from) {
-        logger.debug("ignoring offer from \(message.from) (we are the designated caller)")
+        log.debug("ignoring offer from \(message.from) (we are the designated caller)")
         return
       } else {
-        logger.debug("canceling our initiation for \(message.from) (we are the designated callee)")
+        log.debug("canceling our initiation for \(message.from) (we are the designated callee)")
         closePeerConnection(message.from)
       }
     }
@@ -309,13 +307,13 @@ extension SignalingService {
     startConnectionTimeout(for: message.from)
 
     guard case .offer(let sdpString) = message.payload else {
-      logger.error("payload is not .offer (received \(message.payload.typeString))")
+      log.error("payload is not .offer (received \(message.payload.typeString))")
       return
     }
     let remoteSdp = RTCSessionDescription(type: .offer, sdp: sdpString)
 
     guard let pc = PeerConnectionFactory.shared.makePeerConnection(iceServers: await turnCredentials.iceServers(), delegate: self) else {
-      logger.error("factory returned nil for \(message.from)")
+      log.error("factory returned nil for \(message.from)")
       connectionLocks.remove(message.from)
       return
     }
@@ -328,7 +326,7 @@ extension SignalingService {
       let answer = try await pc.answer(for: constraints)
       try await pc.setLocalDescription(answer)
     } catch {
-      logger.error("SDP exchange failed: \(error.localizedDescription)")
+      log.error("SDP exchange failed: \(error.localizedDescription)")
       peerConnections[message.from] = nil
       connectionLocks.remove(message.from)
       return
@@ -341,22 +339,22 @@ extension SignalingService {
       sequence: nextSequence(for: message.from),
     )
     await wsService.sendSignal(response)
-    logger.info("answer sent to \(message.from)")
+    log.info("answer sent to \(message.from)")
   }
 
   private func handleAnswer(_ message: SignalMessage) async {
     if isDuplicate(message.from, sequence: message.sequence) {
-      logger.debug("ignoring duplicate sequence from \(message.from)")
+      log.debug("ignoring duplicate sequence from \(message.from)")
       return
     }
 
     guard let pc = peerConnections[message.from] else {
-      logger.warning("no peer connection for \(message.from)")
+      log.warning("no peer connection for \(message.from)")
       return
     }
 
     guard case .answer(let sdpString) = message.payload else {
-      logger.error("payload is not .answer")
+      log.error("payload is not .answer")
       return
     }
     let remoteSdp = RTCSessionDescription(type: .answer, sdp: sdpString)
@@ -364,40 +362,40 @@ extension SignalingService {
     do {
       try await pc.setRemoteDescription(remoteSdp)
       await drainCandidateQueue(for: message.from)
-      logger.info("remote description set for \(message.from)")
+      log.info("remote description set for \(message.from)")
     } catch {
-      logger.error("setRemoteDescription failed: \(error.localizedDescription)")
+      log.error("setRemoteDescription failed: \(error.localizedDescription)")
     }
   }
 
   private func handleCandidate(_ message: SignalMessage) async {
     guard case .candidate(let sdpString, let sdpMid, let sdpMLineIndex) = message.payload else {
-      logger.error("payload is not .candidate")
+      log.error("payload is not .candidate")
       return
     }
     let candidate = RTCIceCandidate(sdp: sdpString, sdpMLineIndex: sdpMLineIndex, sdpMid: sdpMid)
 
     guard let pc = peerConnections[message.from], pc.remoteDescription != nil else {
       candidateQueues[message.from, default: []].append(candidate)
-      logger.info("queued candidate for \(message.from) (queue size: \(candidateQueues[message.from]?.count ?? 0))")
+      log.info("queued candidate for \(message.from) (queue size: \(candidateQueues[message.from]?.count ?? 0))")
       return
     }
 
     do {
       try await pc.add(candidate)
-      logger.info("candidate added for \(message.from)")
+      log.info("candidate added for \(message.from)")
     } catch {
-      logger.error("add failed: \(error.localizedDescription)")
+      log.error("add failed: \(error.localizedDescription)")
     }
   }
 
   private func handleConnectionRequest(_ message: SignalMessage) async {
     if isDuplicate(message.from, sequence: message.sequence) {
-      logger.debug("ignoring duplicate sequence from \(message.from)")
+      log.debug("ignoring duplicate sequence from \(message.from)")
       return
     }
 
-    logger.info("\(message.from) is asking us to initiate")
+    log.info("\(message.from) is asking us to initiate")
     await initiateConnection(to: message.from)
   }
 
@@ -411,10 +409,10 @@ extension SignalingService {
       do {
         try await pc.add(candidate)
       } catch {
-        logger.error("add failed for \(peer)")
+        log.error("add failed for \(peer)")
       }
     }
-    logger.info("drained \(queued.count) candidates for \(peer)")
+    log.info("drained \(queued.count) candidates for \(peer)")
   }
 }
 
@@ -424,13 +422,13 @@ extension SignalingService {
 
   private func scheduleReconnect(to peer: String) {
     guard reconnectTasks[peer] == nil else {
-      logger.debug("already scheduled for \(peer)")
+      log.debug("already scheduled for \(peer)")
       return
     }
 
     // Only connect if the peer is still expected to be in the room
     guard peerDirectory.peers.contains(peer) else {
-      logger.info("\(peer) is no longer a peer, skipping")
+      log.info("\(peer) is no longer a peer, skipping")
       reconnectAttempts[peer] = nil
       connectingPeers.remove(peer)
       return
@@ -438,7 +436,7 @@ extension SignalingService {
 
     let attempts = reconnectAttempts[peer] ?? 0
     guard attempts < Self.maxReconnectAttempts else {
-      logger.error("max attempts reached for \(peer)")
+      log.error("max attempts reached for \(peer)")
       reconnectAttempts[peer] = nil
       connectingPeers.remove(peer)
       return
@@ -449,7 +447,7 @@ extension SignalingService {
 
     // Exponential backoff: 2s, 3s, 4.5s, ...
     let delay = min(Self.baseReconnectDelay * pow(1.5, Double(attempts)), Self.maxReconnectDelay)
-    logger.warning("attempt \(attempts + 1) for \(peer) in \(delay)s")
+    log.warning("attempt \(attempts + 1) for \(peer) in \(delay)s")
 
     reconnectTasks[peer] = Task { [weak self] in
       try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
@@ -458,7 +456,7 @@ extension SignalingService {
       self.reconnectTasks[peer] = nil
 
       guard self.peerDirectory.peers.contains(peer) else {
-        self.logger.info("\(peer) left during backoff, skipping")
+        log.info("\(peer) left during backoff, skipping")
         self.reconnectAttempts[peer] = nil
         connectingPeers.remove(peer)
         return
@@ -466,13 +464,13 @@ extension SignalingService {
 
       // Don't reconnect if we have already healed since scheduling
       if self.connectedPeers.contains(peer) {
-        self.logger.debug("\(peer) already healthy, skipping")
+        log.debug("\(peer) already healthy, skipping")
         self.reconnectAttempts[peer] = nil
         connectingPeers.remove(peer)
         return
       }
 
-      self.logger.info("reconnecting to \(peer)")
+      log.info("reconnecting to \(peer)")
       self.closePeerConnection(peer, resetReconnectState: false)
       await self.initiateConnection(to: peer)
     }
@@ -493,7 +491,7 @@ extension SignalingService {
       // Check if we already connected then don't do anything
       if self.connectedPeers.contains(peer) { return }
 
-      self.logger.warning("connectionTimeout: \(peer) did not reach connected in \(Self.connectionTimeout)s, treating as failure")
+      log.warning("connectionTimeout: \(peer) did not reach connected in \(Self.connectionTimeout)s, treating as failure")
       self.logConnectionDiagnostics(for: peer)
       self.scheduleReconnect(to: peer)
     }
@@ -517,7 +515,7 @@ extension SignalingService {
       self.connectionRequestTimeouts[peer] = nil
 
       guard self.peerConnections[peer] == nil, self.peerDirectory.peers.contains(peer) else { return }
-      self.logger.warning("no offer from \(peer) within \(Self.connectionRequestTimeout)s — force-initiating")
+      log.warning("no offer from \(peer) within \(Self.connectionRequestTimeout)s — force-initiating")
       await self.initiateConnection(to: peer, force: true)
     }
   }
@@ -575,7 +573,7 @@ extension SignalingService {
     if !hasRelay {
       report += "\n  ISSUE: No TURN relay candidates — connection will fail behind symmetric NAT"
     }
-    logger.error("\(report)")
+    log.error("\(report)")
   }
 }
 
@@ -609,12 +607,12 @@ extension SignalingService {
   /// Called by services that build their own envelopes (e.g. `FileTransferService`).
   func send(_ data: Data, to peer: String, isBinary: Bool = false) -> Bool {
     guard let channel = dataChannels[peer], channel.readyState == .open else {
-      logger.warning("no open channel to \(peer)")
+      log.warning("no open channel to \(peer)")
       return false
     }
 
     guard !isBinary || channel.bufferedAmount < WebRTCConfig.maxBufferedAmount else {
-      logger.debug("channel to \(peer) back-pressured (\(channel.bufferedAmount) bytes)")
+      log.debug("channel to \(peer) back-pressured (\(channel.bufferedAmount) bytes)")
       return false
     }
 
@@ -625,7 +623,7 @@ extension SignalingService {
     do {
       return try DataChannelMessage.encodeChat(chat)
     } catch {
-      logger.error("encodeChat failed: \(error)")
+      log.error("encodeChat failed: \(error)")
       return nil
     }
   }
@@ -684,7 +682,7 @@ extension SignalingService: RTCPeerConnectionDelegate {
       guard let self else { return }
       guard let peer = self.peer(forConnectionID: peerConnectionID) else { return }
 
-      self.logger.debug("iceConnectionState: \(peer) → \(state.rawValue)")
+      log.debug("iceConnectionState: \(peer) → \(state.rawValue)")
       switch state {
       case .failed, .disconnected:
         self.scheduleReconnect(to: peer)
@@ -707,7 +705,7 @@ extension SignalingService: RTCPeerConnectionDelegate {
       await userService.waitForUsername()
 
       guard let peer = self.peer(forConnectionID: peerConnectionID) else {
-        self.logger.warning("unknown peer connection")
+        log.warning("unknown peer connection")
         return
       }
 
@@ -731,13 +729,13 @@ extension SignalingService: RTCPeerConnectionDelegate {
       guard let self else { return }
 
       guard let peer = self.peer(forConnectionID: peerConnectionID) else {
-        self.logger.warning("unknown peer connection")
+        log.warning("unknown peer connection")
         return
       }
 
       box.value.delegate = self
       self.dataChannels[peer] = box.value
-      self.logger.info("data channel attached to peer: \(peer)")
+      log.info("data channel attached to peer: \(peer)")
       if box.value.readyState == .open {
         self.handleChannelOpened(peer)
       }
@@ -757,7 +755,7 @@ extension SignalingService: RTCDataChannelDelegate {
       guard let self else { return }
 
       guard let peer = self.peer(forChannelID: dataChannelID) else {
-        self.logger.debug("unknown channel (already closed)")
+        log.debug("unknown channel (already closed)")
         return
       }
 
@@ -767,12 +765,12 @@ extension SignalingService: RTCDataChannelDelegate {
       case .closed:
         self.connectedPeers.remove(peer)
         self.connectionLocks.remove(peer)
-        self.logger.info("disconnected from \(peer)")
+        log.info("disconnected from \(peer)")
         self.scheduleReconnect(to: peer)
       case .connecting:
-        self.logger.info("connecting to \(peer)")
+        log.info("connecting to \(peer)")
       case .closing:
-        self.logger.info("closing connection to \(peer)")
+        log.info("closing connection to \(peer)")
       @unknown default:
         break
       }
@@ -787,7 +785,7 @@ extension SignalingService: RTCDataChannelDelegate {
     connectionLocks.remove(peer)
     reconnectAttempts[peer] = nil
     clearConnectionTimeout(for: peer)
-    self.logger.info("connected to \(peer)")
+    log.info("connected to \(peer)")
   }
 
   nonisolated func dataChannel(_ dataChannel: RTCDataChannel, didReceiveMessageWith buffer: RTCDataBuffer) {
@@ -799,13 +797,13 @@ extension SignalingService: RTCDataChannelDelegate {
       guard let self else { return }
 
       guard let peer = self.peer(forChannelID: dataChannelID) else {
-        self.logger.warning("unknown channel")
+        log.warning("unknown channel")
         return
       }
 
       if isBinary {
         guard let parsed = BinaryChunk.decode(bytes) else {
-          self.logger.warning("dropped malformed binary chunk from \(peer)")
+          log.warning("dropped malformed binary chunk from \(peer)")
           return
         }
 
@@ -817,14 +815,14 @@ extension SignalingService: RTCDataChannelDelegate {
         let decoded = try DataChannelMessage.decode(bytes)
         self.route(decoded, from: peer)
       } catch {
-        self.logger.error("failed to decode data-channel message from \(peer): \(error)")
+        log.error("failed to decode data-channel message from \(peer): \(error)")
       }
     }
   }
 
   private func route(_ decoded: DataChannelMessage.Decoded, from peer: String) {
     guard !blockService.isBlocked(peer) else {
-      logger.info("dropping data-channel message from blocked peer \(peer)")
+      log.info("dropping data-channel message from blocked peer \(peer)")
       return
     }
 
@@ -836,7 +834,7 @@ extension SignalingService: RTCDataChannelDelegate {
     case .fileCancelUpload(let payload): fileEvent.send(.cancelUpload(payload, from: peer))
     case .fileCancelDownload(let payload): fileEvent.send(.cancelDownload(payload, from: peer))
     case .fileReceived(let payload): fileEvent.send(.received(payload, from: peer))
-    case .unknown(let type): logger.warning("unknown data-channel type \(type) from \(peer)")
+    case .unknown(let type): log.warning("unknown data-channel type \(type) from \(peer)")
     }
   }
 

--- a/client/ios/PastePoint/Core/Services/WebRTC/TurnCredentialsService.swift
+++ b/client/ios/PastePoint/Core/Services/WebRTC/TurnCredentialsService.swift
@@ -4,7 +4,6 @@
 //
 
 import Foundation
-import Logging
 import WebRTC
 
 /// Fetches short-lived TURN credentials from `GET /turn-credentials` and caches
@@ -19,8 +18,6 @@ final class TurnCredentialsService {
     let ttl: Int
     let urls: [String]
   }
-
-  private let logger = Logger(label: "TurnCredentials")
 
   private var cached: [RTCIceServer]?
   private var expiresAt: Date = .distantPast
@@ -44,13 +41,13 @@ final class TurnCredentialsService {
         http.statusCode != 204,
         !data.isEmpty
       else {
-        logger.info("No TURN relay configured on server — STUN-only")
+        log.info("No TURN relay configured on server — STUN-only")
         return WebRTCConfig.stunServers
       }
 
       let creds = try JSONDecoder().decode(Response.self, from: data)
       guard !creds.urls.isEmpty, !creds.username.isEmpty, !creds.credential.isEmpty else {
-        logger.info("No TURN relay configured on server — STUN-only")
+        log.info("No TURN relay configured on server — STUN-only")
         return WebRTCConfig.stunServers
       }
 
@@ -64,10 +61,10 @@ final class TurnCredentialsService {
 
       // Refresh a minute before the credential actually expires.
       expiresAt = Date().addingTimeInterval(TimeInterval(max(creds.ttl - 60, 60)))
-      logger.info("TURN credentials fetched — relay available (ttl \(creds.ttl)s, urls: \(creds.urls.joined(separator: ", ")))")
+      log.info("TURN credentials fetched — relay available (ttl \(creds.ttl)s, urls: \(creds.urls.joined(separator: ", ")))")
       return servers
     } catch {
-      logger.debug("TURN fetch failed, STUN-only: \(error.localizedDescription)")
+      log.debug("TURN fetch failed, STUN-only: \(error.localizedDescription)")
       return WebRTCConfig.stunServers
     }
   }

--- a/client/ios/PastePoint/Core/Services/WebSocket/WebSocketConnectionService.swift
+++ b/client/ios/PastePoint/Core/Services/WebSocket/WebSocketConnectionService.swift
@@ -5,7 +5,6 @@
 
 import Combine
 import Foundation
-import Logging
 import SwiftUI
 
 struct ReconnectState: Equatable {
@@ -15,7 +14,6 @@ struct ReconnectState: Equatable {
 
 @MainActor
 final class WebSocketConnectionService: ObservableObject {
-  private let logger = Logger(label: "WebSocket")
 
   // MARK: - Connection State
 
@@ -60,7 +58,7 @@ final class WebSocketConnectionService: ObservableObject {
 
   func setupPrivateSession(_ code: String) async {
     guard SessionService.isValidSessionCode(code) else {
-      logger.warning("Private session code is not valid: \(code)")
+      log.warning("Private session code is not valid: \(code)")
       return
     }
     disconnect(manual: true)
@@ -75,7 +73,7 @@ final class WebSocketConnectionService: ObservableObject {
 #endif
 
     guard !isConnecting else {
-      logger.debug("Already connecting — ignored")
+      log.debug("Already connecting — ignored")
       isLeavingSession = false
       return
     }
@@ -83,7 +81,7 @@ final class WebSocketConnectionService: ObservableObject {
     let effectiveCode = code ?? sessionCode
 
     if isConnected, sessionCode == effectiveCode {
-      logger.debug("Already connected to same session")
+      log.debug("Already connected to same session")
       isLeavingSession = false
       return
     }
@@ -105,12 +103,12 @@ final class WebSocketConnectionService: ObservableObject {
 
     let urlString = AppEnvironment.webSocketUrl(sessionCode: effectiveCode)
     guard let url = URL(string: urlString) else {
-      logger.error("Invalid WS URL: \(urlString)")
+      log.error("Invalid WS URL: \(urlString)")
       isConnecting = false
       return
     }
 
-    logger.info("Connecting to \(urlString)")
+    log.info("Connecting to \(urlString)")
 
 #if DEBUG
     let session = URLSession(
@@ -137,10 +135,10 @@ final class WebSocketConnectionService: ObservableObject {
         self.isConnecting = false
         self.isLeavingSession = false
         if let error {
-          self.logger.warning("Connection handshake ping failed: \(error.localizedDescription)")
+          log.warning("Connection handshake ping failed: \(error.localizedDescription)")
           self.teardownConnection()
           if self.isPermanentError(error) {
-            self.logger.warning("Session code invalid or expired — falling back to public session")
+            log.warning("Session code invalid or expired — falling back to public session")
             self.sessionRejected.send()
             self.clearSessionCode()
             await self.connect(sessionCode: nil, isReconnectAttempt: false)
@@ -177,7 +175,7 @@ final class WebSocketConnectionService: ObservableObject {
           case .string(let text):
             handleIncoming(text)
           case .data(let data):
-            logger.debug("Binary frame received: \(data.count) bytes (ignored)")
+            log.debug("Binary frame received: \(data.count) bytes (ignored)")
           @unknown default:
             break
           }
@@ -185,7 +183,7 @@ final class WebSocketConnectionService: ObservableObject {
           guard !Task.isCancelled else { break }
 
           if isPermanentError(error) {
-            logger.warning("Session code invalid or expired — falling back to public session")
+            log.warning("Session code invalid or expired — falling back to public session")
             sessionRejected.send()
             clearSessionCode()
             teardownConnection()
@@ -193,7 +191,7 @@ final class WebSocketConnectionService: ObservableObject {
             break
           }
 
-          logger.error("Receive error: \(error.localizedDescription)")
+          log.error("Receive error: \(error.localizedDescription)")
           scheduleReconnect()
           break
         }
@@ -217,16 +215,16 @@ final class WebSocketConnectionService: ObservableObject {
       do {
         let obj = try JSONSerialization.jsonObject(with: Data(json.utf8))
         guard let dict = obj as? [String: Any] else {
-          logger.warning("signal JSON is not a dictionary")
+          log.warning("signal JSON is not a dictionary")
           return
         }
         guard let sig = SignalMessage(from: dict) else {
-          logger.warning("malformed SignalMessage — missing required fields in: \(json)")
+          log.warning("malformed SignalMessage — missing required fields in: \(json)")
           return
         }
         signalMessage.send(sig)
       } catch {
-        logger.error("JSON parse error: \(error.localizedDescription)")
+        log.error("JSON parse error: \(error.localizedDescription)")
       }
     } else if isSystemMessage(msg) {
       systemMessage.send(msg)
@@ -251,14 +249,14 @@ final class WebSocketConnectionService: ObservableObject {
 #endif
 
     guard task != nil else {
-      logger.warning("Send failed — no active socket task")
+      log.warning("Send failed — no active socket task")
       return
     }
 
     do {
       try await task?.send(.string(text))
     } catch {
-      logger.error("Send error: \(error.localizedDescription)")
+      log.error("Send error: \(error.localizedDescription)")
     }
   }
 
@@ -266,12 +264,12 @@ final class WebSocketConnectionService: ObservableObject {
     do {
       let data = try JSONSerialization.data(withJSONObject: message.toDict())
       guard let json = String(data: data, encoding: .utf8) else {
-        logger.error("failed to encode JSON as UTF-8 string")
+        log.error("failed to encode JSON as UTF-8 string")
         return
       }
       await send("[SignalMessage] \(json)")
     } catch {
-      logger.error("JSON serialization failed: \(error.localizedDescription)")
+      log.error("JSON serialization failed: \(error.localizedDescription)")
     }
   }
 
@@ -289,7 +287,7 @@ final class WebSocketConnectionService: ObservableObject {
           task?.sendPing { [weak self] error in
             guard let self else { return }
             if let error {
-              logger.warning("Ping failed: \(error.localizedDescription) — triggering reconnect")
+              log.warning("Ping failed: \(error.localizedDescription) — triggering reconnect")
 
               // sendPing callback fires on an arbitrary queue; hop to MainActor.
               Task { @MainActor in
@@ -300,7 +298,7 @@ final class WebSocketConnectionService: ObservableObject {
             }
           }
         } catch {
-          logger.debug("Ping loop interrupted: \(error.localizedDescription)")
+          log.debug("Ping loop interrupted: \(error.localizedDescription)")
           break
         }
       }
@@ -336,7 +334,7 @@ final class WebSocketConnectionService: ObservableObject {
     let delay = reconnectAttempts <= maxReconnectAttempts
       ? min(baseReconnectDelaySec * pow(2.0, Double(reconnectAttempts - 1)), maxReconnectDelaySec)
       : maxReconnectDelaySec
-    logger.info("Reconnecting in \(Int(delay))s (attempt \(reconnectAttempts))")
+    log.info("Reconnecting in \(Int(delay))s (attempt \(reconnectAttempts))")
     reconnectState = ReconnectState(attempt: reconnectAttempts, nextAttemptDate: Date().addingTimeInterval(delay))
 
     reconnectTask?.cancel()
@@ -350,7 +348,7 @@ final class WebSocketConnectionService: ObservableObject {
   // MARK: - Disconnect
 
   func disconnect(manual: Bool = true) {
-    logger.info("Disconnecting (manual: \(manual))")
+    log.info("Disconnecting (manual: \(manual))")
     manualDisconnect = manual
     reconnectState = nil
     if manual {

--- a/client/ios/PastePoint/Core/Utils/Logging/AppLog.swift
+++ b/client/ios/PastePoint/Core/Utils/Logging/AppLog.swift
@@ -1,0 +1,53 @@
+//
+//  Copyright © 2026 PastePoint. All rights reserved.
+//  SPDX-License-Identifier: GPL-3.0-only
+//
+
+import Logging
+import os
+
+nonisolated let log = AppLog()
+
+struct AppLog: Sendable {
+  private let cache = OSAllocatedUnfairLock<[String: Logging.Logger]>(initialState: [:])
+
+  nonisolated init() {}
+
+  private nonisolated func logger(for file: String) -> Logging.Logger {
+    cache.withLock { store in
+      if let existing = store[file] { return existing }
+      let created = Logging.Logger(label: Self.category(from: file))
+      store[file] = created
+      return created
+    }
+  }
+
+  private nonisolated static func category(from fileID: String) -> String {
+    let name = fileID.split(separator: "/").last.map(String.init) ?? fileID
+    return name.hasSuffix(".swift") ? String(name.dropLast(6)) : name
+  }
+
+  nonisolated func debug(_ msg: @autoclosure () -> String, file: String = #fileID, function: String = #function, line: UInt = #line) {
+    logger(for: file).debug("\(msg())", file: file, function: function, line: line)
+  }
+
+  nonisolated func info(_ msg: @autoclosure () -> String, file: String = #fileID, function: String = #function, line: UInt = #line) {
+    logger(for: file).info("\(msg())", file: file, function: function, line: line)
+  }
+
+  nonisolated func notice(_ msg: @autoclosure () -> String, file: String = #fileID, function: String = #function, line: UInt = #line) {
+    logger(for: file).notice("\(msg())", file: file, function: function, line: line)
+  }
+
+  nonisolated func warning(_ msg: @autoclosure () -> String, file: String = #fileID, function: String = #function, line: UInt = #line) {
+    logger(for: file).warning("\(msg())", file: file, function: function, line: line)
+  }
+
+  nonisolated func error(_ msg: @autoclosure () -> String, file: String = #fileID, function: String = #function, line: UInt = #line) {
+    logger(for: file).error("\(msg())", file: file, function: function, line: line)
+  }
+
+  nonisolated func critical(_ msg: @autoclosure () -> String, file: String = #fileID, function: String = #function, line: UInt = #line) {
+    logger(for: file).critical("\(msg())", file: file, function: function, line: line)
+  }
+}

--- a/client/ios/PastePoint/Views/Attachment/AttachmentMenuView.swift
+++ b/client/ios/PastePoint/Views/Attachment/AttachmentMenuView.swift
@@ -4,7 +4,6 @@
 //
 
 import AVFoundation
-import Logging
 import PhotosUI
 import SwiftUI
 import UIKit
@@ -13,7 +12,6 @@ import UIKit
 /// each routing through `FileStaging`. Callers supply the trigger label and an
 /// `onStaged` handler (stage into chips, or send to one member).
 struct AttachmentMenu<Content: View>: View {
-  private let logger = Logger(label: "AttachmentMenu")
 
   let onStaged: ([StagedFile]) async -> Void
   @ViewBuilder let content: Content
@@ -74,7 +72,7 @@ struct AttachmentMenu<Content: View>: View {
         Task { await onStaged(await FileStaging.stage(urls: urls)) }
       case .failure(let error):
         // TODO: surface a toast on failure.
-        logger.error("fileImporter failed: \(String(describing: error))")
+        log.error("fileImporter failed: \(String(describing: error))")
       }
     }
     .photosPicker(

--- a/client/ios/PastePoint/Views/Chat/Components/ChatInputBar.swift
+++ b/client/ios/PastePoint/Views/Chat/Components/ChatInputBar.swift
@@ -3,14 +3,12 @@
 //  SPDX-License-Identifier: GPL-3.0-only
 //
 
-import Logging
 import SwiftUI
 
 struct ChatInputBar: View {
   @Environment(\.layoutDirection) private var layoutDirection
   @EnvironmentObject private var toast: ToastCenter
 
-  private let logger = Logger(label: "ChatInputBar")
   let onSend: (String) -> Bool
   let onSendFiles: ([StagedFile]) -> Bool
   let hasConnectedPeers: Bool
@@ -50,7 +48,7 @@ struct ChatInputBar: View {
 
       HStack(alignment: .bottom, spacing: 8) {
 
-        // TODO: Show toast on picker/stage failure (see logger.error sites)
+        // TODO: Show toast on picker/stage failure (see log.error sites)
         AttachmentMenu { staged in
           let marked = staged.map { file -> StagedFile in
             var copy = file
@@ -143,20 +141,20 @@ struct ChatInputBar: View {
 
     if hasText {
       if onSend(trimmed) {
-        logger.info("send message successfully")
+        log.info("send message successfully")
         message = ""
       } else {
-        logger.error("send message failed")
+        log.error("send message failed")
       }
     }
 
     if hasFiles {
       if onSendFiles(stagedFiles) {
         // Ownership of tmp files transfers to FileUpload; do NOT delete here.
-        logger.info("send files successfully")
+        log.info("send files successfully")
         stagedFiles = []
       } else {
-        logger.error("send files failed")
+        log.error("send files failed")
       }
     }
   }

--- a/client/ios/PastePoint/Views/Settings/Sections/SettingsPrivateSessionSection.swift
+++ b/client/ios/PastePoint/Views/Settings/Sections/SettingsPrivateSessionSection.swift
@@ -110,16 +110,17 @@ struct SettingsPrivateSessionSection: View {
           isStarting = true
           do {
             log.info("Start private session button tapped")
+
             let code = try await services.sessionService.getNewSessionCode()
             await services.wsService.setupPrivateSession(code)
+
             isStarting = false
             guard await services.connectIfPermitted() else {
               toast.show(.error(.localNetworkOffStart))
               return
             }
+
             toast.show(.success(.privateSessionStarted))
-            await services.roomService.listRooms()
-            await services.userService.getUsername()
           } catch {
             isStarting = false
             log.error("Cannot get the session code \(error)")

--- a/client/ios/PastePoint/Views/Settings/Sections/SettingsPrivateSessionSection.swift
+++ b/client/ios/PastePoint/Views/Settings/Sections/SettingsPrivateSessionSection.swift
@@ -3,7 +3,6 @@
 //  SPDX-License-Identifier: GPL-3.0-only
 //
 
-import Logging
 import SwiftUI
 
 struct SettingsPrivateSessionSection: View {
@@ -14,7 +13,6 @@ struct SettingsPrivateSessionSection: View {
   @State private var isJoinPrivateSessionPresented: Bool = false
   @State private var isStarting: Bool = false
 
-  private let logger = Logger(label: "SettingsPrivateSessionSection")
   var onSessionJoin: (() -> Void)?
 
   var body: some View {
@@ -111,7 +109,7 @@ struct SettingsPrivateSessionSection: View {
         Task {
           isStarting = true
           do {
-            logger.info("Start private session button tapped")
+            log.info("Start private session button tapped")
             let code = try await services.sessionService.getNewSessionCode()
             await services.wsService.setupPrivateSession(code)
             isStarting = false
@@ -124,7 +122,7 @@ struct SettingsPrivateSessionSection: View {
             await services.userService.getUsername()
           } catch {
             isStarting = false
-            logger.error("Cannot get the session code \(error)")
+            log.error("Cannot get the session code \(error)")
             toast.show(.error(.startPrivateFailed))
           }
         }
@@ -159,7 +157,7 @@ struct SettingsPrivateSessionSection: View {
       .disabled(isStarting)
 
       Button {
-        logger.info("Join private session button tapped")
+        log.info("Join private session button tapped")
         isJoinPrivateSessionPresented = true
       } label: {
         HStack(spacing: 8) {

--- a/client/ios/PastePoint/Views/Settings/Sections/SettingsRoomsSection.swift
+++ b/client/ios/PastePoint/Views/Settings/Sections/SettingsRoomsSection.swift
@@ -3,15 +3,12 @@
 //  SPDX-License-Identifier: GPL-3.0-only
 //
 
-import Logging
 import SwiftUI
 
 struct SettingsRoomsSection: View {
   @Environment(\.layoutDirection) private var layoutDirection
   @EnvironmentObject private var services: AppServices
   @EnvironmentObject private var toast: ToastCenter
-
-  private let logger = Logger(label: "SettingsRoomsSection")
 
   var body: some View {
     VStack {
@@ -39,7 +36,7 @@ struct SettingsRoomsSection: View {
         HStack(alignment: .center, spacing: 0) {
           Button {
             Task {
-              logger.info("Joining room \(room)")
+              log.info("Joining room \(room)")
               await services.roomService.joinOrCreateRoom(room)
               toast.show(.info(.roomJoined(room)))
             }

--- a/client/ios/PastePoint/Views/Settings/SettingsView.swift
+++ b/client/ios/PastePoint/Views/Settings/SettingsView.swift
@@ -3,7 +3,6 @@
 //  SPDX-License-Identifier: GPL-3.0-only
 //
 
-import Logging
 import SwiftUI
 
 struct SettingsView: View {
@@ -11,7 +10,6 @@ struct SettingsView: View {
   @EnvironmentObject private var services: AppServices
   @EnvironmentObject private var toast: ToastCenter
 
-  private let logger = Logger(label: "SettingsView")
   var onClose: (() -> Void)?
   var onSessionJoin: (() -> Void)?
   var onBlock: ((String) -> Void)?
@@ -53,7 +51,7 @@ struct SettingsView: View {
           // MARK: - Create New Room Button
 
           Button {
-            logger.info("Create new room tapped")
+            log.info("Create new room tapped")
             isJoinRoomSheetPresented = true
           } label: {
             HStack(spacing: 8) {
@@ -158,13 +156,13 @@ struct SettingsView: View {
     }
     .sheet(isPresented: $isLeaveSessionSheetPresented) {
       SettingsLeaveSessionView {
-        logger.info("User left a private session")
+        log.info("User left a private session")
         toast.show(.info(.leftPrivateSession))
       }
     }
     .sheet(isPresented: $isJoinRoomSheetPresented) {
       SettingsCreateRoomView {
-        logger.info("User created a room")
+        log.info("User created a room")
         toast.show(.success(.roomCreated))
       }
     }

--- a/client/ios/PastePoint/Views/Settings/Sheets/SettingsCreateRoomView.swift
+++ b/client/ios/PastePoint/Views/Settings/Sheets/SettingsCreateRoomView.swift
@@ -3,14 +3,11 @@
 //  SPDX-License-Identifier: GPL-3.0-only
 //
 
-import Logging
 import SwiftUI
 
 struct SettingsCreateRoomView: View {
   @Environment(\.dismiss) private var dismiss
   @EnvironmentObject private var services: AppServices
-
-  private let logger = Logger(label: "SettingsCreateRoomView")
 
   var onRoomCreate: (() -> Void)?
 
@@ -35,10 +32,10 @@ struct SettingsCreateRoomView: View {
       // Buttons
       HStack(spacing: 12) {
         Button {
-          logger.info("User joining room with name: \(sanitizedRoomName)")
+          log.info("User joining room with name: \(sanitizedRoomName)")
           Task {
             await services.roomService.joinOrCreateRoom(sanitizedRoomName)
-            logger.info("Successfully joined room: \(sanitizedRoomName)")
+            log.info("Successfully joined room: \(sanitizedRoomName)")
             dismiss()
             onRoomCreate?()
           }
@@ -50,7 +47,7 @@ struct SettingsCreateRoomView: View {
         .opacity(sanitizedRoomName.isEmpty ? 0.6 : 1)
 
         Button {
-          logger.info("Dismiss join private session")
+          log.info("Dismiss join private session")
           dismiss()
         } label: {
           Text(.cancel)

--- a/client/ios/PastePoint/Views/Settings/Sheets/SettingsJoinPrivateView.swift
+++ b/client/ios/PastePoint/Views/Settings/Sheets/SettingsJoinPrivateView.swift
@@ -3,15 +3,12 @@
 //  SPDX-License-Identifier: GPL-3.0-only
 //
 
-import Logging
 import SwiftUI
 
 struct SettingsJoinPrivateView: View {
   @Environment(\.dismiss) private var dismiss
   @EnvironmentObject private var services: AppServices
   @EnvironmentObject private var toast: ToastCenter
-
-  private let logger = Logger(label: "SettingsJoinPrivateView")
 
   var onSessionJoin: (() -> Void)?
 
@@ -61,7 +58,7 @@ struct SettingsJoinPrivateView: View {
         .opacity(sessionCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? 0.6 : 1)
 
         Button {
-          logger.info("Dismiss join private session")
+          log.info("Dismiss join private session")
           dismiss()
         } label: {
           Text(.cancel)
@@ -84,11 +81,11 @@ struct SettingsJoinPrivateView: View {
     let trimmed = code.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return }
     guard SessionService.isValidSessionCode(trimmed) else {
-      logger.warning("Invalid session code entered: \(trimmed)")
+      log.warning("Invalid session code entered: \(trimmed)")
       toast.show(.error(.invalidSessionCode))
       return
     }
-    logger.info("Joining private session with code: \(trimmed)")
+    log.info("Joining private session with code: \(trimmed)")
     isJoining = true
     await services.wsService.setupPrivateSession(trimmed)
     guard await services.connectIfPermitted() else {

--- a/client/ios/PastePoint/Views/Settings/Sheets/SettingsJoinPrivateView.swift
+++ b/client/ios/PastePoint/Views/Settings/Sheets/SettingsJoinPrivateView.swift
@@ -80,26 +80,26 @@ struct SettingsJoinPrivateView: View {
   private func joinSession(code: String) async {
     let trimmed = code.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return }
+
     guard SessionService.isValidSessionCode(trimmed) else {
       log.warning("Invalid session code entered: \(trimmed)")
       toast.show(.error(.invalidSessionCode))
       return
     }
+
     log.info("Joining private session with code: \(trimmed)")
     isJoining = true
+
     await services.wsService.setupPrivateSession(trimmed)
     guard await services.connectIfPermitted() else {
       isJoining = false
       toast.show(.error(.localNetworkOffJoin))
       return
     }
+
     isJoining = false
     dismiss()
     onSessionJoin?()
-    Task {
-      await services.roomService.listRooms()
-      await services.userService.getUsername()
-    }
   }
 }
 

--- a/client/ios/PastePoint/Views/Settings/Sheets/SettingsLeaveSessionView.swift
+++ b/client/ios/PastePoint/Views/Settings/Sheets/SettingsLeaveSessionView.swift
@@ -3,14 +3,11 @@
 //  SPDX-License-Identifier: GPL-3.0-only
 //
 
-import Logging
 import SwiftUI
 
 struct SettingsLeaveSessionView: View {
   @Environment(\.dismiss) private var dismiss
   @EnvironmentObject private var services: AppServices
-
-  private let logger = Logger(label: "SettingsLeaveSessionView")
 
   var onSessionLeft: (() -> Void)?
 
@@ -42,7 +39,7 @@ struct SettingsLeaveSessionView: View {
         .disabled(isLeaving)
 
         Button {
-          logger.info("Dismiss Leave Session view")
+          log.info("Dismiss Leave Session view")
           dismiss()
         } label: {
           Text(.cancel)
@@ -56,7 +53,7 @@ struct SettingsLeaveSessionView: View {
   }
 
   private func leaveSession() async {
-    logger.info("User confirmed leaving private session")
+    log.info("User confirmed leaving private session")
     isLeaving = true
     services.wsService.disconnect(manual: true)
     if await services.connectIfPermitted(sessionCode: nil) {
@@ -64,7 +61,7 @@ struct SettingsLeaveSessionView: View {
       await services.userService.getUsername()
     }
     isLeaving = false
-    logger.info("Left private session")
+    log.info("Left private session")
     dismiss()
     onSessionLeft?()
   }

--- a/client/ios/PastePoint/Views/Settings/Sheets/SettingsLeaveSessionView.swift
+++ b/client/ios/PastePoint/Views/Settings/Sheets/SettingsLeaveSessionView.swift
@@ -55,11 +55,10 @@ struct SettingsLeaveSessionView: View {
   private func leaveSession() async {
     log.info("User confirmed leaving private session")
     isLeaving = true
+
     services.wsService.disconnect(manual: true)
-    if await services.connectIfPermitted(sessionCode: nil) {
-      await services.roomService.listRooms()
-      await services.userService.getUsername()
-    }
+    _ = await services.connectIfPermitted(sessionCode: nil)
+
     isLeaving = false
     log.info("Left private session")
     dismiss()

--- a/client/ios/PastePoint/Views/Settings/Sheets/SettingsQRCodeView.swift
+++ b/client/ios/PastePoint/Views/Settings/Sheets/SettingsQRCodeView.swift
@@ -4,7 +4,6 @@
 //
 
 import CoreImage.CIFilterBuiltins
-import Logging
 import SwiftUI
 
 struct QRCodeView: View {
@@ -47,8 +46,6 @@ struct SettingsQRCodeView: View {
   @Environment(\.dismiss) private var dismiss
   @EnvironmentObject private var services: AppServices
 
-  private let logger = Logger(label: "SettingsQRCodeView")
-
   var body: some View {
     VStack(spacing: 16) {
       QRCodeView(
@@ -70,7 +67,7 @@ struct SettingsQRCodeView: View {
         .padding(.horizontal)
     }
     .padding()
-    .onAppear { logger.info("QR code sheet presented for session: \(services.wsService.currentSessionCode ?? "none")") }
+    .onAppear { log.info("QR code sheet presented for session: \(services.wsService.currentSessionCode ?? "none")") }
     .sheetContainer(title: .qrCode, initialHeight: 420)
   }
 }

--- a/client/ios/PastePoint/Views/Settings/Sheets/SettingsScanQRCodeView.swift
+++ b/client/ios/PastePoint/Views/Settings/Sheets/SettingsScanQRCodeView.swift
@@ -4,7 +4,6 @@
 //
 
 import AVFoundation
-import Logging
 import SwiftUI
 import Vision
 import VisionKit
@@ -182,7 +181,6 @@ private struct ViewfinderBracketsShape: Shape {
 struct SettingsScanQRCodeView: View {
   @Environment(\.dismiss) private var dismiss
   @EnvironmentObject private var toast: ToastCenter
-  private let logger = Logger(label: "SettingsScanQRCodeView")
 
   private let cutoutSize: CGFloat = 240
   @State private var bracketScale: CGFloat = 1.0
@@ -232,12 +230,12 @@ struct SettingsScanQRCodeView: View {
       // Camera feed
       QRCodeScannerRepresentable { code in
         UINotificationFeedbackGenerator().notificationOccurred(.success)
-        logger.info("QR code scanned successfully")
+        log.info("QR code scanned successfully")
         onCodeScanned(code)
         dismiss()
       } onInvalidCodeScanned: {
         UINotificationFeedbackGenerator().notificationOccurred(.error)
-        logger.warning("Invalid QR code scanned")
+        log.warning("Invalid QR code scanned")
         toast.show(.error(.invalidQrCode))
       }
       .ignoresSafeArea()


### PR DESCRIPTION
### Summary

Simplify iOS logging with one concurrency-safe global helper and remove duplicate room and username requests during session transitions.

### What changed

#### Logging

- Add a global `AppLog` wrapper around Swift Logging
- Automatically derive log categories from the calling Swift filename
- Preserve source file, function, and line metadata
- Cache one logger per file behind an unfair lock
- Keep logging callable from MainActor and background contexts
- Remove repeated `Logger` properties and `Logging` imports across services and views
- Standardize call sites on `log.debug`, `log.info`, `log.warning`, and related methods

#### Session transitions

- Remove explicit room and username refreshes after reconnecting
- Rely on the existing `didConnect` subscriptions in `RoomService` and `UserService`
- Apply the cleanup to private-session creation, joining, leaving, and universal-link flows
- Eliminate duplicate `[SystemRooms]` and `[SystemName]` round trips