### PR TITLE
iOS: Dock toasts to the Dynamic Island and notch

### DIFF
--- a/client/ios/PastePoint.xcodeproj/project.pbxproj
+++ b/client/ios/PastePoint.xcodeproj/project.pbxproj
@@ -456,7 +456,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.1;
+				MARKETING_VERSION = 0.13.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pastepoint.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -495,7 +495,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.1;
+				MARKETING_VERSION = 0.13.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pastepoint.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/client/ios/PastePoint/App/ContentView+Events.swift
+++ b/client/ios/PastePoint/App/ContentView+Events.swift
@@ -131,6 +131,7 @@ private struct ChatEventHandlers: ViewModifier {
       return
     }
     guard !owner.showSettings else { return }
+    guard !owner.toast.items.contains(where: { $0.style == .success || $0.style == .info }) else { return }
 
     if wasPrivateJoin {
       owner.toast.show(.success(.privateSessionJoined))

--- a/client/ios/PastePoint/Core/Utils/Toast/Toast.swift
+++ b/client/ios/PastePoint/Core/Utils/Toast/Toast.swift
@@ -35,7 +35,7 @@ enum ToastStyle {
 // MARK: - Toast Item
 
 struct ToastItem: Identifiable, Equatable {
-  let id = UUID()
+  var id = UUID()
   let message: LocalizedStringResource
   let style: ToastStyle
 

--- a/client/ios/PastePoint/Core/Utils/Toast/Toast.swift
+++ b/client/ios/PastePoint/Core/Utils/Toast/Toast.swift
@@ -92,8 +92,12 @@ private struct ToastRowView: View {
     }
     .frame(maxWidth: 400)
     .onTapGesture { onDismiss() }
+    .accessibilityElement(children: .combine)
+    .accessibilityAddTraits(.isButton)
+    .accessibilityAction { onDismiss() }
     .task {
-      try? await Task.sleep(for: .seconds(2))
+      try? await Task.sleep(for: .seconds(ToastCenter.displayDuration))
+      guard !Task.isCancelled else { return }
       onDismiss()
     }
   }
@@ -101,33 +105,55 @@ private struct ToastRowView: View {
 
 // MARK: - Toast Overlay
 
-/// Renders the active toasts at the top edge of its container. Hosted in the
-/// global overlay window (see `ToastWindow`) bound to the shared `ToastCenter`,
-/// so toasts float above every view — including sheets.
+/// Draws the toast queue in the global overlay window (see `ToastWindow`), above sheets and
+/// everything else. The first toast docks to the Island or notch if the device has one.
 struct ToastOverlayView: View {
   @ObservedObject var center: ToastCenter
 
   var onFrameChange: (CGRect) -> Void = { _ in }
 
+  var onDockedChange: (Bool) -> Void = { _ in }
+
   var body: some View {
-    VStack(spacing: 8) {
-      ForEach(center.items) { item in
-        ToastRowView(toast: item) {
-          withAnimation(.spring(response: 0.4)) {
-            center.dismiss(item.id)
-          }
+    Group {
+      if let cutout = center.cutout, let head = center.items.first {
+        stack(top: cutout.top) {
+          DockedToastView(toast: head, cutout: cutout) { dismiss(head.id) }
+            .id(head.id)
+            .transition(.identity)
+
+          capsules(Array(center.items.dropFirst()))
         }
-        .transition(.asymmetric(
-          insertion: .move(edge: .top).combined(with: .opacity),
-          removal: .move(edge: .top).combined(with: .opacity),
-        ))
+        .ignoresSafeArea(edges: .top)
+      } else {
+        stack(top: 8) { capsules(center.items) }
       }
     }
-    .padding(.horizontal, 20)
-    .onGeometryChange(for: CGRect.self) { $0.frame(in: .global) } action: { onFrameChange($0) }
-    .padding(.top, 8)
-    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-    .animation(.spring(response: 0.4), value: center.items)
+    .onChange(of: center.isDocked, initial: true) { _, docked in onDockedChange(docked) }
+  }
+
+  private func stack(top: CGFloat, @ViewBuilder _ content: () -> some View) -> some View {
+    VStack(spacing: 8, content: content)
+      .animation(.spring(response: 0.4), value: center.items)
+      .padding(.horizontal, 20)
+      .onGeometryChange(for: CGRect.self) { $0.frame(in: .global) } action: { onFrameChange($0) }
+      .padding(.top, top)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+      .transition(.identity)
+  }
+
+  @ViewBuilder
+  private func capsules(_ items: [ToastItem]) -> some View {
+    ForEach(items) { item in
+      ToastRowView(toast: item) { dismiss(item.id) }
+        .transition(.move(edge: .top).combined(with: .opacity))
+    }
+  }
+
+  private func dismiss(_ id: ToastItem.ID) {
+    withAnimation(.spring(response: 0.4)) {
+      center.dismiss(id)
+    }
   }
 }
 
@@ -138,27 +164,20 @@ struct ToastOverlayView: View {
 private struct ToastPreview: View {
   @StateObject private var center = ToastCenter()
 
+  private let samples: [(label: String, item: ToastItem)] = [
+    ("Success", .success(.codeCopied)),
+    ("Error", .error(.startPrivateFailed)),
+    ("Warning", .warning(.connectionLost)),
+    ("Info", .info(.roomJoined("General"))),
+  ]
+
   var body: some View {
     VStack(spacing: 16) {
-      Spacer()
-
-      Button { center.show(.success(.codeCopied)) } label: { Text(verbatim: "Success") }
-        .buttonStyle(.borderedProminent)
-        .tint(AppColors.Status.success)
-
-      Button { center.show(.error(.startPrivateFailed)) } label: { Text(verbatim: "Error") }
-        .buttonStyle(.borderedProminent)
-        .tint(AppColors.Status.danger)
-
-      Button { center.show(.warning(.connectionLost)) } label: { Text(verbatim: "Warning") }
-        .buttonStyle(.borderedProminent)
-        .tint(AppColors.Status.warning)
-
-      Button { center.show(.info(.roomJoined("General"))) } label: { Text(verbatim: "Info") }
-        .buttonStyle(.borderedProminent)
-        .tint(AppColors.Status.info)
-
-      Spacer()
+      ForEach(samples, id: \.label) { sample in
+        Button { center.show(sample.item) } label: { Text(verbatim: sample.label) }
+          .buttonStyle(.borderedProminent)
+          .tint(sample.item.style.color)
+      }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(AppColors.Background.background)

--- a/client/ios/PastePoint/Core/Utils/Toast/ToastCenter.swift
+++ b/client/ios/PastePoint/Core/Utils/Toast/ToastCenter.swift
@@ -26,6 +26,9 @@ final class ToastCenter: ObservableObject {
   }
 
   func show(_ item: ToastItem) {
+    var item = item
+    item.id = UUID()
+
     cutout = ToastCutout.current()
     items.append(item)
     if items.count > Self.maxVisible {

--- a/client/ios/PastePoint/Core/Utils/Toast/ToastCenter.swift
+++ b/client/ios/PastePoint/Core/Utils/Toast/ToastCenter.swift
@@ -6,17 +6,35 @@
 import Combine
 import SwiftUI
 
-/// App-wide toast queue. A single instance is created in `PastePointApp`,
-/// injected into the SwiftUI environment, and observed by the overlay window
-/// (see `ToastWindow`) so toasts float above every view — including sheets.
-///
-/// Call site stays simple: `toast.show(.success(.codeCopied))`.
+/// App-wide toast queue. One instance lives in `PastePointApp` and the overlay window
+/// observes it, so a call site only ever writes `toast.show(.success(.codeCopied))`.
 @MainActor
 final class ToastCenter: ObservableObject {
+  static let displayDuration: Double = 2
+
+  /// One docked slot plus two queued capsules, so a burst can't bury the chat.
+  private static let maxVisible = 3
+
   @Published private(set) var items: [ToastItem] = []
 
+  /// Looked up on every `show`, since at init there is no window to measure yet.
+  @Published private(set) var cutout: ToastCutout?
+
+  /// True while a toast is covering the clock and status icons.
+  var isDocked: Bool {
+    cutout != nil && !items.isEmpty
+  }
+
   func show(_ item: ToastItem) {
+    cutout = ToastCutout.current()
     items.append(item)
+    if items.count > Self.maxVisible {
+      // Drop a queued one, never index 0 — that toast is on screen and may be mid-animation.
+      items.remove(at: 1)
+    }
+
+    // VoiceOver never reaches the overlay's own window, so announce the toast ourselves.
+    AccessibilityNotification.Announcement(String(localized: item.message)).post()
   }
 
   func dismiss(_ id: ToastItem.ID) {

--- a/client/ios/PastePoint/Core/Utils/Toast/ToastDock.swift
+++ b/client/ios/PastePoint/Core/Utils/Toast/ToastDock.swift
@@ -1,0 +1,266 @@
+//
+//  Copyright © 2026 PastePoint. All rights reserved.
+//  SPDX-License-Identifier: GPL-3.0-only
+//
+
+import SwiftUI
+import UIKit
+
+// MARK: - Cutout
+
+/// Housing geometry in points, portrait only. `nonisolated` so `DockShape` can read it.
+nonisolated struct ToastCutout {
+  static let cardRadius: CGFloat = 26
+
+  let top: CGFloat
+  let size: CGSize
+  let housingRadius: CGFloat
+  let contentTop: CGFloat
+  let minWidth: CGFloat
+  let maxWidth: CGFloat
+
+  static let island = Self(
+    top: 11,
+    size: CGSize(width: 125, height: 36),
+    housingRadius: 18,
+    contentTop: 47,
+    minWidth: 168,
+    maxWidth: 344,
+  )
+
+  static let notch = Self(
+    top: 0,
+    size: CGSize(width: 162, height: 32),
+    housingRadius: 20,
+    contentTop: 42,
+    minWidth: 206,
+    maxWidth: 340,
+  )
+
+  func radii(_ radius: CGFloat) -> RectangleCornerRadii {
+    let topRadius = top == 0 ? 0 : radius
+    return RectangleCornerRadii(
+      topLeading: topRadius,
+      bottomLeading: radius,
+      bottomTrailing: radius,
+      topTrailing: topRadius,
+    )
+  }
+
+  /// `nil` when there is no housing (SE, iPad, landscape). iPad is excluded by idiom rather
+  /// than by inset, because its 32pt top would pass for a notch. Measure a `UIWindow`: the
+  /// overlay ignores the safe area, so a `GeometryReader` inside it always reads zero.
+  @MainActor
+  static func current() -> Self? {
+    guard UIDevice.current.userInterfaceIdiom == .phone else { return nil }
+
+    let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+    guard
+      let scene = scenes.first(where: { $0.activationState == .foregroundActive }) ?? scenes.first,
+      scene.interfaceOrientation.isPortrait,
+      let window = scene.keyWindow ?? scene.windows.first
+    else { return nil }
+
+    switch window.safeAreaInsets.top {
+    case 51...: return .island
+    case 30..<51: return .notch
+    default: return nil
+    }
+  }
+}
+
+// MARK: - Reveal Shape
+
+private nonisolated struct DockShape: Shape {
+  let cutout: ToastCutout
+  var progress: CGFloat
+
+  var animatableData: CGFloat {
+    get { progress }
+    set { progress = newValue }
+  }
+
+  func path(in rect: CGRect) -> Path {
+    let width = max(0, lerp(cutout.size.width, rect.width, progress))
+    let height = max(0, lerp(cutout.size.height, rect.height, progress))
+    let box = CGRect(x: rect.midX - width / 2, y: rect.minY, width: width, height: height)
+
+    // Radius tracks height, so a short card stays as round as the housing.
+    let radius = min(ToastCutout.cardRadius, height * cutout.housingRadius / cutout.size.height)
+
+    return UnevenRoundedRectangle(cornerRadii: cutout.radii(radius), style: .continuous)
+      .path(in: box)
+  }
+}
+
+private nonisolated func lerp(_ from: CGFloat, _ to: CGFloat, _ progress: CGFloat) -> CGFloat {
+  from + (to - from) * progress
+}
+
+// MARK: - Docked Toast
+
+/// A black card grown out of the Dynamic Island or notch, sized to its message. It stays black
+/// in both appearances so it looks welded to the cutout; the status colour lives in the icon.
+struct DockedToastView: View {
+  private static let retractDuration = 0.22
+
+  private static let barDelay = 0.2
+
+  let toast: ToastItem
+  let cutout: ToastCutout
+  let onDismiss: () -> Void
+
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @Environment(\.layoutDirection) private var layoutDirection
+
+  @State private var revealed = false
+  @State private var contentShown = false
+  @State private var barShown = false
+  @State private var drained = false
+  @State private var dismissing = false
+
+  var body: some View {
+    ViewThatFits(in: .horizontal) {
+      card.fixedSize(horizontal: true, vertical: false)
+      card
+    }
+    .frame(maxWidth: cutout.maxWidth)
+    .onTapGesture(perform: retract)
+    .accessibilityElement(children: .combine)
+    .accessibilityAddTraits(.isButton)
+    .accessibilityAction { retract() }
+    // Start on the next turn: a state change made inside `onAppear` lands together with
+    // the insertion, so the card is drawn already grown and never animates.
+    .onAppear { Task { start() } }
+    .task {
+      try? await Task.sleep(for: .seconds(ToastCenter.displayDuration))
+      guard !Task.isCancelled else { return }
+      retract()
+    }
+  }
+
+  private func start() {
+    guard !reduceMotion else {
+      revealed = true
+      contentShown = true
+      barShown = true
+      withAnimation(.linear(duration: ToastCenter.displayDuration)) { drained = true }
+      return
+    }
+
+    withAnimation(.spring(response: 0.44, dampingFraction: 0.68)) { revealed = true }
+    withAnimation(.timingCurve(0.2, 0.8, 0.3, 1, duration: 0.28).delay(0.06)) { contentShown = true }
+    withAnimation(.easeInOut(duration: 0.3).delay(Self.barDelay)) { barShown = true }
+    withAnimation(.linear(duration: ToastCenter.displayDuration - Self.barDelay).delay(Self.barDelay)) { drained = true }
+  }
+
+  private func retract() {
+    guard !dismissing else { return }
+    dismissing = true
+
+    guard !reduceMotion else { return onDismiss() }
+
+    withAnimation(.timingCurve(0.34, 0.9, 0.3, 1, duration: Self.retractDuration)) {
+      revealed = false
+      contentShown = false
+      barShown = false
+    }
+
+    Task {
+      try? await Task.sleep(for: .seconds(Self.retractDuration))
+      onDismiss()
+    }
+  }
+
+  private var card: some View {
+    HStack(spacing: 10) {
+      ZStack {
+        Circle()
+          .fill(toast.style.color)
+          .frame(width: 28, height: 28)
+
+        Image(systemName: toast.style.icon)
+          .font(.system(size: 13, weight: .bold, design: .rounded))
+          .foregroundStyle(.white)
+      }
+
+      Text(toast.message)
+        .font(.system(size: 14, weight: .medium, design: .rounded))
+        .foregroundStyle(.white.opacity(0.94))
+        .lineLimit(3)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+    .opacity(contentShown ? 1 : 0)
+    .scaleEffect(revealed ? 1 : 0.86, anchor: .top)
+    .padding(.top, cutout.contentTop)
+    .padding(.horizontal, 16)
+    .padding(.bottom, 12)
+    .frame(minWidth: cutout.minWidth)
+    .background { surface }
+    // Mask the message too, or the card's edge just sweeps across text already sitting there.
+    .mask { dock }
+    .compositingGroup()
+    .shadow(color: .black.opacity(revealed ? 0.45 : 0), radius: 20, x: 0, y: 18)
+  }
+
+  private var surface: some View {
+    Color.black
+      .overlay(alignment: .bottom) {
+        Rectangle()
+          .fill(toast.style.color)
+          .frame(height: 2)
+          .scaleEffect(x: drained ? 0 : 1, anchor: drainAnchor)
+          .opacity(barShown ? 0.85 : 0)
+      }
+      .overlay { dock.stroke(.white.opacity(revealed ? 0.07 : 0), lineWidth: 2) }
+  }
+
+  private var dock: DockShape {
+    DockShape(cutout: cutout, progress: revealed ? 1 : 0)
+  }
+
+  /// `UnitPoint` is a raw geometric point, so unlike `Alignment` it needs flipping for RTL.
+  private var drainAnchor: UnitPoint {
+    UnitPoint(x: layoutDirection == .rightToLeft ? 1 : 0, y: 0.5)
+  }
+}
+
+#if DEBUG
+
+// MARK: - Preview
+
+private struct DockedToastPreview: View {
+  let cutout: ToastCutout
+  let toast: ToastItem
+
+  /// Replays the entrance instead of leaving the canvas blank after one lifetime.
+  @State private var generation = 0
+
+  var body: some View {
+    DockedToastView(toast: toast, cutout: cutout) { generation += 1 }
+      .id(generation)
+      .padding(.top, cutout.top)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+      .background(AppColors.Background.background)
+      .overlay(alignment: .top) {
+        UnevenRoundedRectangle(cornerRadii: cutout.radii(cutout.housingRadius), style: .continuous)
+          .fill(.black)
+          .frame(width: cutout.size.width, height: cutout.size.height)
+          .padding(.top, cutout.top)
+      }
+      .ignoresSafeArea()
+  }
+}
+
+#Preview("Island · short") {
+  DockedToastPreview(cutout: .island, toast: .success(.codeCopied))
+}
+
+#Preview("Island · wrapping") {
+  DockedToastPreview(cutout: .island, toast: .error(.startPrivateFailed))
+}
+
+#Preview("Notch") {
+  DockedToastPreview(cutout: .notch, toast: .info(.roomJoined("General")))
+}
+#endif

--- a/client/ios/PastePoint/Core/Utils/Toast/ToastWindow.swift
+++ b/client/ios/PastePoint/Core/Utils/Toast/ToastWindow.swift
@@ -8,8 +8,7 @@ import UIKit
 
 // MARK: - Pass-through Window
 
-/// A transparent window that sits above the sheet/alert layer and lets touches
-/// fall through to the app below — except where they land on a toast row.
+/// Sits above the sheet/alert layer and lets touches fall through, except on a toast.
 final class PassthroughWindow: UIWindow {
   var interactiveRect: CGRect = .zero
 
@@ -17,6 +16,19 @@ final class PassthroughWindow: UIWindow {
     guard interactiveRect.contains(point) else { return nil }
     return super.hitTest(point, with: event)
   }
+}
+
+// MARK: - Host
+
+private final class ToastHostingController: UIHostingController<ToastOverlayView> {
+  var hidesStatusBar = false {
+    didSet {
+      guard hidesStatusBar != oldValue else { return }
+      setNeedsStatusBarAppearanceUpdate()
+    }
+  }
+
+  override var prefersStatusBarHidden: Bool { hidesStatusBar }
 }
 
 // MARK: - Presenter
@@ -30,11 +42,9 @@ final class ToastPresenter {
     guard window == nil else { return }
 
     let window = PassthroughWindow(windowScene: scene)
-    let host = UIHostingController(
-      rootView: ToastOverlayView(center: center) { [weak window] rect in
-        window?.interactiveRect = rect
-      },
-    )
+    let host = ToastHostingController(rootView: ToastOverlayView(center: center))
+    host.rootView.onFrameChange = { [weak window] rect in window?.interactiveRect = rect }
+    host.rootView.onDockedChange = { [weak host] docked in host?.hidesStatusBar = docked }
     host.view.backgroundColor = .clear
 
     window.rootViewController = host
@@ -50,8 +60,7 @@ final class ToastPresenter {
 
 // MARK: - Scene Finder
 
-/// Reports the `UIWindowScene` once the view is in the hierarchy so the overlay
-/// window can be attached to the active scene.
+/// Reports the `UIWindowScene` once the view is in the hierarchy.
 private struct WindowSceneFinder: UIViewRepresentable {
   let onScene: (UIWindowScene) -> Void
 
@@ -89,8 +98,7 @@ private struct ToastWindowModifier: ViewModifier {
 }
 
 extension View {
-  /// Installs the global toast overlay window (above sheets) bound to `center`,
-  /// matching the app's resolved light/dark `style`.
+  /// Installs the global toast overlay window (above sheets) bound to `center`.
   func toastWindow(center: ToastCenter, style: UIUserInterfaceStyle) -> some View {
     modifier(ToastWindowModifier(center: center, style: style))
   }

--- a/server/config/development.toml
+++ b/server/config/development.toml
@@ -12,7 +12,7 @@ cors_allowed_origins = "https://127.0.0.1"
 # Raise these only AFTER the build is live on the store/web, or you soft-brick users.
 [client_version.ios]
 minimum = "0.13.0"
-latest = "0.13.1"
+latest = "0.13.2"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]

--- a/server/config/docker-dev.toml
+++ b/server/config/docker-dev.toml
@@ -12,7 +12,7 @@ cors_allowed_origins = "https://127.0.0.1"
 # Raise these only AFTER the build is live on the store/web, or you soft-brick users.
 [client_version.ios]
 minimum = "0.13.0"
-latest = "0.13.1"
+latest = "0.13.2"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]

--- a/server/config/production.toml
+++ b/server/config/production.toml
@@ -12,7 +12,7 @@ cors_allowed_origins = "https://pastepoint.com"
 # Raise these only AFTER the build is live on the store/web, or you soft-brick users.
 [client_version.ios]
 minimum = "0.13.0"
-latest = "0.13.1"
+latest = "0.13.2"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]


### PR DESCRIPTION
### Summary

Toasts used to be a frosted capsule floating under the status bar. On a phone with a housing they now grow out of it as a black card welded to the Dynamic Island or the notch, sized to its own message, and they retract back into the cutout when they expire. Devices with no housing (SE, iPad, landscape) keep the capsule exactly as it was.

Also bumps the iOS client to 0.13.2.

### What changed

- Add `ToastDock.swift` with `ToastCutout` for the housing geometry, an `Animatable` `DockShape` whose corner radius tracks its own height, and `DockedToastView`
- Dock the first toast and queue the rest below it as capsules, promoting each into the docked slot as it frees up, with three on screen at most
- Hide the status bar from `ToastHostingController` while a card is docked
- Check `Task.isCancelled` after the display sleep in both toast views
- Stamp a fresh id on every toast in `ToastCenter.show`
- Skip the connect toast when a success or info toast is already on screen
- Announce each toast to VoiceOver and make the rows dismissible
- Bump `MARKETING_VERSION` to 0.13.2 and the `client_version.ios` policy in all three server configs