### PR TITLE
iOS: Fix toasts not dismissing on tap

### DIFF
--- a/client/ios/PastePoint/Core/Utils/Toast/Toast.swift
+++ b/client/ios/PastePoint/Core/Utils/Toast/Toast.swift
@@ -107,6 +107,8 @@ private struct ToastRowView: View {
 struct ToastOverlayView: View {
   @ObservedObject var center: ToastCenter
 
+  var onFrameChange: (CGRect) -> Void = { _ in }
+
   var body: some View {
     VStack(spacing: 8) {
       ForEach(center.items) { item in
@@ -120,10 +122,9 @@ struct ToastOverlayView: View {
           removal: .move(edge: .top).combined(with: .opacity),
         ))
       }
-
-      Spacer(minLength: 0)
     }
     .padding(.horizontal, 20)
+    .onGeometryChange(for: CGRect.self) { $0.frame(in: .global) } action: { onFrameChange($0) }
     .padding(.top, 8)
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     .animation(.spring(response: 0.4), value: center.items)

--- a/client/ios/PastePoint/Core/Utils/Toast/ToastWindow.swift
+++ b/client/ios/PastePoint/Core/Utils/Toast/ToastWindow.swift
@@ -11,10 +11,11 @@ import UIKit
 /// A transparent window that sits above the sheet/alert layer and lets touches
 /// fall through to the app below — except where they land on a toast row.
 final class PassthroughWindow: UIWindow {
+  var interactiveRect: CGRect = .zero
+
   override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-    guard let hit = super.hitTest(point, with: event) else { return nil }
-    // Empty areas resolve to the hosting controller's root view → pass through.
-    return hit === rootViewController?.view ? nil : hit
+    guard interactiveRect.contains(point) else { return nil }
+    return super.hitTest(point, with: event)
   }
 }
 
@@ -28,10 +29,14 @@ final class ToastPresenter {
   func install(in scene: UIWindowScene, center: ToastCenter) {
     guard window == nil else { return }
 
-    let host = UIHostingController(rootView: ToastOverlayView(center: center))
+    let window = PassthroughWindow(windowScene: scene)
+    let host = UIHostingController(
+      rootView: ToastOverlayView(center: center) { [weak window] rect in
+        window?.interactiveRect = rect
+      },
+    )
     host.view.backgroundColor = .clear
 
-    let window = PassthroughWindow(windowScene: scene)
     window.rootViewController = host
     window.windowLevel = .alert + 1
     window.isHidden = false


### PR DESCRIPTION
- Hit-test `PassthroughWindow` against an `interactiveRect` reported by `ToastOverlayView` instead of comparing the hit against `rootViewController.view`

- SwiftUI renders every row into the hosting view itself, so the identity check matched taps on a toast too and passed every touch through to the app below