### PR TITLE
Bump iOS and web patch versions

### DIFF
--- a/client/ios/PastePoint.xcodeproj/project.pbxproj
+++ b/client/ios/PastePoint.xcodeproj/project.pbxproj
@@ -456,7 +456,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.0;
+				MARKETING_VERSION = 0.13.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pastepoint.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -495,7 +495,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.0;
+				MARKETING_VERSION = 0.13.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pastepoint.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/client/web/package-lock.json
+++ b/client/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.24.0",
+      "version": "0.24.1",
       "dependencies": {
         "@angular/cdk": "^21.2.9",
         "@angular/common": "^21.2.17",

--- a/client/web/package.json
+++ b/client/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/server/config/development.toml
+++ b/server/config/development.toml
@@ -17,7 +17,7 @@ url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]
 minimum = "0.24.0"
-latest = "0.24.0"
+latest = "0.24.1"
 url = "https://127.0.0.1"
 
 [sentry]

--- a/server/config/development.toml
+++ b/server/config/development.toml
@@ -12,7 +12,7 @@ cors_allowed_origins = "https://127.0.0.1"
 # Raise these only AFTER the build is live on the store/web, or you soft-brick users.
 [client_version.ios]
 minimum = "0.13.0"
-latest = "0.13.0"
+latest = "0.13.1"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]

--- a/server/config/docker-dev.toml
+++ b/server/config/docker-dev.toml
@@ -17,7 +17,7 @@ url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]
 minimum = "0.24.0"
-latest = "0.24.0"
+latest = "0.24.1"
 url = "https://127.0.0.1"
 
 [sentry]

--- a/server/config/docker-dev.toml
+++ b/server/config/docker-dev.toml
@@ -12,7 +12,7 @@ cors_allowed_origins = "https://127.0.0.1"
 # Raise these only AFTER the build is live on the store/web, or you soft-brick users.
 [client_version.ios]
 minimum = "0.13.0"
-latest = "0.13.0"
+latest = "0.13.1"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]

--- a/server/config/production.toml
+++ b/server/config/production.toml
@@ -17,7 +17,7 @@ url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]
 minimum = "0.24.0"
-latest = "0.24.0"
+latest = "0.24.1"
 url = "https://pastepoint.com"
 
 [sentry]

--- a/server/config/production.toml
+++ b/server/config/production.toml
@@ -12,7 +12,7 @@ cors_allowed_origins = "https://pastepoint.com"
 # Raise these only AFTER the build is live on the store/web, or you soft-brick users.
 [client_version.ios]
 minimum = "0.13.0"
-latest = "0.13.0"
+latest = "0.13.1"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]


### PR DESCRIPTION
### Summary

Prepare patch releases for the iOS and web clients.

### What changed

- Bump the iOS marketing version from `0.13.0` to `0.13.1`
- Bump the web version from `0.24.0` to `0.24.1`
- Update the web lockfile version
- Advertise the new latest client versions across development, Docker, and production server configurations
- Keep the existing minimum supported versions unchanged