### PR TITLE
Web: Recover from stale chunk loads and ignore translation-extension errors

### DIFF
--- a/client/web/src/app/utils/chunk-reload.ts
+++ b/client/web/src/app/utils/chunk-reload.ts
@@ -1,5 +1,5 @@
 const CHUNK_LOAD_ERROR =
-  /Failed to fetch dynamically imported module|Loading chunk \d+ failed|ChunkLoadError/i;
+  /Failed to fetch dynamically imported module|Loading chunk \d+ failed|ChunkLoadError|Importing a module script failed|is not a valid JavaScript MIME type|error loading dynamically imported module/i;
 
 export function isChunkLoadError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);

--- a/client/web/src/main.ts
+++ b/client/web/src/main.ts
@@ -25,6 +25,7 @@ if (typeof window !== 'undefined' && environment.sentry?.enabled && environment.
     release: `${pkgName}@${pkgVersion}`,
     sendDefaultPii: false,
     maxBreadcrumbs: 50,
+    ignoreErrors: ['translation engine failed to load'],
     tracesSampleRate: environment.sentry.tracesSampleRate ?? 0,
     enableLogs: environment.sentry.enableLogs ?? false,
     replaysSessionSampleRate: 0,

--- a/client/web/src/server.ts
+++ b/client/web/src/server.ts
@@ -60,6 +60,10 @@ export function app(): express.Express {
     })
   );
 
+  server.get('*.*', (req, res) => {
+    res.sendStatus(404);
+  });
+
   // All regular routes use the Universal engine
   server.get('*', (req, res, next) => {
     const { protocol, originalUrl, baseUrl, headers } = req;


### PR DESCRIPTION
### Summary

After a deploy rotates the hashed bundle names, tabs opened on the previous release request chunks that no longer exist. The one-shot reload guard only recognised Chrome's error wording, and a missing chunk came back from the SSR server as the app shell instead of an error. This makes the recovery cover Safari and Firefox, makes missing assets fail cleanly, and filters one external Sentry error. Chunk errors still report to Sentry, so unrecovered cases stay visible.

### What changed

- `CHUNK_LOAD_ERROR` now matches Safari's `Importing a module script failed` and MIME-type wordings and Firefox's `error loading dynamically imported module`, so the reload guard covers every browser
- The SSR server returns `404` for file-like paths that miss `express.static`, instead of rendering the app shell as `text/html`
- Sentry ignores `translation engine failed to load`, which page-translation extensions throw inside the page