### PR TITLE
Block outdated clients from connecting until they update

### DIFF
--- a/client/ios/PastePoint.xcodeproj/project.pbxproj
+++ b/client/ios/PastePoint.xcodeproj/project.pbxproj
@@ -456,7 +456,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.14.1;
+				MARKETING_VERSION = 0.14.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pastepoint.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -495,7 +495,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.14.1;
+				MARKETING_VERSION = 0.14.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pastepoint.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/client/ios/PastePoint/App/ContentView.swift
+++ b/client/ios/PastePoint/App/ContentView.swift
@@ -77,6 +77,9 @@ struct ContentView: View {
           .transition(.opacity)
           .zIndex(1)
           .onReceive(services.wsService.didConnect) { dismissSplash() }
+          .onReceive(services.updateService.$recommendation) { recommendation in
+            if case .required = recommendation { dismissSplash() }
+          }
           .task {
             if services.wsService.isConnected || needsLegalConsent { dismissSplash() }
           }

--- a/client/ios/PastePoint/Core/Services/App/AppServices.swift
+++ b/client/ios/PastePoint/Core/Services/App/AppServices.swift
@@ -33,6 +33,7 @@ final class AppServices: ObservableObject {
 
   private var isInBackground = false
   private var isForegroundHandling = false
+  private var isDisconnectedForUpdate = false
 
   private let networkMonitor = NWPathMonitor()
   private var lastPathStatus: NWPath.Status = .satisfied
@@ -81,6 +82,7 @@ final class AppServices: ObservableObject {
 
     startNetworkMonitoring()
     startTerminationObserver()
+    startUpdateGateObserver()
     forwardServiceChanges()
   }
 
@@ -167,6 +169,11 @@ final class AppServices: ObservableObject {
     }
 #endif
 
+    if case .required = updateService.recommendation {
+      log.warning("connectIfPermitted — update required, skipping connect")
+      return false
+    }
+
     let denied = await LocalNetworkPermission.isDenied()
     localNetworkDenied = denied
     guard !denied else {
@@ -240,6 +247,26 @@ final class AppServices: ObservableObject {
       }
     }
     networkMonitor.start(queue: DispatchQueue(label: "com.pastepoint.NetworkMonitor"))
+  }
+
+  // MARK: - Update Gate
+
+  /// Tears down the connection while a required update is pending; resumes when it clears.
+  private func startUpdateGateObserver() {
+    updateService.$recommendation
+      .sink { [weak self] recommendation in
+        guard let self else { return }
+        if case .required = recommendation {
+          guard self.wsService.isConnected || self.wsService.isConnecting else { return }
+          log.warning("Update required — disconnecting until the app is updated")
+          self.isDisconnectedForUpdate = true
+          self.wsService.disconnect(manual: false)
+        } else if self.isDisconnectedForUpdate {
+          self.isDisconnectedForUpdate = false
+          Task { await self.handleForeground() }
+        }
+      }
+      .store(in: &cancellables)
   }
 
   // MARK: - Termination

--- a/client/ios/PastePoint/Core/Services/App/AppUpdateService.swift
+++ b/client/ios/PastePoint/Core/Services/App/AppUpdateService.swift
@@ -90,6 +90,15 @@ private extension AppUpdateService {
   func evaluate(_ policy: PlatformVersion) -> UpdateRecommendation? {
     let installed = Bundle.main.appVersion
 
+    // Defensive: floor above latest is a config typo — treat as no-policy.
+    if
+      !policy.minimum.isEmpty, !policy.latest.isEmpty,
+      compareVersions(policy.minimum, policy.latest) > 0
+    {
+      log.warning("Version policy misconfigured (minimum > latest); ignoring")
+      return recommendation
+    }
+
     guard !policy.url.isEmpty, let url = URL(string: policy.url) else {
       if !policy.minimum.isEmpty || !policy.latest.isEmpty {
         log.warning("Version policy has no valid url; ignoring")

--- a/client/web/package-lock.json
+++ b/client/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.25.0",
+      "version": "0.25.1",
       "dependencies": {
         "@angular/cdk": "^21.2.9",
         "@angular/common": "^21.2.19",

--- a/client/web/package.json
+++ b/client/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/client/web/src/app/core/components/splash/splash.component.ts
+++ b/client/web/src/app/core/components/splash/splash.component.ts
@@ -7,11 +7,13 @@ import {
   OnInit,
   Output,
   PLATFORM_ID,
+  effect,
   inject,
 } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { Subscription } from 'rxjs';
 import { WebSocketConnectionService } from '../../services/communication/websocket-connection.service';
+import { AppUpdateService } from '../../services/update/app-update.service';
 
 @Component({
   selector: 'app-splash',
@@ -27,6 +29,14 @@ export class SplashComponent implements OnInit, OnDestroy {
   private platformId = inject(PLATFORM_ID);
   private cdr = inject(ChangeDetectorRef);
   private ws = inject(WebSocketConnectionService);
+  private updateService = inject(AppUpdateService);
+
+  // A required update blocks connecting, so connected$ never fires.
+  private readonly updateGateEffect = effect(() => {
+    if (this.updateService.recommendation()?.kind === 'required') {
+      this.dismiss();
+    }
+  });
 
   private timers: ReturnType<typeof setTimeout>[] = [];
   private sub?: Subscription;

--- a/client/web/src/app/core/services/communication/webrtc.service.ts
+++ b/client/web/src/app/core/services/communication/webrtc.service.ts
@@ -1,9 +1,10 @@
-import { Injectable, inject } from '@angular/core';
+import { Injectable, effect, inject } from '@angular/core';
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { ChatMessage, DataChannelMessage } from '../../../utils/constants';
 import { IWebRTCService } from '../../interfaces/webrtc.interface';
 import { WebRTCSignalingService } from './webrtc-signaling.service';
 import { WebRTCCommunicationService } from './webrtc-communication.service';
+import { AppUpdateService } from '../update/app-update.service';
 import { NGXLogger } from 'ngx-logger';
 
 @Injectable({
@@ -12,7 +13,17 @@ import { NGXLogger } from 'ngx-logger';
 export class WebRTCService implements IWebRTCService {
   private signalingService = inject(WebRTCSignalingService);
   private communicationService = inject(WebRTCCommunicationService);
+  private updateService = inject(AppUpdateService);
   private logger = inject(NGXLogger);
+
+  constructor() {
+    effect(() => {
+      if (this.updateService.recommendation()?.kind === 'required') {
+        this.logger.warn('updateGate', 'Update required, closing all peer connections');
+        this.closeAllConnections();
+      }
+    });
+  }
 
   // =============== Public Properties ===============
   public get peerDisconnected$(): Observable<string> {

--- a/client/web/src/app/core/services/communication/websocket-connection.service.ts
+++ b/client/web/src/app/core/services/communication/websocket-connection.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, PLATFORM_ID, OnDestroy, inject } from '@angular/core';
+import { Injectable, PLATFORM_ID, OnDestroy, effect, inject } from '@angular/core';
 import { BehaviorSubject, Subject } from 'rxjs';
 import * as Sentry from '@sentry/angular';
 import { startNewTrace } from '@sentry/core';
@@ -12,6 +12,7 @@ import {
   WS_KEEP_ALIVE_INTERVAL_MS,
 } from '../../../utils/constants';
 import { HotToastService } from '@ngxpert/hot-toast';
+import { AppUpdateService } from '../update/app-update.service';
 @Injectable({
   providedIn: 'root',
 })
@@ -20,6 +21,7 @@ export class WebSocketConnectionService implements OnDestroy {
   private toaster = inject(HotToastService);
   private translate = inject<TranslateService>(TranslateService);
   private platformId = inject(PLATFORM_ID);
+  private updateService = inject(AppUpdateService);
 
   /**
    * ==========================================================
@@ -39,6 +41,7 @@ export class WebSocketConnectionService implements OnDestroy {
   private keepAliveTimer: ReturnType<typeof setInterval> | null = null;
   private manualDisconnect = false;
   private isConnecting = false;
+  private isDisconnectedForUpdate = false;
 
   // For bfcache support
   private pageHideListener: (() => void) | undefined;
@@ -77,7 +80,29 @@ export class WebSocketConnectionService implements OnDestroy {
   constructor() {
     if (isPlatformBrowser(this.platformId)) {
       this.setupBFCacheHandlers();
+      this.setupUpdateGate();
     }
+  }
+
+  /** Tears down the connection while a required update is pending; resumes when it clears. */
+  private setupUpdateGate(): void {
+    effect(() => {
+      const required = this.updateRequired();
+      if (required && (this.isConnected() || this.isConnecting || this.reconnectTimer !== null)) {
+        this.logger.warn('updateGate', 'Update required, disconnecting until the app is updated');
+        this.isDisconnectedForUpdate = true;
+        this.disconnect(false);
+      } else if (!required && this.isDisconnectedForUpdate) {
+        this.isDisconnectedForUpdate = false;
+        this.connect(this.sessionCode).catch((err: unknown) => {
+          this.logger.error('updateGate', `Reconnect after update gate cleared failed: ${err}`);
+        });
+      }
+    });
+  }
+
+  private updateRequired(): boolean {
+    return this.updateService.recommendation()?.kind === 'required';
   }
 
   /**
@@ -148,6 +173,11 @@ export class WebSocketConnectionService implements OnDestroy {
    * ==========================================================
    */
   public connect(code?: string): Promise<void> {
+    if (this.updateRequired()) {
+      this.logger.warn('connect', 'Update required, refusing to connect');
+      return Promise.resolve();
+    }
+
     if (this.isConnecting) {
       this.logger.warn('connect', 'Connection already in progress, ignoring duplicate request');
       return Promise.resolve();
@@ -304,6 +334,11 @@ export class WebSocketConnectionService implements OnDestroy {
   }
 
   private scheduleReconnect(): void {
+    if (this.updateRequired()) {
+      this.reconnectState$.next(null);
+      return;
+    }
+
     this.stopKeepAlive();
 
     if (this.reconnectTimer) {

--- a/server/config/development.toml
+++ b/server/config/development.toml
@@ -16,8 +16,8 @@ latest = "0.14.2"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]
-minimum = "0.25.0"
-latest = "0.25.0"
+minimum = "0.25.1"
+latest = "0.25.1"
 url = "https://127.0.0.1"
 
 [sentry]

--- a/server/config/development.toml
+++ b/server/config/development.toml
@@ -11,8 +11,8 @@ cors_allowed_origins = "https://127.0.0.1"
 # Client update policy (GET /version). minimum = force floor, latest = soft nudge.
 # Raise these only AFTER the build is live on the store/web, or you soft-brick users.
 [client_version.ios]
-minimum = "0.14.1"
-latest = "0.14.1"
+minimum = "0.14.2"
+latest = "0.14.2"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]

--- a/server/config/docker-dev.toml
+++ b/server/config/docker-dev.toml
@@ -16,8 +16,8 @@ latest = "0.14.2"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]
-minimum = "0.25.0"
-latest = "0.25.0"
+minimum = "0.25.1"
+latest = "0.25.1"
 url = "https://127.0.0.1"
 
 [sentry]

--- a/server/config/docker-dev.toml
+++ b/server/config/docker-dev.toml
@@ -11,8 +11,8 @@ cors_allowed_origins = "https://127.0.0.1"
 # Client update policy (GET /version). minimum = force floor, latest = soft nudge.
 # Raise these only AFTER the build is live on the store/web, or you soft-brick users.
 [client_version.ios]
-minimum = "0.14.1"
-latest = "0.14.1"
+minimum = "0.14.2"
+latest = "0.14.2"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]

--- a/server/config/production.toml
+++ b/server/config/production.toml
@@ -11,8 +11,8 @@ cors_allowed_origins = "https://pastepoint.com"
 # Client update policy (GET /version). minimum = force floor, latest = soft nudge.
 # Raise these only AFTER the build is live on the store/web, or you soft-brick users.
 [client_version.ios]
-minimum = "0.14.1"
-latest = "0.14.1"
+minimum = "0.14.2"
+latest = "0.14.2"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]

--- a/server/config/production.toml
+++ b/server/config/production.toml
@@ -16,8 +16,8 @@ latest = "0.14.2"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]
-minimum = "0.25.0"
-latest = "0.25.0"
+minimum = "0.25.1"
+latest = "0.25.1"
 url = "https://pastepoint.com"
 
 [sentry]


### PR DESCRIPTION
### Summary

A client below the server's required minimum version now disconnects and stays offline until it is updated, instead of showing the update gate while continuing to run behind it. Enforcement is client-side only: the wire protocol, the `/version` endpoint, and its caching are unchanged, and the optional update tier still nudges without blocking. Connects stay optimistic — the version check runs in parallel and fails open, so an unreachable `/version` never locks anyone out.

### What changed

- Web refuses WebSocket connects while an update is required, stops the reconnect loop and its banner, and `WebSocketConnectionService` tears down on a mid-session verdict and resumes the same session if the policy is rolled back

- Web closes all peer connections when a required update lands, since data channels are peer-to-peer and outlive the signaling teardown; iOS needs no equivalent because its WebSocket disconnect already empties `PeerDirectory` and `syncMesh` closes every peer

- iOS guards `connectIfPermitted` on the update recommendation and `AppServices` observes it to disconnect while required and reconnect through `handleForeground` when it clears

- Both splash screens dismiss when a required update is pending, since they wait on a connection signal the gate now prevents and otherwise sat until their fail-open ceiling

- iOS adopts web's guard that treats a policy with `minimum` above `latest` as a config typo and ignores it