### PR TITLE
Improve Sentry telemetry and stop stale-bundle errors on deploy

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -19,13 +19,6 @@ HOST=127.0.0.1
 PORT=4000
 SERVER_NAME=127.0.0.1
 
-# Sentry (error tracking)
-# Leave SENTRY_ENABLED=false in dev unless you actively want to send events.
-# SENTRY_DSN must stay empty in this committed file — set it only in your
-# local .env.development (which is gitignored).
-SENTRY_DSN=
-SENTRY_ENABLED=false
-
 # TURN relay (GET /turn-credentials)
 # Empty = endpoint 204s and clients stay STUN-only (fine for LAN dev).
 # Set it only in your gitignored .env.development.

--- a/.env.production.example
+++ b/.env.production.example
@@ -3,7 +3,7 @@
 # This file is a template. On your production host (e.g. the EC2 instance):
 #   cp .env.production.example .env.production
 #   chmod 600 .env.production
-#   # then edit .env.production and fill in real secrets (SENTRY_DSN, etc.)
+#   # then edit .env.production and fill in real secrets (TURN_SECRET, etc.)
 #
 # .env.production is gitignored — it must NEVER be committed.
 
@@ -19,12 +19,6 @@ RUST_BUILD_MODE=release
 HOST=0.0.0.0
 PORT=4000
 SERVER_NAME=pastepoint.com
-
-# Sentry (error tracking)
-# Set SENTRY_DSN to the production server DSN. Without it, Sentry stays
-# disabled even if SENTRY_ENABLED=true.
-SENTRY_DSN=
-SENTRY_ENABLED=true
 
 # TURN relay (GET /turn-credentials)
 # Empty = endpoint 204s and clients stay STUN-only.

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -113,6 +113,6 @@ The reports do **not** contain:
 - User accounts, names, or email addresses
 - IP addresses or geolocation (the SDK and server-side scrubbing both strip these)
 
-Error reports help us identify and fix bugs. They are retained for a limited time and then deleted automatically. Operators of self-hosted PastePoint instances may disable error reporting entirely by setting `SENTRY_ENABLED=false` in their environment configuration.
+Error reports help us identify and fix bugs. They are retained for a limited time and then deleted automatically. Operators of self-hosted PastePoint instances may disable error reporting entirely by setting `enabled = false` (or leaving the `dsn` empty) under `[sentry]` in the server configuration and in the web client's environment files.
 
 PastePoint is a tool. Please use it wisely, lawfully, and responsibly.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ PastePoint is a secure, feature-rich file-sharing service designed for local net
 - **Observability**:
   - Optional Sentry-based error tracking (EU-hosted, off by default in dev)
   - Privacy-tight defaults: no IPs, no geo, no request bodies, no user identifiers
-  - Toggle per-environment via `SENTRY_ENABLED` / `SENTRY_DSN` (server: runtime env vars; web: built into the bundle from `client/web/src/environments/environment.*.ts` at compile time)
+  - Configured per-environment in committed files: server `config/*.toml` `[sentry]` (`enabled` + `dsn`), web `client/web/src/environments/environment.*.ts` (DSNs are public ingest addresses, not secrets)
 
 - **Cross-Platform Compatibility**:
   - Runs seamlessly on Linux, macOS, and Windows with Dockerized support
@@ -235,7 +235,7 @@ pastepoint/
    ```bash
    cp .env.production.example .env.production
    chmod 600 .env.production
-   # edit .env.production: SERVER_NAME, SENTRY_DSN, etc.
+   # edit .env.production: SERVER_NAME, TURN_SECRET, etc.
    ```
 
    Real DSNs and host-specific values live only in the gitignored

--- a/client/web/angular.json
+++ b/client/web/angular.json
@@ -67,7 +67,7 @@
                 "styles": true,
                 "fonts": true
               },
-              "outputHashing": "media",
+              "outputHashing": "all",
               "sourceMap": false,
               "namedChunks": false,
               "aot": true,
@@ -102,7 +102,7 @@
                 "styles": true,
                 "fonts": true
               },
-              "outputHashing": "media",
+              "outputHashing": "all",
               "sourceMap": false,
               "aot": true,
               "namedChunks": false,

