### PR TITLE
Web: Recover connections after mobile browser suspension

### DIFF
--- a/client/web/src/app/core/services/communication/heartbeat.service.ts
+++ b/client/web/src/app/core/services/communication/heartbeat.service.ts
@@ -17,6 +17,9 @@ export class HeartbeatService implements OnDestroy {
 
   private intervalId: ReturnType<typeof setInterval> | null = null;
   private lastHeartbeat: number = Date.now();
+  private hiddenAt: number | null = null;
+  private heartbeatTimeout = 0;
+  private visibilityChangeListener: (() => void) | null = null;
 
   /** Emits when a suspension is detected (interval missed by more than the timeout) */
   readonly suspended$ = new Subject<{ secondsSinceLastBeat: number }>();
@@ -31,6 +34,7 @@ export class HeartbeatService implements OnDestroy {
     const heartbeatTimeout = isDesktop
       ? HEARTBEAT_TIMEOUT_DESKTOP_SEC
       : HEARTBEAT_TIMEOUT_MOBILE_SEC;
+    this.heartbeatTimeout = heartbeatTimeout;
 
     this.logger.debug(
       'HeartbeatService.start',
@@ -38,6 +42,7 @@ export class HeartbeatService implements OnDestroy {
     );
 
     this.lastHeartbeat = Date.now();
+    this.setupVisibilityMonitor();
 
     this.intervalId = setInterval(() => {
       const now = Date.now();
@@ -51,12 +56,46 @@ export class HeartbeatService implements OnDestroy {
     }, heartbeatInterval * 1000);
   }
 
+  private setupVisibilityMonitor(): void {
+    if (typeof document === 'undefined') return;
+
+    this.visibilityChangeListener = () => {
+      if (document.visibilityState === 'hidden') {
+        this.hiddenAt = Date.now();
+        return;
+      }
+
+      if (document.visibilityState !== 'visible' || this.hiddenAt === null) return;
+
+      const now = Date.now();
+      const secondsInBackground = (now - this.hiddenAt) / 1000;
+      this.hiddenAt = null;
+      this.lastHeartbeat = now;
+
+      if (secondsInBackground > this.heartbeatTimeout) {
+        this.logger.warn(
+          'HeartbeatService',
+          `Suspension detected on resume: backgrounded for ${secondsInBackground}s`
+        );
+        this.suspended$.next({ secondsSinceLastBeat: secondsInBackground });
+      }
+    };
+
+    document.addEventListener('visibilitychange', this.visibilityChangeListener);
+  }
+
   stop(): void {
     if (this.intervalId) {
       clearInterval(this.intervalId);
       this.intervalId = null;
       this.logger.debug('HeartbeatService.stop', 'Heartbeat stopped');
     }
+
+    if (this.visibilityChangeListener && typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', this.visibilityChangeListener);
+      this.visibilityChangeListener = null;
+    }
+    this.hiddenAt = null;
   }
 
   ngOnDestroy(): void {

--- a/client/web/src/app/features/chat/chat.component.ts
+++ b/client/web/src/app/features/chat/chat.component.ts
@@ -178,17 +178,20 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
   private connectionWarningDismissed = false;
   private connectionWarningTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
   private themeTransitionTimeout: ReturnType<typeof setTimeout> | null = null;
+  private isResumeReconnectInProgress = false;
 
   appVersion: string = packageJson.version;
 
   private visibilityChangeListener = () => {
-    if (
-      document.visibilityState === 'visible' &&
-      this.SessionCode &&
-      !this.wsConnectionService.isConnected()
-    ) {
+    if (document.visibilityState === 'visible' && !this.wsConnectionService.isConnected()) {
       this.logger.info('visibilitychange', 'Page visible, reconnecting if needed');
       this.reconnectInPlace('visibilitychange');
+    }
+  };
+  private onlineListener = () => {
+    if (document.visibilityState === 'visible' && !this.wsConnectionService.isConnected()) {
+      this.logger.info('online', 'Network restored, reconnecting if needed');
+      this.reconnectInPlace('online');
     }
   };
   private beforeUnloadHandler = () => {
@@ -423,6 +426,10 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
     if (isPlatformBrowser(this.platformId) && this.beforeUnloadHandler) {
       window.removeEventListener('beforeunload', this.beforeUnloadHandler);
     }
+
+    if (isPlatformBrowser(this.platformId) && this.onlineListener) {
+      window.removeEventListener('online', this.onlineListener);
+    }
   }
 
   /**
@@ -465,7 +472,7 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
    * ==========================================================
    * HEARTBEAT MONITOR
    * Subscribes to HeartbeatService.suspended$ and reacts to suspensions
-   * by warning the user and forcing a page reload.
+   * by rebuilding the server and peer connections.
    * ==========================================================
    */
   private startHeartbeatMonitor(): void {
@@ -490,6 +497,12 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
    * (tab backgrounded while picking a file, then resumed).
    */
   private reconnectInPlace(context: string): void {
+    if (this.isResumeReconnectInProgress) {
+      this.logger.debug(context, 'Resume reconnect already in progress');
+      return;
+    }
+    this.isResumeReconnectInProgress = true;
+
     this.wsConnectionService.disconnect(false);
     this.webrtcService.closeAllConnections();
 
@@ -505,6 +518,9 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
       .then(() => this.initiateConnectionsWithMembers())
       .catch((err: unknown) => {
         this.logger.warn(context, `Reconnect after resume failed: ${err}`);
+      })
+      .finally(() => {
+        this.isResumeReconnectInProgress = false;
       });
   }
 
@@ -875,6 +891,7 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
 
     document.addEventListener('visibilitychange', this.visibilityChangeListener);
     window.addEventListener('beforeunload', this.beforeUnloadHandler);
+    window.addEventListener('online', this.onlineListener);
 
     this.cdr.detectChanges();
     if (this.messageInput?.nativeElement) {


### PR DESCRIPTION
- Track time spent hidden so foregrounding detects suspended tabs even when throttled heartbeat timers fire in the wrong lifecycle phase

- Rebuild stale WebSocket and WebRTC connections for public and private sessions, retry on network restoration, and prevent overlapping reconnect attempts