### PR TITLE
Docs: Add iOS client guide and refresh project documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,19 +118,37 @@ npm run test:ci    # Run tests
 
 ### iOS (SwiftUI)
 
-Requires macOS + Xcode. CI runs only on `client/ios/**` changes. Build and test with the standard `xcodebuild` scheme.
+Requires macOS Tahoe 26.2+ and Xcode **26.5** (see `client/ios/.xcode-version`). Deployment target iOS 17.6+, Swift 6 language mode.
+
+```bash
+cd client/ios
+swiftformat .          # Format code
+swiftlint --fix        # Autocorrect lint issues
+swiftlint lint --strict  # Lint code (CI runs this)
+xcodebuild test \
+  -project PastePoint.xcodeproj \
+  -scheme PastePoint \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro'  # Run tests
+```
 
 **Requirements:**
 
 - Follow Swift API design guidelines
 - Prefer `async/await` for concurrency
 - Keep UI logic in SwiftUI views and business logic in separate types
+- Match the CI-pinned tool versions — SwiftLint **0.65.0**, SwiftFormat **0.61.1** (see `.github/workflows/ios.yml`); CI asserts the exact versions
+- Localize user-facing strings in `Localizable.xcstrings` using the symbolic `UPPER_SNAKE_CASE` keys shared with the web client
+- Changes to the signaling, data-channel, or chunk protocol must stay wire-compatible with the web client — the two clients interoperate
+
+**Running against a server:** the app needs a signaling server to do anything useful. Start one with `make dev` (Docker stack, reachable on 443) or `cd server && cargo run` (standalone, port 9000), then point the `DEBUG` host and `wsPort` in `PastePoint/Core/Config/AppEnvironment.swift` at it. Those are local-only values — do not commit them.
+
+**Testing peer-to-peer flows** needs two peers: run two simulators, a simulator plus a device, or one simulator plus the web client in a browser. Web ↔ iOS is a valid pair, and it is the fastest way to catch a protocol regression.
 
 ### General Guidelines
 
 - **Files**: kebab-case (`user-service.ts`) in Web, snake_case (`user_name.rs`) in Server, PascalCase (`UserService.swift`) on iOS, PascalCase (`UserService.kt`) on Android.
 - **Variables**: camelCase (`userName`) in TypeScript, Swift, and Kotlin; snake_case (`user_name`) in Server
-- **Constants**: UPPER_SNAKE_CASE (`MAX_FILE_SIZE`)
+- **Constants**: UPPER_SNAKE_CASE in TypeScript, Rust, and Kotlin; lowerCamelCase in Swift
 - **Comments**: Explain "why", not "what"
 - **Error handling**: Always handle errors gracefully
 
@@ -142,6 +160,12 @@ cd client/web && npm run build:dev
 
 # Server build
 cd server && cargo build
+
+# iOS build
+cd client/ios && xcodebuild build \
+  -project PastePoint.xcodeproj \
+  -scheme PastePoint \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
 
 # Full stack via Docker Compose
 make dev

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 <br>
 <br>
 