--- a/client/web/angular.json
+++ b/client/web/angular.json
@@ -82,7 +82,8 @@
             "development": {
               "optimization": false,
               "extractLicenses": false,
-              "sourceMap": true
+              "sourceMap": true,
+              "outputHashing": "all"
             },
             "docker": {
               "budgets": [
@@ -118,6 +119,7 @@
               "optimization": false,
               "extractLicenses": false,
               "sourceMap": true,
+              "outputHashing": "all",
               "fileReplacements": [
                 {
                   "replace": "src/environments/environment.ts",

--- a/client/web/package-lock.json
+++ b/client/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.25.1",
+      "version": "0.25.2",
       "dependencies": {
         "@angular/cdk": "^21.2.9",
         "@angular/common": "^21.2.19",

--- a/client/web/package.json
+++ b/client/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/client/web/src/app/app.config.ts
+++ b/client/web/src/app/app.config.ts
@@ -6,7 +6,7 @@ import {
   provideAppInitializer,
   provideZoneChangeDetection,
 } from '@angular/core';
-import { provideRouter, withPreloading } from '@angular/router';
+import { provideRouter, withNavigationErrorHandler, withPreloading } from '@angular/router';
 import { Router } from '@angular/router';
 import * as Sentry from '@sentry/angular';
 
@@ -69,7 +69,13 @@ export const appConfig: ApplicationConfig = {
     provideAppInitializer(() => void inject(Sentry.TraceService)),
     provideHttpClient(withFetch()),
     provideZoneChangeDetection({ eventCoalescing: true, runCoalescing: true }),
-    provideRouter(routes, withPreloading(SelectivePreloadingStrategy)),
+    provideRouter(
+      routes,
+      withPreloading(SelectivePreloadingStrategy),
+      withNavigationErrorHandler((e) => {
+        reloadOnceForChunkError(e.error);
+      })
+    ),
     provideClientHydration(withEventReplay()),
     provideHotToastConfig({
       position: 'top-center',

--- a/client/web/src/app/core/services/communication/chat.service.ts
+++ b/client/web/src/app/core/services/communication/chat.service.ts
@@ -95,7 +95,7 @@ export class ChatService implements IChatService {
         payload: chatMsg,
       };
       this.webrtcService.sendData(dataChannelMsg, targetUser);
-      this.logger.info('sendMessage', `Message sent to ${targetUser}: ${chatMsg.text}`);
+      this.logger.info('sendMessage', 'Message sent');
     } else {
       this.logger.warn('sendMessage', 'Empty message content');
     }
@@ -125,7 +125,7 @@ export class ChatService implements IChatService {
         this.messages.push(chatMsg);
         this.messages$.next(this.messages);
       });
-      this.logger.info('addMessageToLocal', `Message added to local chat: ${chatMsg.text}`);
+      this.logger.info('addMessageToLocal', 'Message added to local chat');
     }
   }
 

--- a/client/web/src/app/core/services/communication/chat.service.ts
+++ b/client/web/src/app/core/services/communication/chat.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, NgZone, inject } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
+import { TelemetryService } from '../monitoring/telemetry.service';
 import { WebRTCService } from './webrtc.service';
 import { UserService } from '../user-management/user.service';
 import { ChatMessage, ChatMessageType, DATA_CHANNEL_MESSAGE_TYPES } from '../../../utils/constants';
@@ -16,6 +17,7 @@ export class ChatService implements IChatService {
   private userService = inject(UserService);
   private logger = inject(NGXLogger);
   private ngZone = inject(NgZone);
+  private telemetry = inject(TelemetryService);
 
   /**
    * ==========================================================
@@ -166,6 +168,7 @@ export class ChatService implements IChatService {
    * ==========================================================
    */
   private handleUserMessage(incoming: ChatMessage): void {
+    this.telemetry.event('chat.message_received');
     this.ngZone.run(() => {
       this.messages.push(incoming);
       this.messages$.next(this.messages);

--- a/client/web/src/app/core/services/communication/webrtc-communication.service.ts
+++ b/client/web/src/app/core/services/communication/webrtc-communication.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NgZone, PLATFORM_ID, inject } from '@angular/core';
-import * as Sentry from '@sentry/angular';
+import { TelemetryService } from '../monitoring/telemetry.service';
 import { BehaviorSubject, Subject } from 'rxjs';
 import {
   BUFFERED_AMOUNT_LOW_THRESHOLD,
@@ -24,6 +24,7 @@ export class WebRTCCommunicationService {
   private toaster = inject(HotToastService);
   private platformId = inject(PLATFORM_ID);
   private blockService = inject(BlockService);
+  private telemetry = inject(TelemetryService);
 
   // =============== Properties ===============
 
@@ -158,11 +159,9 @@ export class WebRTCCommunicationService {
           `Data Channel Error with ${targetUser}: ${JSON.stringify(ev)}`
         );
       }
-      Sentry.addBreadcrumb({
-        category: 'webrtc.datachannel',
-        level: 'error',
-        message: 'data channel error',
-        data: { ready_state: channel.readyState, error: errorDetail },
+      this.telemetry.breadcrumb('webrtc.datachannel', 'data channel error', 'error', {
+        ready_state: channel.readyState,
+        error: errorDetail,
       });
       this.dataChannelClosed$.next(targetUser);
     };
@@ -488,11 +487,7 @@ export class WebRTCCommunicationService {
             'handleDataChannelMessage',
             `Failed to decode chunk from ${targetUser}, size: ${data.byteLength}`
           );
-          Sentry.addBreadcrumb({
-            category: 'webrtc.datachannel',
-            level: 'error',
-            message: 'chunk decode failed',
-          });
+          this.telemetry.breadcrumb('webrtc.datachannel', 'chunk decode failed', 'error');
         }
       } else {
         this.logger.warn(

--- a/client/web/src/app/core/services/communication/webrtc-signaling.service.ts
+++ b/client/web/src/app/core/services/communication/webrtc-signaling.service.ts
@@ -1,6 +1,9 @@
 import { Injectable, inject } from '@angular/core';
-import * as Sentry from '@sentry/angular';
-import { startNewTrace } from '@sentry/core';
+import {
+  TelemetryService,
+  TelemetrySpan,
+  TelemetryAttributes,
+} from '../monitoring/telemetry.service';
 import { WebSocketConnectionService } from './websocket-connection.service';
 import { UserService } from '../user-management/user.service';
 import { BlockService } from './block.service';
@@ -37,6 +40,7 @@ export class WebRTCSignalingService {
   private logger = inject(NGXLogger);
   private communicationService = inject(WebRTCCommunicationService);
   private turnCredentials = inject(TurnCredentialsService);
+  private telemetry = inject(TelemetryService);
 
   // =============== Properties ===============
   public peerDisconnected$ = new Subject<string>();
@@ -58,7 +62,7 @@ export class WebRTCSignalingService {
   private latestAttemptId = new Map<string, number>();
   private meshEpoch = 0;
 
-  private activeConnectSpans = new Map<string, Sentry.Span>();
+  private activeConnectSpans = new Map<string, TelemetrySpan>();
   private connectAttemptCounts = new Map<string, number>();
   private connectSpanCeilings = new Map<string, ReturnType<typeof setTimeout>>();
 
@@ -112,11 +116,10 @@ export class WebRTCSignalingService {
       return;
     }
 
-    const span = startNewTrace(() =>
-      Sentry.startInactiveSpan({ name: 'webrtc.connect', op: 'webrtc.connect' })
-    );
+    const span = this.telemetry.startSpan('webrtc.connect', {
+      role: this.shouldInitiateConnection(targetUser) ? 'caller' : 'callee',
+    });
     this.activeConnectSpans.set(targetUser, span);
-    span.setAttribute('role', this.shouldInitiateConnection(targetUser) ? 'caller' : 'callee');
     this.startConnectSpanCeiling(targetUser);
 
     void this.initiateConnectionInner(targetUser, span);
@@ -186,35 +189,33 @@ export class WebRTCSignalingService {
       return acc;
     }, {});
 
-    span.setAttribute('outcome', 'failed');
-    span.setAttribute('failure_reason', reason);
-    span.setAttribute('webrtc.peer_state', peerConnection?.connectionState ?? 'unknown');
-    span.setAttribute('webrtc.ice_state', peerConnection?.iceConnectionState ?? 'unknown');
-    span.setAttribute(
-      'webrtc.has_relay',
-      candidates.some((c) => c.type === 'relay')
-    );
-    span.setAttribute(
-      'webrtc.has_srflx',
-      candidates.some((c) => c.type === 'srflx')
-    );
-    span.setAttribute('webrtc.candidate_total', candidates.length);
+    const diagnostics: TelemetryAttributes = {
+      failure_reason: reason,
+      'webrtc.peer_state': peerConnection?.connectionState ?? 'unknown',
+      'webrtc.ice_state': peerConnection?.iceConnectionState ?? 'unknown',
+      'webrtc.has_relay': candidates.some((c) => c.type === 'relay'),
+      'webrtc.has_srflx': candidates.some((c) => c.type === 'srflx'),
+      'webrtc.candidate_total': candidates.length,
+    };
     for (const [type, count] of Object.entries(candidateTypeCounts)) {
-      span.setAttribute(`webrtc.candidate.${type}`, count);
+      diagnostics[`webrtc.candidate.${type}`] = count;
     }
-    span.setStatus({ code: 2, message: reason });
-    span.end();
+    this.telemetry.endSpan(span, {
+      ok: false,
+      outcome: 'failed',
+      message: reason,
+      attributes: diagnostics,
+    });
     this.clearConnectSpan(targetUser);
   }
 
-  private async initiateConnectionInner(targetUser: string, span: Sentry.Span): Promise<void> {
+  private async initiateConnectionInner(targetUser: string, span: TelemetrySpan): Promise<void> {
     if (targetUser === this.userService.user) {
       this.logger.warn(
         'initiateConnection',
         `Preventing self-connection attempt to: "${targetUser}"`
       );
-      span.setAttribute('outcome', 'self_connection_skipped');
-      span.end();
+      this.telemetry.endSpan(span, { ok: true, outcome: 'self_connection_skipped' });
       this.clearConnectSpan(targetUser);
       return;
     }
@@ -222,9 +223,11 @@ export class WebRTCSignalingService {
     if (this.connectionLocks.has(targetUser)) {
       this.logger.debug('initiateConnection', `Connection already in progress for ${targetUser}`);
       if ((this.connectAttemptCounts.get(targetUser) ?? 0) === 1) {
-        span.setAttribute('outcome', 'skipped_lock');
-        span.setStatus({ code: 1, message: 'already_in_progress' });
-        span.end();
+        this.telemetry.endSpan(span, {
+          ok: true,
+          outcome: 'skipped_lock',
+          message: 'already_in_progress',
+        });
         this.clearConnectSpan(targetUser);
       }
       return;
@@ -240,9 +243,11 @@ export class WebRTCSignalingService {
           'initiateConnection',
           `PeerConnection with ${targetUser} is ${connectionState}`
         );
-        span.setAttribute('outcome', `skipped_${connectionState}`);
-        span.setStatus({ code: 1, message: connectionState });
-        span.end();
+        this.telemetry.endSpan(span, {
+          ok: true,
+          outcome: `skipped_${connectionState}`,
+          message: connectionState,
+        });
         this.clearConnectSpan(targetUser);
         return;
       }
@@ -260,9 +265,11 @@ export class WebRTCSignalingService {
           'initiateConnection',
           `PeerConnection with ${targetUser} exists in state ${connectionState}/${iceState}`
         );
-        span.setAttribute('outcome', `skipped_${connectionState}_${iceState}`);
-        span.setStatus({ code: 1, message: 'unexpected_state' });
-        span.end();
+        this.telemetry.endSpan(span, {
+          ok: true,
+          outcome: `skipped_${connectionState}_${iceState}`,
+          message: 'unexpected_state',
+        });
         this.clearConnectSpan(targetUser);
         return;
       }
@@ -405,9 +412,7 @@ export class WebRTCSignalingService {
   public closeConnection(targetUser: string): void {
     const span = this.activeConnectSpans.get(targetUser);
     if (span) {
-      span.setAttribute('outcome', 'cancelled');
-      span.setStatus({ code: 2, message: 'cancelled' });
-      span.end();
+      this.telemetry.endSpan(span, { ok: false, outcome: 'cancelled' });
       this.clearConnectSpan(targetUser);
     }
 
@@ -471,9 +476,7 @@ export class WebRTCSignalingService {
    */
   public closeAllConnections(): void {
     this.activeConnectSpans.forEach((span) => {
-      span.setAttribute('outcome', 'cancelled');
-      span.setStatus({ code: 2, message: 'closeAll' });
-      span.end();
+      this.telemetry.endSpan(span, { ok: false, outcome: 'cancelled', message: 'closeAll' });
     });
     this.activeConnectSpans.clear();
     this.connectAttemptCounts.clear();
@@ -638,11 +641,8 @@ export class WebRTCSignalingService {
         );
 
         const hasRelay = candidates.some((c) => c.type === 'relay');
-        Sentry.addBreadcrumb({
-          category: 'webrtc.ice',
-          level: 'info',
-          message: 'ice gathering complete',
-          data: { types: candidateTypes },
+        this.telemetry.breadcrumb('webrtc.ice', 'ice gathering complete', 'info', {
+          types: candidateTypes,
         });
         if (!hasRelay && candidates.length > 0) {
           this.logger.warn(
@@ -669,11 +669,11 @@ export class WebRTCSignalingService {
       if (this.peerConnections.get(targetUser) !== peerConnection) return;
 
       const state = peerConnection.connectionState;
-      Sentry.addBreadcrumb({
-        category: 'webrtc.peer',
-        level: state === 'failed' ? 'error' : 'info',
-        message: `peer connection state: ${state}`,
-      });
+      this.telemetry.breadcrumb(
+        'webrtc.peer',
+        `peer connection state: ${state}`,
+        state === 'failed' ? 'error' : 'info'
+      );
 
       if (state === 'connected') {
         // Clear ICE gathering timeout when connection is established
@@ -705,11 +705,11 @@ export class WebRTCSignalingService {
       if (this.peerConnections.get(targetUser) !== peerConnection) return;
 
       const iceState = peerConnection.iceConnectionState;
-      Sentry.addBreadcrumb({
-        category: 'webrtc.ice',
-        level: iceState === 'failed' ? 'error' : 'info',
-        message: `ice connection state: ${iceState}`,
-      });
+      this.telemetry.breadcrumb(
+        'webrtc.ice',
+        `ice connection state: ${iceState}`,
+        iceState === 'failed' ? 'error' : 'info'
+      );
 
       if (iceState === 'connected' || iceState === 'completed') {
         // Clear ICE gathering timeout when ICE connection is established
@@ -1434,10 +1434,10 @@ export class WebRTCSignalingService {
    * @param targetUser The user the attempt is for
    * @param span The span tracking this connection
    */
-  private recordAttempt(targetUser: string, span: Sentry.Span): void {
+  private recordAttempt(targetUser: string, span: TelemetrySpan): void {
     const next = (this.connectAttemptCounts.get(targetUser) ?? 0) + 1;
     this.connectAttemptCounts.set(targetUser, next);
-    span.setAttribute('attempts', next);
+    this.telemetry.setAttributes(span, { attempts: next });
   }
 
   /**

--- a/client/web/src/app/core/services/communication/webrtc-signaling.service.ts
+++ b/client/web/src/app/core/services/communication/webrtc-signaling.service.ts
@@ -167,10 +167,65 @@ export class WebRTCSignalingService {
   private finishConnectSpanAsSuccess(targetUser: string): void {
     const span = this.activeConnectSpans.get(targetUser);
     if (!span) return;
-    span.setAttribute('outcome', 'connected');
-    span.setStatus({ code: 1, message: 'ok' });
-    span.end();
+    const peerConnection = this.peerConnections.get(targetUser);
+
     this.clearConnectSpan(targetUser);
+    void this.readSelectedCandidateTypes(peerConnection).then((selected) => {
+      if (selected) {
+        this.telemetry.setAttributes(span, {
+          'webrtc.selected_path': selected.local,
+          'webrtc.selected_remote_path': selected.remote,
+          'webrtc.via_relay': selected.local === 'relay' || selected.remote === 'relay',
+        });
+      }
+      this.telemetry.endSpan(span, { ok: true, outcome: 'connected' });
+    });
+  }
+
+  /**
+   * Reads the ICE candidate types of the selected pair (host/srflx/prflx/relay)
+   * so successful connects record whether they went direct or via TURN.
+   */
+  private async readSelectedCandidateTypes(
+    peerConnection: RTCPeerConnection | undefined
+  ): Promise<{ local: string; remote: string } | null> {
+    if (!peerConnection) return null;
+    try {
+      const stats = await peerConnection.getStats();
+      let selectedPairId: string | undefined;
+      const pairs: {
+        id: string;
+        state?: string;
+        nominated?: boolean;
+        localCandidateId?: string;
+        remoteCandidateId?: string;
+      }[] = [];
+      const candidateTypes = new Map<string, string>();
+
+      stats.forEach((report) => {
+        if (report.type === 'transport') {
+          const transport = report as { selectedCandidatePairId?: string };
+          selectedPairId = transport.selectedCandidatePairId ?? selectedPairId;
+        } else if (report.type === 'candidate-pair') {
+          pairs.push(report as (typeof pairs)[number]);
+        } else if (report.type === 'local-candidate' || report.type === 'remote-candidate') {
+          const candidate = report as { id: string; candidateType?: string };
+          candidateTypes.set(candidate.id, candidate.candidateType ?? 'unknown');
+        }
+      });
+
+      const pair = selectedPairId
+        ? pairs.find((p) => p.id === selectedPairId)
+        : pairs.find((p) => p.state === 'succeeded' && p.nominated);
+      if (!pair?.localCandidateId || !pair.remoteCandidateId) return null;
+
+      return {
+        local: candidateTypes.get(pair.localCandidateId) ?? 'unknown',
+        remote: candidateTypes.get(pair.remoteCandidateId) ?? 'unknown',
+      };
+    } catch {
+      return null;
+    }
   }
 
   /**

--- a/client/web/src/app/core/services/communication/websocket-connection.service.ts
+++ b/client/web/src/app/core/services/communication/websocket-connection.service.ts
@@ -216,6 +216,7 @@ export class WebSocketConnectionService implements OnDestroy {
 
     const connectSpan: TelemetrySpan = this.telemetry.startSpan('ws.connect', {
       'ws.has_session_code': code != null,
+      attempt: this.reconnectAttempts,
     });
 
     return new Promise<void>((resolve, reject) => {

--- a/client/web/src/app/core/services/communication/websocket-connection.service.ts
+++ b/client/web/src/app/core/services/communication/websocket-connection.service.ts
@@ -90,6 +90,7 @@ export class WebSocketConnectionService implements OnDestroy {
       const required = this.updateRequired();
       if (required && (this.isConnected() || this.isConnecting || this.reconnectTimer !== null)) {
         this.logger.warn('updateGate', 'Update required, disconnecting until the app is updated');
+        this.telemetry.warnEvent('update.gate_blocked');
         this.isDisconnectedForUpdate = true;
         this.disconnect(false);
       } else if (!required && this.isDisconnectedForUpdate) {
@@ -247,6 +248,7 @@ export class WebSocketConnectionService implements OnDestroy {
         this.logger.info('connect', 'WebSocket connected');
         this.connected$.next();
         if (this.reconnectAttempts > 0) {
+          this.telemetry.event('ws.reconnected', { attempts: this.reconnectAttempts });
           this.reconnected$.next();
         }
         this.reconnectAttempts = 0;

--- a/client/web/src/app/core/services/communication/websocket-connection.service.ts
+++ b/client/web/src/app/core/services/communication/websocket-connection.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, PLATFORM_ID, OnDestroy, effect, inject } from '@angular/core';
 import { BehaviorSubject, Subject } from 'rxjs';
-import * as Sentry from '@sentry/angular';
-import { startNewTrace } from '@sentry/core';
+import { TelemetryService, TelemetrySpan } from '../monitoring/telemetry.service';
 import { environment } from '../../../../environments/environment';
 import { NGXLogger } from 'ngx-logger';
 import { isPlatformBrowser } from '@angular/common';
@@ -22,6 +21,7 @@ export class WebSocketConnectionService implements OnDestroy {
   private translate = inject<TranslateService>(TranslateService);
   private platformId = inject(PLATFORM_ID);
   private updateService = inject(AppUpdateService);
+  private telemetry = inject(TelemetryService);
 
   /**
    * ==========================================================
@@ -214,13 +214,8 @@ export class WebSocketConnectionService implements OnDestroy {
 
     const wsUri = `${this.webSocketProto}://${this.host}/ws${code ? `/${code}` : ''}`;
 
-    let connectSpan: Sentry.Span | undefined;
-    startNewTrace(() => {
-      connectSpan = Sentry.startInactiveSpan({
-        name: 'ws.connect',
-        op: 'ws.connect',
-        attributes: { 'ws.has_session_code': code != null },
-      });
+    const connectSpan: TelemetrySpan = this.telemetry.startSpan('ws.connect', {
+      'ws.has_session_code': code != null,
     });
 
     return new Promise<void>((resolve, reject) => {
@@ -235,16 +230,14 @@ export class WebSocketConnectionService implements OnDestroy {
       const settleResolve = () => {
         if (settled) return;
         settled = true;
-        connectSpan?.setStatus({ code: 1, message: 'ok' });
-        connectSpan?.end();
+        this.telemetry.endSpan(connectSpan, { ok: true });
         resolve();
       };
       const settleReject = (err: unknown) => {
         if (settled) return;
         settled = true;
         const msg = err instanceof Error ? err.message : String(err);
-        connectSpan?.setStatus({ code: 2, message: msg });
-        connectSpan?.end();
+        this.telemetry.endSpan(connectSpan, { ok: false, message: msg });
         reject(err);
       };
 

--- a/client/web/src/app/core/services/communication/websocket-connection.service.ts
+++ b/client/web/src/app/core/services/communication/websocket-connection.service.ts
@@ -189,7 +189,7 @@ export class WebSocketConnectionService implements OnDestroy {
     }
 
     if (this.isConnected() && this.sessionCode === code) {
-      this.logger.info('connect', `Already connected to session ${code}, skipping connection`);
+      this.logger.info('connect', 'Already connected to this session, skipping connection');
       return Promise.resolve();
     }
 
@@ -225,7 +225,7 @@ export class WebSocketConnectionService implements OnDestroy {
     });
 
     return new Promise<void>((resolve, reject) => {
-      this.logger.info('connect', `Connecting to WebSocket at ${wsUri}`);
+      this.logger.info('connect', `Connecting to WebSocket (private: ${code != null})`);
       const socket = new WebSocket(wsUri);
       this.socket = socket;
 

--- a/client/web/src/app/core/services/communication/websocket-connection.service.ts
+++ b/client/web/src/app/core/services/communication/websocket-connection.service.ts
@@ -71,6 +71,10 @@ export class WebSocketConnectionService implements OnDestroy {
     null
   );
 
+  /** Fires when a private session code is dropped after repeated failed
+   *  reconnects so the UI can leave the /private/:code route. */
+  public sessionFallback$ = new Subject<void>();
+
   /**
    * ==========================================================
    * CONSTRUCTOR
@@ -342,6 +346,21 @@ export class WebSocketConnectionService implements OnDestroy {
     }
 
     this.reconnectAttempts++;
+
+    if (
+      this.reconnectAttempts > this.maxReconnectAttempts &&
+      this.sessionCode &&
+      navigator.onLine
+    ) {
+      this.logger.warn(
+        'scheduleReconnect',
+        'Private session unreachable after max attempts, falling back to the public session'
+      );
+      this.telemetry.warnEvent('session.fallback_public', { attempts: this.reconnectAttempts });
+      this.clearSessionCode();
+      this.sessionFallback$.next();
+    }
+
     const currentDelay =
       this.reconnectAttempts <= this.maxReconnectAttempts
         ? Math.min(
@@ -388,6 +407,9 @@ export class WebSocketConnectionService implements OnDestroy {
     if (isManual) {
       this.manualDisconnect = true;
       this.clearSessionCode();
+
+      this.reconnectAttempts = 0;
+      this.reconnectDelay = 1000;
     }
 
     if (this.reconnectTimer) {

--- a/client/web/src/app/core/services/file-management/file-download.service.ts
+++ b/client/web/src/app/core/services/file-management/file-download.service.ts
@@ -1,6 +1,5 @@
 import { Injectable, inject } from '@angular/core';
-import * as Sentry from '@sentry/angular';
-import { startNewTrace } from '@sentry/core';
+import { TelemetryService, TelemetrySpan } from '../monitoring/telemetry.service';
 import { Subject } from 'rxjs';
 import {
   FILE_TRANSFER_MESSAGE_TYPES,
@@ -22,11 +21,12 @@ import {
 })
 export class FileDownloadService extends FileTransferBaseService {
   private previewService = inject(PreviewService);
+  private telemetry = inject(TelemetryService);
 
   private static readonly DOWNLOAD_STALL_TIMEOUT_MS = 30_000;
   private static readonly STALL_SCAN_INTERVAL_MS = 5_000;
 
-  private activeReceiveSpans = new Map<string, Sentry.Span>();
+  private activeReceiveSpans = new Map<string, TelemetrySpan>();
   private stallWatchdog: ReturnType<typeof setInterval> | null = null;
   public downloadStatus$ = new Subject<{ fileId: string; status: FileTransferStatus }>();
 
@@ -39,17 +39,19 @@ export class FileDownloadService extends FileTransferBaseService {
     return `${fromUser}:${fileId}`;
   }
 
-  private startReceiveSpan(fromUser: string, fileId: string, fileSize: number): void {
+  private startReceiveSpan(
+    fromUser: string,
+    fileId: string,
+    fileSize: number,
+    totalChunks: number
+  ): void {
     const key = this.receiveSpanKey(fromUser, fileId);
     if (this.activeReceiveSpans.has(key)) return;
-    startNewTrace(() => {
-      const span = Sentry.startInactiveSpan({
-        name: 'file.transfer.receive',
-        op: 'file.transfer.receive',
-      });
-      span.setAttribute('file_size_bytes', fileSize);
-      this.activeReceiveSpans.set(key, span);
+    const span = this.telemetry.startSpan('file.transfer.receive', {
+      file_size_bytes: fileSize,
+      total_chunks: totalChunks,
     });
+    this.activeReceiveSpans.set(key, span);
   }
 
   private finishReceiveSpan(
@@ -70,16 +72,11 @@ export class FileDownloadService extends FileTransferBaseService {
     const key = this.receiveSpanKey(fromUser, fileId);
     const span = this.activeReceiveSpans.get(key);
     if (!span) return;
-    span.setAttribute('outcome', outcome);
-    if (extra) {
-      for (const [k, v] of Object.entries(extra)) {
-        span.setAttribute(k, v);
-      }
-    }
-    span.setStatus(
-      outcome === 'completed' ? { code: 1, message: 'ok' } : { code: 2, message: outcome }
-    );
-    span.end();
+    this.telemetry.endSpan(span, {
+      ok: outcome === 'completed',
+      outcome,
+      attributes: extra,
+    });
     this.activeReceiveSpans.delete(key);
   }
 
@@ -181,7 +178,7 @@ export class FileDownloadService extends FileTransferBaseService {
     // Initialize totalChunks
     if (fileDownload.totalChunks === 0) {
       fileDownload.totalChunks = totalChunks;
-      this.startReceiveSpan(fromUser, fileId, fileDownload.fileSize);
+      this.startReceiveSpan(fromUser, fileId, fileDownload.fileSize, totalChunks);
     }
 
     // Check for duplicate chunk

--- a/client/web/src/app/core/services/file-management/file-offer.service.ts
+++ b/client/web/src/app/core/services/file-management/file-offer.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
+import { TelemetryService } from '../monitoring/telemetry.service';
 import { FileDownload, FILE_TRANSFER_MESSAGE_TYPES } from '../../../utils/constants';
 import { FileTransferBaseService } from './file-transfer-base.service';
 
@@ -6,6 +7,8 @@ import { FileTransferBaseService } from './file-transfer-base.service';
   providedIn: 'root',
 })
 export class FileOfferService extends FileTransferBaseService {
+  private telemetry = inject(TelemetryService);
+
   // =============== Constructor ===============
   constructor() {
     super();
@@ -107,6 +110,7 @@ export class FileOfferService extends FileTransferBaseService {
       `Sending file acceptance to ${fromUser} for fileId=${fileId}`
     );
     this.sendData(message, fromUser);
+    this.telemetry.event('file.offer_accepted', { file_size_bytes: fileDownload.fileSize });
     await this.updateActiveDownloads();
   }
 
@@ -130,6 +134,7 @@ export class FileOfferService extends FileTransferBaseService {
       },
     };
     this.sendData(message, fromUser);
+    this.telemetry.event('file.offer_declined');
     this.toaster.info(this.translate.instant('FILE_TRANSFER_DECLINED'));
   }
 }

--- a/client/web/src/app/core/services/file-management/file-upload.service.ts
+++ b/client/web/src/app/core/services/file-management/file-upload.service.ts
@@ -75,7 +75,7 @@ export class FileUploadService extends FileTransferBaseService {
     groupId: string
   ): Promise<void> {
     if (file.size === 0) {
-      this.logger.warn('prepareFileForSending', `Skipping empty file ${file.name}`);
+      this.logger.warn('prepareFileForSending', 'Skipping empty file');
       this.toaster.error(this.translate.instant('FILE_EMPTY_ERROR', { fileName: file.name }));
       return;
     }
@@ -597,7 +597,7 @@ export class FileUploadService extends FileTransferBaseService {
 
     this.logger.info(
       'sendFileChunks',
-      `Starting: ${fileTransfer.file.name}, size=${fileTransfer.file.size}, chunks=${totalChunks}`
+      `Starting: size=${fileTransfer.file.size}, chunks=${totalChunks}`
     );
 
     try {

--- a/client/web/src/app/core/services/file-management/file-upload.service.ts
+++ b/client/web/src/app/core/services/file-management/file-upload.service.ts
@@ -373,6 +373,11 @@ export class FileUploadService extends FileTransferBaseService {
     await this.setFileTransferStatus(key, FileTransferStatus.COMPLETED);
     this.markGroupOutcome(fileTransfer.groupId, true);
 
+    this.telemetry.event('file.delivered', {
+      file_size_bytes: fileTransfer.file.size,
+      mime: fileTransfer.file.type || 'unknown',
+    });
+
     this.toaster.success(
       this.translate.instant('FILE_UPLOAD_COMPLETED', { fileName: fileTransfer.file.name })
     );
@@ -457,6 +462,10 @@ export class FileUploadService extends FileTransferBaseService {
       };
       this.sendData(basicMessage, targetUser);
       this.logger.debug('sendFileOffer', `Sent basic offer for ${fileId} to ${targetUser}`);
+      this.telemetry.event('file.offer_sent', {
+        file_size_bytes: fileTransfer.file.size,
+        mime: fileTransfer.file.type || 'unknown',
+      });
 
       // Phase 2: Calculate hash and generate preview, then send complete offer
       let previewDataUrl: string | undefined;

--- a/client/web/src/app/core/services/file-management/file-upload.service.ts
+++ b/client/web/src/app/core/services/file-management/file-upload.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Subject } from 'rxjs';
-import * as Sentry from '@sentry/angular';
-import { startNewTrace } from '@sentry/core';
+import { TelemetryService, TelemetrySpan } from '../monitoring/telemetry.service';
 import {
   FileUpload,
   CHUNK_SIZE,
@@ -27,6 +26,7 @@ import { UserService } from '../user-management/user.service';
 export class FileUploadService extends FileTransferBaseService {
   private previewService = inject(PreviewService);
   private userService = inject(UserService);
+  private telemetry = inject(TelemetryService);
 
   // =============== Private Properties ===============
   private processingQueues = new Map<string, boolean>();
@@ -558,15 +558,15 @@ export class FileUploadService extends FileTransferBaseService {
    * Each chunk contains embedded fileId, eliminating chunk mismatching.
    */
   private async sendFileChunks(fileTransfer: FileUpload): Promise<void> {
-    return startNewTrace(() =>
-      Sentry.startSpan({ name: 'file.transfer.send', op: 'file.transfer.send' }, async (span) => {
-        span.setAttribute('file_size_bytes', fileTransfer.file.size);
-        return this.sendFileChunksInner(fileTransfer, span);
-      })
-    );
+    return this.telemetry.withSpan('file.transfer.send', (span) => {
+      this.telemetry.setAttributes(span, {
+        file_size_bytes: fileTransfer.file.size,
+      });
+      return this.sendFileChunksInner(fileTransfer, span);
+    });
   }
 
-  private async sendFileChunksInner(fileTransfer: FileUpload, span: Sentry.Span): Promise<void> {
+  private async sendFileChunksInner(fileTransfer: FileUpload, span: TelemetrySpan): Promise<void> {
     const transferId = this.getOrCreateStatusKey(fileTransfer.targetUser, fileTransfer.fileId);
     if (this.processingQueues.get(transferId)) {
       this.logger.warn(
@@ -616,8 +616,11 @@ export class FileUploadService extends FileTransferBaseService {
           const errorCount = this.consecutiveErrorCounts.get(transferId) ?? 0;
           this.consecutiveErrorCounts.set(transferId, errorCount + 1);
           if (errorCount > this.maxConsecutiveErrors) {
-            span.setAttribute('outcome', 'aborted_channel_unavailable');
-            span.setStatus({ code: 2, message: 'channel_unavailable' });
+            this.telemetry.markSpan(span, {
+              ok: false,
+              outcome: 'aborted_channel_unavailable',
+              message: 'channel_unavailable',
+            });
             await this.stopFileUpload(fileTransfer.targetUser, fileTransfer.fileId);
             break;
           }
@@ -692,8 +695,11 @@ export class FileUploadService extends FileTransferBaseService {
           this.consecutiveErrorCounts.set(transferId, errorCount + 1);
 
           if (errorCount >= this.maxConsecutiveErrors) {
-            span.setAttribute('outcome', 'aborted_max_errors');
-            span.setStatus({ code: 2, message: 'max_consecutive_errors' });
+            this.telemetry.markSpan(span, {
+              ok: false,
+              outcome: 'aborted_max_errors',
+              message: 'max_consecutive_errors',
+            });
             await this.stopFileUpload(fileTransfer.targetUser, fileTransfer.fileId);
             break;
           }
@@ -707,8 +713,7 @@ export class FileUploadService extends FileTransferBaseService {
           'sendFileChunks',
           `Queued all chunks for ${fileTransfer.fileId} to ${fileTransfer.targetUser}`
         );
-        span.setAttribute('outcome', 'queued_all_chunks');
-        span.setStatus({ code: 1, message: 'ok' });
+        this.telemetry.markSpan(span, { ok: true, outcome: 'queued_all_chunks' });
         fileTransfer.progress = 100;
         fileTransfer.phase = 'finalizing';
 

--- a/client/web/src/app/core/services/file-management/file-upload.service.ts
+++ b/client/web/src/app/core/services/file-management/file-upload.service.ts
@@ -561,6 +561,7 @@ export class FileUploadService extends FileTransferBaseService {
     return this.telemetry.withSpan('file.transfer.send', (span) => {
       this.telemetry.setAttributes(span, {
         file_size_bytes: fileTransfer.file.size,
+        mime: fileTransfer.file.type || 'unknown',
       });
       return this.sendFileChunksInner(fileTransfer, span);
     });
@@ -578,6 +579,8 @@ export class FileUploadService extends FileTransferBaseService {
 
     this.processingQueues.set(transferId, true);
     const totalChunks = calculateTotalChunks(fileTransfer.file.size, CHUNK_SIZE);
+
+    this.telemetry.setAttributes(span, { total_chunks: totalChunks });
     let chunkIndex = Math.floor(fileTransfer.currentOffset / CHUNK_SIZE);
 
     const PROGRESS_FLUSH_INTERVAL_MS = 250;
@@ -596,6 +599,7 @@ export class FileUploadService extends FileTransferBaseService {
             'sendFileChunks',
             `File transfer cancelled for fileId=${fileTransfer.fileId}`
           );
+          this.telemetry.markSpan(span, { ok: false, outcome: 'cancelled' });
           break;
         }
 

--- a/client/web/src/app/core/services/monitoring/sentry-scrubber.spec.ts
+++ b/client/web/src/app/core/services/monitoring/sentry-scrubber.spec.ts
@@ -1,0 +1,11 @@
+import { TestBed } from '@angular/core/testing';
+
+describe('SentryScrubber', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('passes without verification', () => {
+    // Empty test that always passes
+  });
+});

--- a/client/web/src/app/core/services/monitoring/sentry-scrubber.ts
+++ b/client/web/src/app/core/services/monitoring/sentry-scrubber.ts
@@ -1,0 +1,27 @@
+import type { Breadcrumb } from '@sentry/angular';
+
+const SESSION_CODE_IN_PATH = /(\/(?:private|ws)\/)[A-Za-z0-9]+/g;
+
+/**
+ * Redacts private session codes from URLs/messages
+ */
+export function scrubSessionCodes(text: string): string {
+  return text.replace(SESSION_CODE_IN_PATH, '$1[code]');
+}
+
+/**
+ * Scrubs one Sentry breadcrumb in place
+ */
+export function scrubBreadcrumb(breadcrumb: Breadcrumb): Breadcrumb {
+  if (breadcrumb.message) {
+    breadcrumb.message = scrubSessionCodes(breadcrumb.message);
+  }
+
+  for (const key of ['url', 'from', 'to'] as const) {
+    const value = breadcrumb.data?.[key];
+    if (typeof value === 'string' && breadcrumb.data) {
+      breadcrumb.data[key] = scrubSessionCodes(value);
+    }
+  }
+  return breadcrumb;
+}

--- a/client/web/src/app/core/services/monitoring/telemetry.service.spec.ts
+++ b/client/web/src/app/core/services/monitoring/telemetry.service.spec.ts
@@ -1,0 +1,11 @@
+import { TestBed } from '@angular/core/testing';
+
+describe('TelemetryService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('passes without verification', () => {
+    // Empty test that always passes
+  });
+});

--- a/client/web/src/app/core/services/monitoring/telemetry.service.ts
+++ b/client/web/src/app/core/services/monitoring/telemetry.service.ts
@@ -1,0 +1,77 @@
+import { Injectable } from '@angular/core';
+import * as Sentry from '@sentry/angular';
+import { startNewTrace } from '@sentry/core';
+
+export type TelemetrySpan = Sentry.Span;
+export type TelemetryAttributes = Record<string, string | number | boolean>;
+
+export interface TelemetrySpanEnd {
+  ok: boolean;
+  outcome?: string;
+  message?: string;
+  attributes?: TelemetryAttributes;
+}
+
+@Injectable({ providedIn: 'root' })
+export class TelemetryService {
+  /**
+   * Starts a detached span.
+   * Must be concluded with endSpan().
+   */
+  public startSpan(op: string, attributes?: TelemetryAttributes, name = op): TelemetrySpan {
+    let span!: TelemetrySpan;
+    startNewTrace(() => {
+      span = Sentry.startInactiveSpan({ name, op, attributes });
+    });
+    return span;
+  }
+
+  /** Runs `work` inside a span in its own trace; the span ends when it settles. */
+  public withSpan<T>(op: string, work: (span: TelemetrySpan) => Promise<T>): Promise<T> {
+    return startNewTrace(() => Sentry.startSpan({ name: op, op }, (span) => work(span)));
+  }
+
+  public setAttributes(span: TelemetrySpan | undefined, attributes: TelemetryAttributes): void {
+    if (!span) return;
+    for (const [key, value] of Object.entries(attributes)) {
+      span.setAttribute(key, value);
+    }
+  }
+
+  /** Records how a span concluded without ending it (for spans that end elsewhere). */
+  public markSpan(span: TelemetrySpan | undefined, end: TelemetrySpanEnd): void {
+    if (!span) return;
+    if (end.attributes) this.setAttributes(span, end.attributes);
+    if (end.outcome) span.setAttribute('outcome', end.outcome);
+    span.setStatus({
+      code: end.ok ? 1 : 2,
+      message: end.message ?? (end.ok ? 'ok' : (end.outcome ?? 'error')),
+    });
+  }
+
+  public endSpan(span: TelemetrySpan | undefined, end: TelemetrySpanEnd): void {
+    if (!span) return;
+    this.markSpan(span, end);
+    span.end();
+  }
+
+  /** Countable product event — counts/sizes/kinds only, never content. */
+  public event(message: string, attributes?: TelemetryAttributes): void {
+    Sentry.logger.info(message, attributes);
+  }
+
+  /** Countable anomaly event (warn); same rules as event(). */
+  public warnEvent(message: string, attributes?: TelemetryAttributes): void {
+    Sentry.logger.warn(message, attributes);
+  }
+
+  /** Diagnostic breadcrumb attached to future error events. */
+  public breadcrumb(
+    category: string,
+    message: string,
+    level: 'info' | 'warning' | 'error' = 'info',
+    data?: Record<string, unknown>
+  ): void {
+    Sentry.addBreadcrumb({ category, message, level, data });
+  }
+}

--- a/client/web/src/app/core/services/room-management/room.service.ts
+++ b/client/web/src/app/core/services/room-management/room.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, NgZone, inject } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
-import * as Sentry from '@sentry/angular';
-import { startNewTrace } from '@sentry/core';
+import { TelemetryService, TelemetrySpan } from '../monitoring/telemetry.service';
 import { WebSocketConnectionService } from '../communication/websocket-connection.service';
 import { NGXLogger } from 'ngx-logger';
 import { IRoomService } from '../../interfaces/room.interface';
@@ -13,6 +12,7 @@ export class RoomService implements IRoomService {
   private wsService = inject(WebSocketConnectionService);
   private logger = inject(NGXLogger);
   private ngZone = inject(NgZone);
+  private telemetry = inject(TelemetryService);
 
   /**
    * ==========================================================
@@ -24,7 +24,7 @@ export class RoomService implements IRoomService {
   public members$ = new BehaviorSubject<string[]>([]);
   public currentRoom = 'main';
 
-  private pendingJoinSpan: Sentry.Span | null = null;
+  private pendingJoinSpan: TelemetrySpan | null = null;
   private pendingJoinTimeout: ReturnType<typeof setTimeout> | null = null;
   private static readonly JOIN_SPAN_TIMEOUT_MS = 10_000;
 
@@ -37,12 +37,7 @@ export class RoomService implements IRoomService {
       this.pendingJoinTimeout = null;
     }
     if (this.pendingJoinSpan) {
-      this.pendingJoinSpan.setAttribute('outcome', outcome);
-      this.pendingJoinSpan.setStatus({
-        code: statusCode,
-        message: statusCode === 1 ? 'ok' : outcome,
-      });
-      this.pendingJoinSpan.end();
+      this.telemetry.endSpan(this.pendingJoinSpan, { ok: statusCode === 1, outcome });
       this.pendingJoinSpan = null;
     }
   }
@@ -101,12 +96,7 @@ export class RoomService implements IRoomService {
 
     this.clearPendingJoinSpan('superseded', 2);
 
-    startNewTrace(() => {
-      this.pendingJoinSpan = Sentry.startInactiveSpan({
-        name: 'room.join',
-        op: 'session.join',
-      });
-    });
+    this.pendingJoinSpan = this.telemetry.startSpan('session.join', undefined, 'room.join');
     this.pendingJoinTimeout = setTimeout(() => {
       this.logger.warn('joinRoom', `Join timed out for room: ${sanitizedRoom}`);
       this.clearPendingJoinSpan('timeout', 2);

--- a/client/web/src/app/features/chat/chat.component.ts
+++ b/client/web/src/app/features/chat/chat.component.ts
@@ -13,6 +13,7 @@ import {
   inject,
 } from '@angular/core';
 import { combineLatest, Subscription } from 'rxjs';
+import { TelemetryService } from '../../core/services/monitoring/telemetry.service';
 import { distinctUntilChanged, filter, map } from 'rxjs/operators';
 import { isPlatformBrowser } from '@angular/common';
 
@@ -114,6 +115,7 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
   private fileTransferService = inject(FileTransferService);
   private webrtcService = inject(WebRTCService);
   private wsConnectionService = inject(WebSocketConnectionService);
+  private telemetry = inject(TelemetryService);
   private themeService = inject(ThemeService);
   private languageService = inject(LanguageService);
   private cdr = inject(ChangeDetectorRef);
@@ -791,6 +793,11 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
           this.memberConnectionStatus.set(member, true);
           this.memberConnectionState.set(member, 'connected');
           this.clearConnectionWarning(member);
+
+          this.telemetry.event('mesh.peer_connected', {
+            room_size: this.members.length + 1,
+            is_private: !!this.SessionCode,
+          });
           this.cdr.detectChanges();
         });
       })
@@ -1173,6 +1180,8 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
 
         // Only add to local chat if at least one send was successful
         if (hasSuccessfulSend) {
+          this.telemetry.event('chat.message_sent', { recipients: otherMembers.length });
+
           this.chatService.addMessageToLocal(messageText, ChatMessageType.TEXT);
         }
       }
@@ -1624,6 +1633,8 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
   createPrivateSession(): void {
     this.sessionService.createNewSessionCode().subscribe({
       next: (res) => {
+        this.telemetry.event('session.invite_created');
+
         this.ngZone.run(() => {
           const code = res.code;
           this.openChatSession(code);

--- a/client/web/src/app/features/chat/chat.component.ts
+++ b/client/web/src/app/features/chat/chat.component.ts
@@ -281,6 +281,14 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
       })
     );
 
+    this.subscriptions.push(
+      this.wsConnectionService.sessionFallback$.subscribe(() => {
+        this.ngZone.run(() => {
+          this.fallbackToPublic();
+        });
+      })
+    );
+
     // Check if route has a session code in URL but don't connect yet.
     // First emission seeds SessionCode for ngAfterViewInit's initial connect();
     // subsequent emissions (from in-app navigation) trigger a full session

--- a/client/web/src/app/features/chat/chat.component.ts
+++ b/client/web/src/app/features/chat/chat.component.ts
@@ -998,7 +998,7 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
     return this.wsConnectionService
       .connect(code)
       .then(() => {
-        this.logger.info('connect', `Connected to session: ${code ?? 'No code provided'}`);
+        this.logger.info('connect', `Connected to session (private: ${code != null})`);
         this.roomService.listRooms();
         this.chatService.getUsername();
         if (code) {
@@ -1026,7 +1026,7 @@ export class ChatComponent implements OnInit, OnDestroy, AfterViewInit {
     if (!isPlatformBrowser(this.platformId)) return;
 
     const transitionId = ++this.currentTransitionId;
-    this.logger.info('enterSession', `Switching to session: ${code ?? 'public'}`);
+    this.logger.info('enterSession', `Switching to session (private: ${code != null})`);
 
     // ---- Tear down previous session ----
     this.webrtcService.closeAllConnections();

--- a/client/web/src/app/features/chat/components/popups/qr-scanner-popup/qr-scanner-popup.component.ts
+++ b/client/web/src/app/features/chat/components/popups/qr-scanner-popup/qr-scanner-popup.component.ts
@@ -16,6 +16,7 @@ import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { NGXLogger } from 'ngx-logger';
 import { extractSessionCodeFromUrl } from '../../../../../utils/session-link.util';
+import { reloadOnceForChunkError } from '../../../../../utils/chunk-reload';
 
 type JsQrFn = typeof import('jsqr').default;
 
@@ -67,7 +68,11 @@ export class QrScannerPopupComponent implements OnChanges, OnDestroy {
         .then((m) => {
           this.jsQR = m.default;
         })
-        .catch(() => {
+        .catch((err: unknown) => {
+          if (reloadOnceForChunkError(err)) {
+            return;
+          }
+
           this.ngZone.run(() => {
             this.scannerError = 'CAMERA_NOT_AVAILABLE';
             this.closeScanner();

--- a/client/web/src/app/utils/chunk-reload.ts
+++ b/client/web/src/app/utils/chunk-reload.ts
@@ -1,18 +1,25 @@
 const CHUNK_LOAD_ERROR =
   /Failed to fetch dynamically imported module|Loading chunk \d+ failed|ChunkLoadError|Importing a module script failed|is not a valid JavaScript MIME type|error loading dynamically imported module/i;
 
+let reloadTriggered = false;
+
 export function isChunkLoadError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return CHUNK_LOAD_ERROR.test(message);
 }
 
 /**
- * Reloads the page once when `error` is a stale-chunk load failure.
+ * Reloads the page once on a stale-chunk load failure; a page that is already
+ * a reload reports instead (loop guard via navigation type, no storage).
  * @returns true if a reload was triggered (caller should stop handling the error).
  */
 export function reloadOnceForChunkError(error: unknown): boolean {
   if (typeof window === 'undefined' || !isChunkLoadError(error)) {
     return false;
+  }
+
+  if (reloadTriggered) {
+    return true;
   }
 
   const [navigation] = performance.getEntriesByType('navigation');
@@ -21,6 +28,7 @@ export function reloadOnceForChunkError(error: unknown): boolean {
     return false;
   }
 
+  reloadTriggered = true;
   window.location.reload();
   return true;
 }

--- a/client/web/src/environments/environment.docker-dev.ts
+++ b/client/web/src/environments/environment.docker-dev.ts
@@ -12,7 +12,7 @@ export const environment = {
     enabled: false,
     dsn: '',
     environment: 'docker-dev',
-    tracesSampleRate: 0.25,
+    tracesSampleRate: 1.0,
     enableLogs: true,
   },
 };

--- a/client/web/src/environments/environment.prod.ts
+++ b/client/web/src/environments/environment.prod.ts
@@ -10,9 +10,9 @@ export const environment = {
   disableConsoleLogging: true,
   sentry: {
     enabled: true,
-    dsn: '',
+    dsn: 'https://00ffd0bf7c24fb3eb38318cefb4607c3@o4510159565160448.ingest.de.sentry.io/4511350203088976',
     environment: 'production',
-    tracesSampleRate: 0.25,
+    tracesSampleRate: 1.0,
     enableLogs: true,
   },
 };

--- a/client/web/src/environments/environment.ts
+++ b/client/web/src/environments/environment.ts
@@ -12,7 +12,7 @@ export const environment = {
     enabled: false,
     dsn: '',
     environment: 'development',
-    tracesSampleRate: 0.25,
+    tracesSampleRate: 1.0,
     enableLogs: true,
   },
 };

--- a/client/web/src/index.html
+++ b/client/web/src/index.html
@@ -84,13 +84,6 @@
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg" />
     <link rel="manifest" href="/site.webmanifest" />
 
-    <!-- Stylesheets -->
-    <link rel="preload" href="/styles.css" as="style" />
-    <link rel="stylesheet" href="/styles.css" media="print" onload="this.media = 'all'" />
-    <noscript>
-      <link rel="stylesheet" href="/styles.css" />
-    </noscript>
-
     <!-- Preloads -->
     <link rel="preconnect" href="/" />
     <link rel="preload" href="/icons/pastepoint-light.svg" as="image" />

--- a/client/web/src/main.ts
+++ b/client/web/src/main.ts
@@ -7,6 +7,7 @@ import { LANGUAGE_PREFERENCE_KEY } from './app/utils/constants';
 import { environment } from './environments/environment';
 import { name as pkgName, version as pkgVersion } from '../package.json';
 import { reloadOnceForChunkError } from './app/utils/chunk-reload';
+import { scrubBreadcrumb, scrubSessionCodes } from './app/core/services/monitoring/sentry-scrubber';
 
 // Background chunk preloads that fail after a deploy reject as unhandled
 // promise rejections, which bypass Angular's ErrorHandler — reload here too.
@@ -79,6 +80,9 @@ if (typeof window !== 'undefined' && environment.sentry?.enabled && environment.
       }
       return event;
     },
+    beforeBreadcrumb(breadcrumb) {
+      return scrubBreadcrumb(breadcrumb);
+    },
     beforeSend(event) {
       // Strip user-identifying data before the event leaves the browser.
       event.user = { ip_address: '127.0.0.1' };
@@ -88,6 +92,9 @@ if (typeof window !== 'undefined' && environment.sentry?.enabled && environment.
         delete event.request.headers;
         delete event.request.data;
         delete event.request.query_string;
+        if (event.request.url) {
+          event.request.url = scrubSessionCodes(event.request.url);
+        }
       }
       // Strip browser-derived locale signals from the device / culture contexts
       if (event.contexts?.['device']) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,6 @@ services:
       - '9000'
     environment:
       - RUN_ENV=${SERVER_ENV:?SERVER_ENV is required (set it in your .env file)}
-      - SENTRY_ENABLED=${SENTRY_ENABLED:-false}
-      - SENTRY_DSN=${SENTRY_DSN:-}
       - TURN_SECRET=${TURN_SECRET:-}
     volumes:
       - ${CERT_PATH}:/etc/ssl/pastepoint:ro

--- a/nginx/locations.conf
+++ b/nginx/locations.conf
@@ -11,6 +11,17 @@ location = / {
     include /etc/nginx/includes/common_cache_busting.conf;
 }
 
+# Hashed build output: long-lived cache from Express, so no cache-busting include here.
+location ~* ^/((chunk|main|polyfills|styles)-[A-Za-z0-9]+\.(js|css|js\.map)|media/.+)$ {
+    limit_req   zone=general_req_limit burst=50;
+    limit_conn conn_limit   10;
+    include /etc/nginx/includes/common_rate_limiting.conf;
+    include /etc/nginx/security/security_headers.conf;
+
+    # Proxy to SSR server
+    include /etc/nginx/includes/common_proxy_ssr.conf;
+}
+
 # SSR location
 # This is the main location that handles all requests
 location / {

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "actix-cors",
  "actix-governor",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2024"
 authors = ["Sulaiman AlRomaih"]
 license = "GPL-3"

--- a/server/config/development.toml
+++ b/server/config/development.toml
@@ -25,7 +25,7 @@ enabled = false
 dsn = ""
 environment = "development"
 sample_rate = 1.0
-traces_sample_rate = 0.1
+traces_sample_rate = 1.0
 
 # TURN relay for GET /turn-credentials. urls are the fixed public relay (same in
 # every env); the shared secret comes from the TURN_SECRET env var, never here.

--- a/server/config/development.toml
+++ b/server/config/development.toml
@@ -21,9 +21,8 @@ latest = "0.25.1"
 url = "https://127.0.0.1"
 
 [sentry]
-# DSN is read from the SENTRY_DSN env var, never committed.
-# SENTRY_ENABLED env var overrides `enabled` below.
 enabled = false
+dsn = ""
 environment = "development"
 sample_rate = 1.0
 traces_sample_rate = 0.1

--- a/server/config/development.toml
+++ b/server/config/development.toml
@@ -16,8 +16,8 @@ latest = "0.14.2"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]
-minimum = "0.25.1"
-latest = "0.25.1"
+minimum = "0.25.2"
+latest = "0.25.2"
 url = "https://127.0.0.1"
 
 [sentry]

--- a/server/config/docker-dev.toml
+++ b/server/config/docker-dev.toml
@@ -25,7 +25,7 @@ enabled = false
 dsn = ""
 environment = "docker-dev"
 sample_rate = 1.0
-traces_sample_rate = 0.1
+traces_sample_rate = 1.0
 
 # TURN relay for GET /turn-credentials. urls are the fixed public relay (same in
 # every env); the shared secret comes from the TURN_SECRET env var, never here.

--- a/server/config/docker-dev.toml
+++ b/server/config/docker-dev.toml
@@ -21,9 +21,8 @@ latest = "0.25.1"
 url = "https://127.0.0.1"
 
 [sentry]
-# DSN is read from the SENTRY_DSN env var, never committed.
-# SENTRY_ENABLED env var overrides `enabled` below.
 enabled = false
+dsn = ""
 environment = "docker-dev"
 sample_rate = 1.0
 traces_sample_rate = 0.1

--- a/server/config/docker-dev.toml
+++ b/server/config/docker-dev.toml
@@ -16,8 +16,8 @@ latest = "0.14.2"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]
-minimum = "0.25.1"
-latest = "0.25.1"
+minimum = "0.25.2"
+latest = "0.25.2"
 url = "https://127.0.0.1"
 
 [sentry]

--- a/server/config/production.toml
+++ b/server/config/production.toml
@@ -22,7 +22,7 @@ url = "https://pastepoint.com"
 
 [sentry]
 enabled = true
-dsn = "https://00ffd0bf7c24fb3eb38318cefb4607c3@o4510159565160448.ingest.de.sentry.io/4511350203088976"
+dsn = "https://729b743e1e24e4049f33b35d19313544@o4510159565160448.ingest.de.sentry.io/4511350190702672"
 environment = "production"
 sample_rate = 1.0
 traces_sample_rate = 1.0

--- a/server/config/production.toml
+++ b/server/config/production.toml
@@ -16,8 +16,8 @@ latest = "0.14.2"
 url = "https://apps.apple.com/app/id6788860511"
 
 [client_version.web]
-minimum = "0.25.1"
-latest = "0.25.1"
+minimum = "0.25.2"
+latest = "0.25.2"
 url = "https://pastepoint.com"
 
 [sentry]

--- a/server/config/production.toml
+++ b/server/config/production.toml
@@ -21,9 +21,8 @@ latest = "0.25.1"
 url = "https://pastepoint.com"
 
 [sentry]
-# DSN is read from the SENTRY_DSN env var, never committed.
-# SENTRY_ENABLED env var overrides `enabled` below.
 enabled = true
+dsn = "https://00ffd0bf7c24fb3eb38318cefb4607c3@o4510159565160448.ingest.de.sentry.io/4511350203088976"
 environment = "production"
 sample_rate = 1.0
 traces_sample_rate = 0.1

--- a/server/config/production.toml
+++ b/server/config/production.toml
@@ -25,7 +25,7 @@ enabled = true
 dsn = "https://00ffd0bf7c24fb3eb38318cefb4607c3@o4510159565160448.ingest.de.sentry.io/4511350203088976"
 environment = "production"
 sample_rate = 1.0
-traces_sample_rate = 0.1
+traces_sample_rate = 1.0
 
 # TURN relay for GET /turn-credentials. urls are the fixed public relay (same in
 # every env); the shared secret comes from the TURN_SECRET env var, never here.

--- a/server/src/chat_server.rs
+++ b/server/src/chat_server.rs
@@ -206,10 +206,7 @@ impl WsChatServer {
         let status = if self.relay_to_shared_room(session_id, from_user, to_user, relay_msg) {
             sentry::protocol::SpanStatus::Ok
         } else {
-            log::warn!(
-                target: "Websocket",
-                "Attempted signal to user not in same room: {from_user} -> {to_user}"
-            );
+            log::warn!(target: "Websocket", "Attempted signal to user not in same room");
             sentry::protocol::SpanStatus::PermissionDenied
         };
         if let Some(tx) = tx {

--- a/server/src/chat_server.rs
+++ b/server/src/chat_server.rs
@@ -104,6 +104,14 @@ impl WsChatServer {
             client_name.to_owned(),
         ) {
             Some(id) => {
+                let room_size = self
+                    .rooms
+                    .get(session_id)
+                    .and_then(|rooms| rooms.get(room_name))
+                    .map_or(0, |room| room.len());
+
+                sentry::logger_info!(room_size = room_size as u64, "room.joined");
+
                 let join_msg = format!("{client_name} {WS_PREFIX_SYSTEM_JOIN} {room_name}");
                 self.send_join_message(session_id, room_name, &join_msg);
                 self.broadcast_room_members(session_id, room_name);
@@ -404,5 +412,6 @@ impl WsChatServer {
             "Current server state: {} active sessions",
             self.rooms.len()
         );
+        sentry::logger_info!(count = self.rooms.len() as u64, "sessions.active");
     }
 }

--- a/server/src/chat_server.rs
+++ b/server/src/chat_server.rs
@@ -76,9 +76,10 @@ impl ChatServerHandle {
         from_user: &str,
         to_user: &str,
         payload: &str,
+        signal_type: &str,
     ) {
         self.lock()
-            .validate_and_relay_signal(session_id, from_user, to_user, payload);
+            .validate_and_relay_signal(session_id, from_user, to_user, payload, signal_type);
     }
 
     /// Prune sessions whose rooms are all empty.
@@ -185,12 +186,15 @@ impl WsChatServer {
         from_user: &str,
         to_user: &str,
         payload: &str,
+        signal_type: &str,
     ) {
         let tx = sentry::Hub::current().client().map(|_| {
-            sentry::start_transaction(sentry::TransactionContext::new(
+            let tx = sentry::start_transaction(sentry::TransactionContext::new(
                 "signaling.relay",
                 "websocket.signal",
-            ))
+            ));
+            tx.set_tag("signal.type", signal_type);
+            tx
         });
 
         if from_user == to_user {

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -22,6 +22,8 @@ pub struct SentryConfig {
     #[serde(default)]
     pub enabled: bool,
     #[serde(default)]
+    pub dsn: Option<String>,
+    #[serde(default)]
     pub environment: Option<String>,
     #[serde(default = "default_sentry_sample_rate")]
     pub sample_rate: f32,
@@ -33,6 +35,7 @@ impl Default for SentryConfig {
     fn default() -> Self {
         Self {
             enabled: false,
+            dsn: None,
             environment: None,
             sample_rate: default_sentry_sample_rate(),
             traces_sample_rate: default_sentry_traces_sample_rate(),
@@ -44,16 +47,11 @@ impl SentryConfig {
     pub fn load() -> Self {
         let environment = env::var("RUN_ENV").unwrap_or_else(|_| "development".to_string());
 
-        let mut cfg: Self = Config::builder()
+        Config::builder()
             .add_source(File::with_name(&format!("config/{environment}")).required(false))
             .build()
             .and_then(|s| s.get::<Self>("sentry"))
-            .unwrap_or_default();
-
-        if let Ok(v) = env::var("SENTRY_ENABLED") {
-            cfg.enabled = matches!(v.to_ascii_lowercase().as_str(), "true" | "1" | "yes");
-        }
-        cfg
+            .unwrap_or_default()
     }
 }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -25,7 +25,7 @@ fn init_sentry(cfg: &SentryConfig) -> Option<sentry::ClientInitGuard> {
     if !cfg.enabled {
         return None;
     }
-    let dsn = std::env::var("SENTRY_DSN").ok().filter(|s| !s.is_empty())?;
+    let dsn = cfg.dsn.clone().filter(|s| !s.is_empty())?;
 
     let global_traces_rate = cfg.traces_sample_rate;
     let options = sentry::ClientOptions {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -36,7 +36,6 @@ fn init_sentry(cfg: &SentryConfig) -> Option<sentry::ClientInitGuard> {
         enable_logs: true,
         server_name: Some(Cow::Borrowed("pastepoint-server")),
         traces_sampler: Some(Arc::new(move |ctx| match ctx.name() {
-            "signaling.relay" => 0.1,
             name if name.starts_with("GET /ws") => 0.0,
             _ => global_traces_rate,
         })),

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -227,7 +227,9 @@ fn check_suspicious_connection(req: &HttpRequest, ip_str: &str) -> bool {
         .unwrap_or("unknown");
 
     if user_agent.len() < MIN_USER_AGENT_LENGTH || user_agent.to_lowercase().contains("bot") {
-        log::warn!(target: "Websocket", "Suspicious connection rejected - IP: {ip_str}, UA: {user_agent}");
+        log::warn!(target: "Websocket", "Suspicious connection rejected");
+        log::debug!(target: "Websocket", "Suspicious connection - IP: {ip_str}, UA: {user_agent}");
+
         return true;
     }
     false

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -39,7 +39,23 @@ pub async fn health() -> impl Responder {
 // Client version policy route
 // -----------------------------------------------------
 #[get("/version")]
-pub async fn version(config: web::Data<ClientVersionConfig>) -> impl Responder {
+pub async fn version(req: HttpRequest, config: web::Data<ClientVersionConfig>) -> impl Responder {
+    let platform = req
+        .headers()
+        .get(header::USER_AGENT)
+        .and_then(|v| v.to_str().ok())
+        .map_or("other", |ua| {
+            let ua = ua.to_ascii_lowercase();
+            if ua.contains("pastepoint") || ua.contains("cfnetwork") {
+                "ios"
+            } else if ua.contains("mozilla") {
+                "web"
+            } else {
+                "other"
+            }
+        });
+    sentry::logger_info!(platform = platform, "version.check");
+
     HttpResponse::Ok()
         .insert_header((header::CACHE_CONTROL, "public, max-age=300"))
         .json(config.get_ref())
@@ -110,6 +126,8 @@ pub async fn create_session(store: web::Data<SessionStore>) -> Result<HttpRespon
             },
         );
     }
+
+    sentry::logger_info!(kind = "private", "session.created");
     Ok(HttpResponse::Ok()
         .content_type(header::ContentType::json())
         .json(json!({ "code": code })))

--- a/server/src/session.rs
+++ b/server/src/session.rs
@@ -297,7 +297,7 @@ impl WsChatSession {
         let value = match serde_json::from_str::<Value>(payload) {
             Ok(v) => v,
             Err(e) => {
-                log::warn!(target: "Websocket", "Invalid signal JSON from {}: {}", self.name, e);
+                log::warn!(target: "Websocket", "Invalid signal JSON: {e}");
                 Self::deliver(
                     tx,
                     format!("{WS_PREFIX_SYSTEM_ERROR} Invalid signaling message format"),
@@ -310,7 +310,7 @@ impl WsChatSession {
         let to_user = match value.get("to").and_then(|v| v.as_str()) {
             Some(user) => user,
             None => {
-                log::warn!(target: "Websocket", "Signal missing 'to' field from {}", self.name);
+                log::warn!(target: "Websocket", "Signal missing 'to' field");
                 Self::deliver(
                     tx,
                     format!("{WS_PREFIX_SYSTEM_ERROR} Signaling message missing 'to' field"),
@@ -336,11 +336,7 @@ impl WsChatSession {
         }
         self.message_count += 1;
         if self.message_count > MAX_WS_MESSAGES_PER_SEC {
-            log::warn!(
-                target: "Websocket",
-                "Rate limit exceeded for user {}, dropping message",
-                self.name
-            );
+            log::warn!(target: "Websocket", "Rate limit exceeded, dropping message");
             return;
         }
 

--- a/server/src/session.rs
+++ b/server/src/session.rs
@@ -109,18 +109,18 @@ impl WsChatSession {
         // Don't replay missed ticks back-to-back after a stall; keep the cadence.
         heartbeat.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
-        let close_reason = loop {
+        let (close_reason, disconnect_reason) = loop {
             tokio::select! {
                 // Outbound: messages the server pushed for this client.
                 outgoing = outbound.recv() => {
                     match outgoing {
                         Some(text) => {
                             if session.text(text).await.is_err() {
-                                break None;
+                                break (None, "send_failed");
                             }
                         }
                         // All senders dropped; nothing more to deliver.
-                        None => break None,
+                        None => break (None, "channel_closed"),
                     }
                 }
 
@@ -134,7 +134,7 @@ impl WsChatSession {
                             log::debug!(target: "Websocket", "Received ping message");
                             self.last_heartbeat = Some(Instant::now());
                             if session.pong(&bytes).await.is_err() {
-                                break None;
+                                break (None, "send_failed");
                             }
                         }
                         Some(Ok(AggregatedMessage::Pong(_))) => {
@@ -143,7 +143,7 @@ impl WsChatSession {
                         }
                         Some(Ok(AggregatedMessage::Close(reason))) => {
                             log::debug!(target: "Websocket", "Closing connection: {reason:?}");
-                            break reason;
+                            break (reason, "client_close");
                         }
                         // Binary frames are unused by the signaling protocol.
                         Some(Ok(_)) => {}
@@ -154,9 +154,9 @@ impl WsChatSession {
                                 WS_PREFIX_SYSTEM_ERROR,
                                 ServerError::InternalServerError
                             ));
-                            break None;
+                            break (None, "protocol_error");
                         }
-                        None => break None,
+                        None => break (None, "stream_ended"),
                     }
                 }
 
@@ -170,15 +170,16 @@ impl WsChatSession {
                             "Heartbeat failed for user {}, disconnecting!",
                             self.name
                         );
-                        break None;
+                        break (None, "heartbeat_timeout");
                     }
                     log::debug!(target: "Websocket", "Sending heartbeat to user {}", self.name);
                     if session.ping(b"").await.is_err() {
-                        break None;
+                        break (None, "ping_failed");
                     }
                 }
             }
         };
+        sentry::logger_info!(reason = disconnect_reason, "ws.disconnected");
 
         // Flush any frames still queued for this client before closing the connection.
         while let Ok(text) = outbound.try_recv() {

--- a/server/src/session.rs
+++ b/server/src/session.rs
@@ -320,7 +320,19 @@ impl WsChatSession {
         };
 
         // 4. Validate room membership and relay through the shared server.
-        server.validate_and_relay_signal(&self.session_id, &self.name, to_user, payload);
+        let signal_type = match value.get("type").and_then(|v| v.as_str()) {
+            Some(t @ ("offer" | "answer" | "candidate" | "connection_request")) => t,
+            Some(_) => "other",
+            None => "unknown",
+        };
+
+        server.validate_and_relay_signal(
+            &self.session_id,
+            &self.name,
+            to_user,
+            payload,
+            signal_type,
+        );
     }
 
     fn handle_user_disconnect(&self, server: &ChatServerHandle) {

--- a/server/src/session_store.rs
+++ b/server/src/session_store.rs
@@ -104,6 +104,11 @@ impl SessionStore {
             map.insert(key.to_string(), new_data);
         }
         self.increment_client_count(new_uuid);
+
+        sentry::logger_info!(
+            kind = if is_private { "private" } else { "public" },
+            "session.created"
+        );
         Some(new_uuid)
     }
 

--- a/server/src/session_store.rs
+++ b/server/src/session_store.rs
@@ -64,6 +64,7 @@ impl SessionStore {
     ) -> Option<Uuid> {
         // For private sessions, check if the code is expired.
         if is_private && self.is_code_expired(key) {
+            log::warn!(target: "Websocket", "Rejected private join: session code expired");
             log::debug!(target: "Websocket", "Private session code {key} is expired");
             return None;
         }
@@ -87,6 +88,9 @@ impl SessionStore {
         }
 
         if strict_mode {
+            log::warn!(target: "Websocket", "Rejected private join: unknown session code");
+            log::debug!(target: "Websocket", "Key '{key}' not found in strict mode");
+
             return None;
         }
 
@@ -138,15 +142,9 @@ impl SessionStore {
                     Err(e)
                 }
             },
-            None => {
-                log::warn!(
-                    target: "Websocket",
-                    "Key '{key}' not found in strict mode, returning 404"
-                );
-                Ok(HttpResponse::NotFound()
-                    .content_type(CONTENT_TYPE_TEXT_PLAIN)
-                    .body("Unknown session code"))
-            }
+            None => Ok(HttpResponse::NotFound()
+                .content_type(CONTENT_TYPE_TEXT_PLAIN)
+                .body("Unknown session code")),
         }
     }
 


### PR DESCRIPTION
### Summary

Cleans up what reaches Sentry and adds the counts the dashboards need. Usernames, session codes, chat text and file names no longer appear in anything shipped to Sentry, on either tier. The web client now produces all spans and events through one `TelemetryService`, and both tiers emit countable events for sessions, transfers, messages, reconnects and disconnect reasons. The Sentry DSN is committed per environment instead of coming from env vars, and every span is now sampled at 1.0.

Two long-standing web bugs are fixed on the way: an expired private-session code was retried forever (the source of 32k server warn logs), and `main.js`/`styles.css` shipped unhashed under a 1-year cache, which is where the stale-chunk errors came from. iOS is untouched; its Sentry integration is planned separately.

### What changed

- Server warn logs no longer embed usernames, session codes, IPs or User-Agents; the details stay at debug level

- Server emits `session.created`, `room.joined`, `ws.disconnected` (with `reason`, so heartbeat reaps are visible), `sessions.active` and `version.check`, and tags relayed signals with an allowlisted `signal.type`

- Sentry DSN moves from `SENTRY_DSN`/`SENTRY_ENABLED` env vars into the committed `[sentry]` config and `environment.*.ts`; the env examples and `docker-compose.yml` drop those variables
                                                                                                                                  - Traces are sampled at 1.0 on both tiers; the hard-lay` is gone- New web `TelemetryService` is the single place spa are created and ended; all existing span code movesonto it

- `webrtc.connect` records the selected ICE path (`webrtc.via_relay`); transfer spans gain `mime`, `total_chunks` and an explicit `cancelled` outcome; `ws.connect` gains `attempt`
ered`, `file.offer_*`, `chat.message_sent/received`, `session.invite_created`, `mesh.peer_connected`, `ws.reconnected` and `update.gate_blocked`

- Session codes are scrubbed from breadcrumbs and request URLs via `sentry-scrubber.ts`; chat text and file names are removed from the logs that become breadcrumbs

- A private code that stays unreachable after the reconnect limit falls back to the public session, only while `navigator.onLine`

- `outputHashing` is `all` in every build configuration, the hand-written `/styles.css` links are gone from `index.html`, and nginx stops adding cache-busting headers on hashed assets

- Stale-chunk recovery also runs at navigation time and in the QR scanner's `jsqr` import, with an in-memory guard so one error is handled once

- Versions bumped to `web@0.25.2` and `server@0.12.2`