-![Docker](https://img.shields.io/badge/Docker-Containers-blue) ![Rust](https://img.shields.io/badge/Rust-Backend-orange) ![Angular](https://img.shields.io/badge/Angular-Frontend-red) [![Nginx](https://img.shields.io/badge/Nginx-Reverse_Proxy-green)](https://nginx.org)
+![Docker](https://img.shields.io/badge/Docker-Containers-blue) ![Rust](https://img.shields.io/badge/Rust-Backend-orange) ![Angular](https://img.shields.io/badge/Angular-Frontend-red) [![iOS](https://img.shields.io/badge/iOS-17.6%2B-black)](https://developer.apple.com/ios/) [![Nginx](https://img.shields.io/badge/Nginx-Reverse_Proxy-green)](https://nginx.org)
 
 </div>
 
 # PastePoint
 
-PastePoint is a secure, feature-rich file-sharing service designed for local networks. It enables users to share files and communicate efficiently through peer-to-peer WebRTC connections. Built with a Rust-based backend using Actix Web and an Angular 21 frontend with SSR support, PastePoint prioritizes security, performance, and usability.
+PastePoint is a secure, feature-rich file-sharing service designed for local networks. It enables users to share files and communicate efficiently through peer-to-peer WebRTC connections. It combines a Rust signaling server, an Angular 21 web client with SSR, and a native SwiftUI iOS client.
 
 ## Usage Disclaimer
 
@@ -87,12 +87,26 @@ PastePoint is a secure, feature-rich file-sharing service designed for local net
 - **Rendering**: Server-Side Rendering with Angular SSR
 - **State Management**: RxJS observables
 - **Styling**: Tailwind CSS with dark mode
-- **I18n**: ngx-translate integration (English, Arabic with RTL)
+- **I18n**: ngx-translate integration (English, Arabic with RTL, Spanish, French, Russian, Simplified Chinese)
 - **WebRTC**: Native WebRTC API for file transfers
 - **QR Sharing**: `qrcode` for generation, `jsqr` for camera-based scanning
 - **Integrity**: `hash-wasm` for fast file hashing
 - **Notifications**: Hot-toast for real-time feedback
 - **Error Tracking**: `@sentry/angular` with privacy-tight redaction
+
+#### iOS (SwiftUI)
+
+[![Swift](https://img.shields.io/badge/Swift-6.0-orange)](https://swift.org/)
+[![iOS](https://img.shields.io/badge/iOS-17.6%2B-black)](https://developer.apple.com/ios/)
+[![WebRTC](https://img.shields.io/badge/WebRTC-147.0-green)](https://github.com/stasel/WebRTC)
+
+- **UI**: Native SwiftUI for iPhone and iPad
+- **Concurrency**: Swift 6 strict concurrency
+- **WebRTC**: `stasel/WebRTC` binary distribution, same mesh protocol as the web client
+- **I18n**: String Catalogs (English, Arabic with RTL, Spanish, French, Russian, Simplified Chinese)
+- **QR Sharing**: AVFoundation scanning, Core Image generation
+- **Universal Links**: Invite URLs open the app when installed
+- **Integrity**: BLAKE3 file hashing with per-chunk CRC32
 
 ### Infrastructure
 
@@ -112,7 +126,7 @@ PastePoint is a secure, feature-rich file-sharing service designed for local net
 pastepoint/
 ├── client/                         # Frontend clients
 │   ├── web/                        # Angular SSR frontend
-│   └── ios/                        # iOS client (WIP)
+│   └── ios/                        # SwiftUI iOS client
 ├── server/                         # Rust backend with WebSockets
 ├── nginx/                          # Reverse proxy & SSL termination
 ├── scripts/                        # Development & deployment scripts
@@ -133,9 +147,9 @@ pastepoint/
 
 - [Web readme](client/web/README.md)
 
-##### iOS:
+##### iOS (SwiftUI):
 
-- Work in progress
+- [iOS readme](client/ios/README.md)
 
 ##### Android:
 
@@ -233,8 +247,10 @@ pastepoint/
      - Localhost: [https://localhost](https://localhost)
      - Local Network: `https://<your-local-ip>`
    - WebSocket signaling:
-     - Localhost: `wss://localhost:9000/ws`
-     - Local Network: `wss://<your-local-ip>:9000/ws`
+     - Localhost: `wss://localhost/ws`
+     - Local Network: `wss://<your-local-ip>/ws`
+
+   A standalone `cargo run` server uses port 9000 instead of nginx on 443.
 
 ## Contributing
 

--- a/client/ios/PastePoint/Core/Models/FileTransfer/FileTransfer.swift
+++ b/client/ios/PastePoint/Core/Models/FileTransfer/FileTransfer.swift
@@ -45,7 +45,7 @@ enum FileTransferStatus: String, Codable, Sendable {
 }
 
 enum FileTransferFailureReason: Sendable {
-  case integrity // SHA-256 / CRC mismatch
+  case integrity // BLAKE3 / CRC mismatch
   case assembly // couldn't read/write chunks to disk
   case noHash // receiver: sender sent no hash -> reject (verify is mandatory)
   case sendHashFailed // sender: couldn't hash the file -> send aborted

--- a/client/ios/README.md
+++ b/client/ios/README.md
@@ -77,7 +77,7 @@ ios/
 - **macOS**: Tahoe 26.2 or later
 - **Xcode**: 26.5 (specified in `.xcode-version`)
 - **iOS Deployment Target**: 17.6+ (iPhone and iPad)
-- **Backend**: A running PastePoint server (see the [server readme](../../server/README.md) or `make dev` at the repo root)
+- **Backend**: A running PastePoint server (see the [server readme](../../server/README.md) or `make dev` at the repository root)
 
 ### Development Setup
 
@@ -156,7 +156,7 @@ It derives the app's endpoints and local-network probe settings from those two v
 
 > **Note:** `wsPort` selects how the server is reached in development. Use `9000` for a standalone `cargo run` server, and `nil` when running the Docker stack, where only nginx is published on 443. Host and port changes are local-only — do not commit them.
 
-To test against a server on your LAN, replace the `DEBUG` host with your machine's IP. `scripts/configure-network.sh` at the repo root can update it automatically.
+To test against a server on your LAN, replace the `DEBUG` host with your machine's IP. `scripts/configure-network.sh` at the repository root can update it automatically.
 
 ### Entitlements and Permissions
 
@@ -265,7 +265,7 @@ String(localized: .joinRoom)  // for TextField placeholders
 - **Naming**: standalone screens end in `…View`, embedded sub-sections end in `…Section`
 - **Shared components**: reuse `Views/Components/` (`.pill` buttons, `.sheetContainer`, `LabeledInputField`, `StatusBanner`) rather than re-inlining markup
 - **Logging**: `os.Logger` with subsystem `com.pastepoint`; log messages stay in English
-- **Commits**: `iOS:` + imperative subject, `-` bullet body explaining what and why (see the [git history](../../CONTRIBUTING.md))
+- **Commits**: `iOS:` + imperative subject, `-` bullet body explaining what and why (see the [Git history](../../CONTRIBUTING.md))
 
 ### Debug Logging
 

--- a/client/ios/README.md
+++ b/client/ios/README.md
@@ -1,0 +1,327 @@
+# PastePoint Client (iOS)
+
+The PastePoint iOS client is a native SwiftUI application for peer-to-peer file sharing and real-time chat over local networks. Features WebRTC mesh connections, chunked file transfer with integrity verification, QR-based private sessions, and full localization.
+
+[![Swift](https://img.shields.io/badge/Swift-6.0-orange)](https://swift.org/)
+[![iOS](https://img.shields.io/badge/iOS-17.6%2B-black)](https://developer.apple.com/ios/)
+[![Xcode](https://img.shields.io/badge/Xcode-26.5-blue)](https://developer.apple.com/xcode/)
+[![WebRTC](https://img.shields.io/badge/WebRTC-147.0-green)](https://github.com/stasel/WebRTC)
+
+## Tech Stack
+
+### Core Features
+
+- **UI**: SwiftUI with a `NavigationStack` toolbar chat shell, iPad docked settings panel, and Liquid Glass toolbar items on iOS 26
+- **WebRTC**: [`stasel/WebRTC`](https://github.com/stasel/WebRTC) binary distribution for peer-to-peer data channels
+- **Concurrency**: Swift 6 strict concurrency — services are `@MainActor`, WebRTC delegates are `nonisolated`
+- **Transport**: `URLSessionWebSocketTask` for signaling, WebRTC data channels for chat and file payloads
+- **File Integrity**: BLAKE3-256 whole-file hashing (via the [`BlakeHash`](https://github.com/trancee/blake-hash) package) plus per-chunk CRC32, byte-identical to the web chunk protocol
+- **Previews**: ImageIO/PDFKit thumbnail generation for file offers (`PreviewGenerator`)
+- **QR Sharing**: AVFoundation camera scanning, Core Image generation for private-session invites
+- **Universal Links**: `applinks:pastepoint.com` — invite URLs open the app when installed
+- **I18n**: String Catalogs (English, Arabic (RTL), Spanish, French, Russian, Simplified Chinese)
+- **Logging**: [`swift-log`](https://github.com/apple/swift-log) bridged to `os.Logger` under subsystem `com.pastepoint`
+
+### Development Tools
+
+- **Build Tool**: Xcode 26.5 (pinned in `.xcode-version`), synchronized folder groups
+- **Dependencies**: Swift Package Manager (pinned in `Package.resolved`)
+- **Testing**: XCTest via the `PastePointTests.xctestplan` test plan
+- **Linting**: SwiftLint 0.65.0 (`.swiftlint.yml`, `--strict` in CI)
+- **Formatting**: SwiftFormat 0.61.1 (`.swiftformat`, Swift 6 language mode)
+
+## Project Structure
+
+```
+ios/
+├── PastePoint/
+│   ├── App/                        # App entry point and root composition
+│   ├── Core/
+│   │   ├── Config/                 # Environment and networking config
+│   │   ├── Legal/                  # Consent storage
+│   │   ├── Models/                 # Chat, signaling, and transfer models
+│   │   ├── Permissions/            # Camera and Local Network helpers
+│   │   ├── Services/               # App, transport, room, and transfer logic
+│   │   └── Utils/                  # Logging, colors, avatars, and toasts
+│   ├── Views/
+│   │   ├── Chat/                   # Chat screen and components
+│   │   ├── Settings/               # Settings sections and sheets
+│   │   ├── Components/             # Shared UI components
+│   │   ├── Attachment/             # File, photo, and camera pickers
+│   │   ├── Welcome/                # Onboarding
+│   │   ├── Splash/                 # Animated launch handoff
+│   │   ├── Legal/                  # EULA gate
+│   │   ├── Moderation/             # Reporting UI
+│   │   └── Update/                 # Version gate
+│   └── Resources/
+│       ├── Assets.xcassets         # Colors, icons, avatars, and app icon
+│       ├── Fonts/                  # Expo Arabic family
+│       ├── Localization/           # String Catalogs
+│       ├── Info.plist              # Permissions and app metadata
+│       └── PastePoint.entitlements # Associated domains
+├── PastePointTests/                # Unit tests
+├── PastePointUITests/              # UI tests
+├── PastePoint.xcodeproj            # Xcode project
+├── .swiftlint.yml                  # SwiftLint configuration
+├── .swiftformat                    # SwiftFormat configuration
+├── .xcode-version                  # Pinned Xcode version
+└── README.md
+```
+
+> **Note:** The project uses Xcode **synchronized groups** — the folder structure *is* the group structure. Moving files with `git mv` is safe and requires no `.pbxproj` edits.
+
+## Quick Start
+
+### Prerequisites
+
+- **macOS**: Tahoe 26.2 or later
+- **Xcode**: 26.5 (specified in `.xcode-version`)
+- **iOS Deployment Target**: 17.6+ (iPhone and iPad)
+- **Backend**: A running PastePoint server (see the [server readme](../../server/README.md) or `make dev` at the repo root)
+
+### Development Setup
+
+1. **Open the project**:
+
+   ```bash
+   open client/ios/PastePoint.xcodeproj
+   ```
+
+2. **Resolve dependencies**:
+
+   Xcode resolves Swift packages automatically on first open. To do it from the command line:
+
+   ```bash
+   cd client/ios
+   xcodebuild -resolvePackageDependencies -project PastePoint.xcodeproj -scheme PastePoint
+   ```
+
+3. **Point the app at your server**:
+
+   Edit the `DEBUG` host in `PastePoint/Core/Config/AppEnvironment.swift` (see [Configuration](#configuration)).
+
+4. **Build and run** with ⌘R against a simulator or a connected device.
+
+### Command Line
+
+```bash
+cd client/ios
+
+# Build for the simulator
+xcodebuild build \
+  -project PastePoint.xcodeproj \
+  -scheme PastePoint \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+
+# Run tests
+xcodebuild test \
+  -project PastePoint.xcodeproj \
+  -scheme PastePoint \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+
+# Lint and format
+swiftlint lint --strict
+swiftformat --lint .
+```
+
+## Configuration
+
+### AppEnvironment
+
+All hosts and endpoints live in `PastePoint/Core/Config/AppEnvironment.swift`, split by build configuration:
+
+```swift
+#if DEBUG
+  private static let host = "127.0.0.1"
+  private static let wsPort: Int? = 9000
+#else
+  private static let host = "pastepoint.com"
+  private static let wsPort: Int? = nil
+#endif
+```
+
+It derives the app's endpoints and local-network probe settings from those two values:
+
+| Property                | Purpose                                      |
+| ----------------------- | -------------------------------------------- |
+| `webSocketUrl(_:)`      | Signaling WebSocket (`wss://…/ws[/code]`)    |
+| `createSessionUrl`      | Private session creation                     |
+| `versionUrl`            | Launch-time update policy check              |
+| `turnCredentialsUrl`    | Short-lived TURN relay credentials           |
+| `privateSessionUrl(_:)` | QR/invite universal link                     |
+| `legalUrl`              | Privacy and terms pages                      |
+| `localNetworkProbeHost` | Local Network permission probe host          |
+| `localNetworkProbePort` | Local Network permission probe port          |
+| `supportEmail`          | Destination for content reports              |
+
+> **Note:** `wsPort` selects how the server is reached in development. Use `9000` for a standalone `cargo run` server, and `nil` when running the Docker stack, where only nginx is published on 443. Host and port changes are local-only — do not commit them.
+
+To test against a server on your LAN, replace the `DEBUG` host with your machine's IP. `scripts/configure-network.sh` at the repo root can update it automatically.
+
+### Entitlements and Permissions
+
+- `PastePoint.entitlements`: `applinks:pastepoint.com` for universal links
+- `NSLocalNetworkUsageDescription` + `NSBonjourServices` (`_pastepoint._tcp`): prompted once on first launch
+- `NSCameraUsageDescription`: QR scanning and photo/video capture
+- `NSMicrophoneUsageDescription`: recording audio with captured video
+- `NSPhotoLibraryAddUsageDescription`: saving received media
+
+Dev builds point at a LAN IP, so universal links only resolve against the production domain.
+
+## Testing
+
+Tests run through the `PastePointTests.xctestplan` test plan (unit tests enabled, UI tests disabled by default).
+
+```bash
+# All tests
+xcodebuild test -project PastePoint.xcodeproj -scheme PastePoint \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+
+# Single test
+xcodebuild test -project PastePoint.xcodeproj -scheme PastePoint \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -only-testing:PastePointTests/PastePointTests/testExample
+```
+
+### Two-device testing
+
+Peer-to-peer flows need two peers. Run two simulators or a simulator plus a device against the same server.
+
+### Linting and Formatting
+
+```bash
+swiftlint lint --strict     # CI runs this
+swiftlint --fix             # Autocorrect
+swiftformat .               # Format in place
+swiftformat --lint .        # Check only (CI)
+```
+
+CI pins both tools (see `.github/workflows/ios.yml`); keep local versions in lockstep with `SWIFTLINT_VERSION` and `SWIFTFORMAT_VERSION`.
+
+## Architecture
+
+Mesh topology — one `RTCPeerConnection` per remote peer, no SFU. The signaling server relays messages without inspecting SDP or ICE content.
+
+```
+UI (SwiftUI Views)
+  ↓
+Orchestration  ← SignalingService
+  ↓
+Signaling      ← SDP/ICE exchange, glare resolution, reconnect
+Data Channels  ← RTCDataChannelDelegate
+  ↓
+Transport      ← WebSocketConnectionService
+Room State     ← RoomService + PeerDirectory
+```
+
+Key protocol invariants:
+
+- **Role decision**: the lexicographically smaller username is the caller (plain `<` byte comparison)
+- **Sequence counters**: per-peer, monotonic, with separate inbound and outbound maps
+- **Data channel**: label `"data"`, `ordered: true`
+- **Back-pressure**: gates binary chunks only, never control messages
+- **Ephemeral identity**: the server assigns a fresh random username on every connection — there is no persisted client identity
+
+Any change touching `SignalingService`, `BinaryChunk`, `DataChannelMessage`, or `WebRTCConfig` must preserve wire compatibility with existing peers.
+
+## Internationalization (i18n)
+
+### Supported Languages
+
+- English (default)
+- Arabic (RTL)
+- Spanish
+- French
+- Russian
+- Simplified Chinese
+
+### String Catalogs
+
+```
+PastePoint/Resources/Localization/
+├── Localizable.xcstrings    # UI strings
+└── InfoPlist.xcstrings      # Permission usage descriptions
+```
+
+Keys use symbolic `UPPER_SNAKE_CASE` names so Xcode can generate consistent Swift symbols.
+
+### Usage
+
+Entries are marked `manual`, so Xcode generates `LocalizedStringResource` symbols (`UPPER_SNAKE_CASE` → `lowerCamelCase`):
+
+```swift
+Text(.privateRoom)         // no-arg key -> static var
+Text(.roomsCount(count))   // format key -> static func
+String(localized: .joinRoom)  // for TextField placeholders
+```
+
+> **Note:** Generated symbols only exist after a build — SourceKit reports false "no member" errors on newly added keys until then.
+
+## Development Guide
+
+### Code Standards
+
+- **Swift 6**: strict concurrency, language mode 6
+- **Naming**: standalone screens end in `…View`, embedded sub-sections end in `…Section`
+- **Shared components**: reuse `Views/Components/` (`.pill` buttons, `.sheetContainer`, `LabeledInputField`, `StatusBanner`) rather than re-inlining markup
+- **Logging**: `os.Logger` with subsystem `com.pastepoint`; log messages stay in English
+- **Commits**: `iOS:` + imperative subject, `-` bullet body explaining what and why (see the [git history](../../CONTRIBUTING.md))
+
+### Debug Logging
+
+The simulator has a known bug (FB5342358) where debug-level messages do not appear in Console.app. Stream them from the terminal instead:
+
+```bash
+xcrun simctl spawn <UDID> log stream --level debug \
+  --predicate 'subsystem == "com.pastepoint"'
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Cannot connect to the server**:
+   - Verify the host and `wsPort` in `AppEnvironment.swift` match how the server is running (standalone `cargo run` uses `:9000`; the Docker stack publishes only nginx on 443)
+   - Self-signed development certificates are accepted through `InsecureSession` in `DEBUG` builds only
+   - On a device, confirm the Local Network permission prompt was accepted
+
+2. **Peers never connect**:
+   - Both clients must reach the same signaling server
+   - Check for phantom members after a network drop — stale sessions are reaped by the server heartbeat within ~20s
+
+3. **"No member" errors on localization symbols**:
+
+   ```bash
+   # Symbols are generated at build time
+   xcodebuild build -project PastePoint.xcodeproj -scheme PastePoint \
+     -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+   ```
+
+4. **Swift package resolution failures**:
+
+   ```bash
+   rm -rf ~/Library/Caches/org.swift.swiftpm
+   xcodebuild -resolvePackageDependencies -project PastePoint.xcodeproj -scheme PastePoint
+   ```
+
+5. **Build succeeds locally but fails CI lint**:
+
+   ```bash
+   # Match the pinned CI versions
+   swiftlint version      # expect 0.65.0
+   swiftformat --version  # expect 0.61.1
+   ```
+
+## Contributing
+
+- [Contributing](../../CONTRIBUTING.md)
+
+## License
+
+This project is licensed under the GPL-3.0 License. See the [LICENSE](../../LICENSE) file for details.
+
+## Related Documentation
+
+- [Main project readme](../../README.md)
+- [Server readme](../../server/README.md)
+- [Docker Compose setup](../../docker-compose.yml)

--- a/client/web/README.md
+++ b/client/web/README.md
@@ -34,54 +34,35 @@ web/
 ├── src/
 │   ├── app/
 │   │   ├── core/
-│   │   │   ├── i18n/           # Internationalization
-│   │   │   ├── components/     # Reusable layout & cross-cutting UI
-│   │   │   ├── services/       # Core services
-│   │   │   │   ├── communication/    # WebRTC, WebSocket, Chat
-│   │   │   │   ├── file-management/  # File transfer services
-│   │   │   │   ├── room-management/  # Room/session join, list, create
-│   │   │   │   ├── session/          # Session lifecycle & QR sharing
-│   │   │   │   ├── user-management/  # User identity & presence
-│   │   │   │   ├── ui/               # Theme, Language services
-│   │   │   │   ├── monitoring/       # Error tracking (Sentry)
-│   │   │   │   └── migration/        # App migration
-│   │   │   └── interfaces/     # TypeScript interfaces
-│   │   ├── features/           # Features such as chat, file sharing, etc.
-│   │   ├── utils/              # Utility functions
+│   │   │   ├── components/     # Shared layout and UI
+│   │   │   ├── i18n/           # Localization
+│   │   │   ├── interfaces/     # Shared types
+│   │   │   └── services/       # Communication, files, rooms, and UI
+│   │   ├── features/           # Feature UI and flows
 │   │   ├── testing/            # Test utilities
-│   │   ├── app.component.*        # Root component
-│   │   ├── app.routes.ts          # Application routes
-│   │   └── app.config.*           # App configuration
-│   ├── environments/           # Environment configs
-│   ├── index.html                 # Main HTML file
-│   ├── main.ts                    # Application entry point
-│   ├── server.ts                  # SSR server
-│   └── styles.css                 # Global styles
-├── public/                     # Static assets
-│   ├── assets/                 # Assets
-│   │   ├── favicon.*              # Favicon files
-│   │   ├── pastepoint-*.svg       # Logo files
-│   │   └── *.png                  # App icons
+│   │   └── utils/              # Shared helpers and constants
+│   ├── environments/           # Build-specific configuration
+│   ├── main.ts                 # Browser entry point
+│   ├── server.ts               # SSR entry point
+│   └── styles.css              # Global styles
+├── public/
+│   ├── assets/                 # Logos and app icons
 │   ├── fonts/                  # Custom fonts
-│   ├── icons/                  # SVG icons
-│   └── site.webmanifest           # Web app manifest
-├── dist/                       # Build output
-├── node_modules/               # Dependencies
-├── package.json                   # Project dependencies
-├── angular.json                   # Angular CLI config
-├── tailwind.config.js             # Tailwind CSS config
-├── tsconfig.json                  # TypeScript config
-├── Dockerfile                     # Docker configuration
-└── README.md                      # Project documentation
+│   └── icons/                  # SVG icons
+├── angular.json                # Angular workspace configuration
+├── package.json                # Scripts and dependencies
+├── tailwind.config.js          # Tailwind configuration
+├── tsconfig.json               # TypeScript configuration
+├── Dockerfile                  # Container build
+└── README.md
 ```
 
 ## Quick Start
 
 ### Prerequisites
 
-- **Node.js**: v24.16.0 (specified in `../.nvmrc`)
+- **Node.js**: v24.16.0 (specified in `../../.nvmrc`)
 - **npm**: Latest version
-- **Angular CLI**: `npm install -g @angular/cli`
 
 ### Development Setup
 
@@ -94,17 +75,23 @@ web/
 2. **Install dependencies**:
 
    ```bash
-   npm install
+   npm ci
    ```
 
-3. **Start development server**:
+3. **Generate the development certificate**:
 
    ```bash
-   ng serve
+   ../../scripts/generate-certs.sh
    ```
 
-4. **Open browser**:
-   Navigate to `http://localhost:4200`
+4. **Start the development server**:
+
+   ```bash
+   npm start
+   ```
+
+5. **Open the browser**:
+   Navigate to `https://localhost`.
 
 ### Available Scripts
 
@@ -136,7 +123,8 @@ Example environment configuration:
 ```typescript
 export const environment = {
   production: false,
-  apiUrl: 'https://localhost:9000',
+  apiUrl: '127.0.0.1:9000',
+  webUrl: '127.0.0.1',
   logLevel: NgxLoggerLevel.DEBUG,
   enableSourceMaps: true,
   disableFileDetails: false,
@@ -145,7 +133,7 @@ export const environment = {
     enabled: false,
     dsn: '',
     environment: 'development',
-    tracesSampleRate: 0.1,
+    tracesSampleRate: 0.25,
     enableLogs: true,
   },
 };
@@ -297,5 +285,6 @@ This project is licensed under the GPL-3.0 License. See the [LICENSE](../../LICE
 ## Related Documentation
 
 - [Main project readme](../../README.md)
+- [iOS client readme](../ios/README.md)
 - [Server readme](../../server/README.md)
 - [Docker Compose setup](../../docker-compose.yml)

--- a/server/README.md
+++ b/server/README.md
@@ -1,6 +1,6 @@
 # PastePoint Server (Rust Backend)
 
-The PastePoint server is a high-performance Rust-based backend built with Actix Web, providing WebSocket-based file sharing and communication services for local networks. Features comprehensive session management, WebRTC signaling, and secure file transfer capabilities.
+The PastePoint server is a Rust signaling backend built with Actix Web. It manages rooms and ephemeral identities, issues TURN credentials, and relays WebRTC signaling without handling file payloads.
 
 [![Actix](https://img.shields.io/badge/Actix-4.13-blue)](https://actix.rs/)
 [![OpenSSL](https://img.shields.io/badge/OpenSSL-0.10-yellow)](https://www.openssl.org/)
@@ -53,21 +53,22 @@ server/
    cd server
    ```
 
-2. **Install dependencies**:
+2. **Generate the development certificate**:
+
+   ```bash
+   ../scripts/generate-certs.sh
+   ```
+
+3. **Build the server**:
 
    ```bash
    cargo build
    ```
 
-3. **Run development server**:
+4. **Run the development server**:
 
    ```bash
    cargo run
-   ```
-
-4. **Run with a specific configuration**:
-   ```bash
-   RUN_ENV=docker-dev cargo run
    ```
 
 ## Configuration
@@ -80,7 +81,8 @@ server/
 
 The active config is selected via the `RUN_ENV` environment variable (e.g.
 `RUN_ENV=development`, `production`, or `docker-dev`), defaulting to the
-development configuration when unset.
+development configuration when unset. The `docker-dev` configuration is used
+inside Docker Compose and expects container certificate paths.
 
 ## Testing
 
@@ -127,7 +129,7 @@ cargo build --release
 - **CORS**: Configurable Cross-Origin Resource Sharing
 - **Input Validation**: Comprehensive input validation and sanitization
 - **Session Management**: Secure UUID-based session handling
-- **WebSocket Security**: Secure WebSocket connections with proper authentication
+- **WebSocket Security**: TLS, origin validation, and room-scoped signaling relay
 
 ## Troubleshooting
 
@@ -174,5 +176,6 @@ This project is licensed under the GPL-3.0 License. See the [LICENSE](../LICENSE
 ## Related Documentation
 
 - [Main project readme](../README.md)
-- [Client readme](../client/web/README.md)
+- [Web client readme](../client/web/README.md)
+- [iOS client readme](../client/ios/README.md)
 - [Docker Compose setup](../docker-compose.yml)


### PR DESCRIPTION
### Summary

Document the native iOS client and update the project, web, server, and contribution guides to match PastePoint’s current cross-platform architecture and development workflow.

### What changed

#### iOS documentation

- Add a complete iOS client README
- Document the SwiftUI architecture and project structure
- Add setup, configuration, build, test, lint, and formatting instructions
- Explain two-device and web-to-iOS interoperability testing
- Document localization, permissions, entitlements, logging, and troubleshooting
- Record the required Xcode, SwiftLint, and SwiftFormat versions

#### Project documentation

- Present iOS as a supported client instead of work in progress
- Add the iOS stack, feature overview, badge, and documentation links
- Expand supported-language lists across client documentation
- Correct nginx and standalone WebSocket URLs
- Explain that web and iOS share the same wire protocol

#### Web and server guides

- Refresh the Angular project structure and setup steps
- Correct environment examples, paths, certificates, and local URLs
- Describe the server accurately as a signaling and TURN credential backend
- Clarify certificate generation, configuration selection, and security behavior
- Cross-link the server, web, and iOS documentation

#### Contributing guide

- Add iOS build, test, lint, and formatting commands
- Document Swift naming and localization conventions
- Require protocol changes to remain compatible across both clients
- Explain how to run the app against Docker or a standalone server

### Maintenance

- Correct a stale SHA-256 comment to reference the current BLAKE3 integrity hash